### PR TITLE
Add mutex to functions in ReaderHistory

### DIFF
--- a/src/cpp/rtps/history/ReaderHistory.cpp
+++ b/src/cpp/rtps/history/ReaderHistory.cpp
@@ -157,11 +157,13 @@ void ReaderHistory::waitSemaphore() //TODO CAMBIAR NOMBRE PARA que el usuario se
 
 bool ReaderHistory::thereIsRecordOf(GUID_t& guid, SequenceNumber_t& seq)
 {
+    boost::lock_guard<boost::recursive_mutex> guard(*mp_mutex);
     return m_historyRecord[guid].find(seq) != m_historyRecord[guid].end();
 }
 
 bool ReaderHistory::thereIsUpperRecordOf(GUID_t& guid, SequenceNumber_t& seq)
 {
+    boost::lock_guard<boost::recursive_mutex> guard(*mp_mutex);
     return m_historyRecord[guid].upper_bound(seq) != m_historyRecord[guid].end();
 }
 


### PR DESCRIPTION
Using [Clang ThreadSanitizer](http://clang.llvm.org/docs/ThreadSanitizer.html) with some ROS 2 examples, I discovered a data race in ReaderHistory: `m_historyRecord` could be written to from `ReaderHistory::add_change` while other functions reading `m_historyRecord` are called in other threads. I have added acquisition of `mp_mutex` to other functions which access m_historyRecord.

I thought this would fix some issues with mysterious values appearing in serialization of bools that @dirk-thomas is debugging right now, but it does not appear to fix the problem on my side.