### PR TITLE
Using MD5 to generate Participant GUID

### DIFF
--- a/src/cpp/rtps/RTPSDomain.cpp
+++ b/src/cpp/rtps/RTPSDomain.cpp
@@ -26,6 +26,7 @@
 
 #include <fastrtps/utils/IPFinder.h>
 #include <fastrtps/utils/eClock.h>
+#include <fastrtps/utils/md5.h>
 
 #include <fastrtps/rtps/writer/RTPSWriter.h>
 #include <fastrtps/rtps/reader/RTPSReader.h>
@@ -120,10 +121,16 @@ RTPSParticipant* RTPSDomain::createParticipant(RTPSParticipantAttributes& PParam
 	IPFinder::getIP4Address(&loc);
 	if(loc.size()>0)
 	{
+		MD5 md5;
+		for(auto& l : loc)
+		{
+			md5.update(l.address, sizeof(l.address));
+		}
+		md5.finalize();
 		guidP.value[0] = c_VendorId_eProsima[0];
 		guidP.value[1] = c_VendorId_eProsima[1];
-		guidP.value[2] = loc.begin()->address[14];
-		guidP.value[3] = loc.begin()->address[15];
+		guidP.value[2] = md5.digest[0];
+		guidP.value[3] = md5.digest[1];
 	}
 	else
 	{


### PR DESCRIPTION
Previously, two last octets from the first address returned by getifaddrs() were used to generate a part of GUID. It was not unique enough as the first address happens to be 127.0.0.1. Now all addresses are used to generate MD5 hash and part of it is used in GUID.
This problem occurred because we run Fast-RTPS nodes in Docker containers and all instances have the same PID so IP address is the only way to get unique GUID. If GUID is not unique a connection will not be established.