### PR TITLE
additionally use find_package for fastcdr

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -149,6 +149,10 @@ endif()
 include(${PROJECT_SOURCE_DIR}/cmake/dev/eprosima_libraries.cmake)
 
 find_eprosima_package(fastcdr)
+# this is redundant but enables detecting the build dependency
+if(NOT (EPROSIMA_INSTALLER AND (MSVC OR MSVC_IDE)))
+    find_package(fastcdr QUIET)
+endif()
 
 ###############################################################################
 # Java application


### PR DESCRIPTION
Without a manifest file it is impossible for ament to detect the dependency on `fastcdr` if a non-standard function is being used. Therefore FastRTPS is being built without finding `FastCDR`: http://ci.ros2.org/job/ros2_batch_ci_osx/412/consoleFull#console-section-37

The additional `find_package` call should not have any side effects. I used the same conditional as within the `find_eprosima_package` macro.