### PR TITLE
Large message pub sub

### DIFF
--- a/include/fastrtps/TopicDataType.h
+++ b/include/fastrtps/TopicDataType.h
@@ -41,10 +41,10 @@ namespace fastrtps {
  */
 class  TopicDataType {
 public:
-	RTPS_DllAPI TopicDataType(){
-		this->m_typeSize = 0;
-        this->m_isGetKeyDefined = false;
-	}
+	RTPS_DllAPI TopicDataType()
+	: m_typeSize(0), m_isGetKeyDefined(false)
+	{}
+
 	RTPS_DllAPI virtual ~TopicDataType(){};
 	/**
 	 * Serialize method, it should be implemented by the user, since it is abstract.

--- a/include/fastrtps/TopicDataType.h
+++ b/include/fastrtps/TopicDataType.h
@@ -92,9 +92,9 @@ public:
 	* @return Topic data type name
 	*/
 	RTPS_DllAPI inline const char* getName() const { return m_topicDataTypeName.c_str(); }
-	
-	//! Maximum Type size in bytes. (If the type includes a string the user MUST ensure that the maximum
-	//! size of the string respect the maximum defined size.).
+
+	//! Maximum serialized size of the type in bytes.
+	//! If the type has unbounded fields, and therefore cannot have a maximum size, use 0.
 	uint32_t m_typeSize;
 	
 	//! Indicates whether the method to obtain the key has been implemented.

--- a/include/fastrtps/attributes/PublisherAttributes.h
+++ b/include/fastrtps/attributes/PublisherAttributes.h
@@ -40,7 +40,7 @@ namespace fastrtps{
 class PublisherAttributes {
 
 public:
-	PublisherAttributes(){
+	PublisherAttributes() : allowPayloadResize(false) {
 		m_userDefinedID = -1;
 		m_entityID = -1;
 	};
@@ -57,6 +57,8 @@ public:
 	LocatorList_t multicastLocatorList;
 	//!Terminal throughput controller
 	ThroughputControllerDescriptor terminalThroughputController;
+	//!Option to allow resizable serialized payloads in the history caches.
+	bool allowPayloadResize;
 
 	/**
 	 * Get the user defined ID

--- a/include/fastrtps/attributes/PublisherAttributes.h
+++ b/include/fastrtps/attributes/PublisherAttributes.h
@@ -55,8 +55,8 @@ public:
 	LocatorList_t unicastLocatorList;
 	//!Multicast locator list
 	LocatorList_t multicastLocatorList;
-   //!Terminal throughput controller
-   ThroughputControllerDescriptor terminalThroughputController;
+	//!Terminal throughput controller
+	ThroughputControllerDescriptor terminalThroughputController;
 
 	/**
 	 * Get the user defined ID

--- a/include/fastrtps/publisher/PublisherHistory.h
+++ b/include/fastrtps/publisher/PublisherHistory.h
@@ -43,7 +43,7 @@ public:
 	/**
 	* Constructor of the PublisherHistory.
 	* @param pimpl Pointer to the PublisherImpl.
-	* @param payloadMax Maximum payload size.
+	* @param payloadInitialSize Initial payload size.
 	* @param history QOS of the associated History.
 	* @param resource ResourceLimits for the History.
 	*/

--- a/include/fastrtps/publisher/PublisherHistory.h
+++ b/include/fastrtps/publisher/PublisherHistory.h
@@ -44,10 +44,11 @@ public:
 	* Constructor of the PublisherHistory.
 	* @param pimpl Pointer to the PublisherImpl.
 	* @param payloadInitialSize Initial payload size.
+	* @param allowPayloadResize If true, payload can be dynamically resized, otherwise not.
 	* @param history QOS of the associated History.
 	* @param resource ResourceLimits for the History.
 	*/
-	PublisherHistory(PublisherImpl* pimpl,uint32_t payloadMax,
+	PublisherHistory(PublisherImpl* pimpl,uint32_t payloadInitialSize,bool allowPayloadResize,
 			HistoryQosPolicy& history,ResourceLimitsQosPolicy& resource);
 			
 	virtual ~PublisherHistory();

--- a/include/fastrtps/rtps/attributes/HistoryAttributes.h
+++ b/include/fastrtps/rtps/attributes/HistoryAttributes.h
@@ -39,20 +39,27 @@ class RTPS_DllAPI HistoryAttributes
 public:
 	HistoryAttributes():
 		payloadInitialSize(500),
+		allowPayloadResize(false),
 		initialReservedCaches(500),
 		maximumReservedCaches(0)
 	{}
 	/** Constructor
 	* @param payload Initial payload size.
+	* @param allowResize If true allow the payload to be resized dynamically.
 	* @param initial Initial reserved caches.
 	* @param maxRes Maximum reserved caches.
 	*/
-	HistoryAttributes(uint32_t payload,int32_t initial,int32_t maxRes):
-		payloadMaxSize(payload),initialReservedCaches(initial),
-		maximumReservedCaches(maxRes){}
+	HistoryAttributes(uint32_t payload,bool allowResize,int32_t initial,int32_t maxRes):
+		payloadInitialSize(payload),
+		allowPayloadResize(allowResize),
+		initialReservedCaches(initial),
+		maximumReservedCaches(maxRes)
+	{}
 	virtual ~HistoryAttributes(){}
 	//!Intial payload size of the history, default value 500.
 	uint32_t payloadInitialSize;
+	//!Allow payload to be resized when it is too small, default to false.
+	bool allowPayloadResize;
 	//!Number of the initial Reserved Caches, default value 500.
 	int32_t initialReservedCaches;
 	//!Maximum number of reserved caches. Default value is 0 that indicates to keep reserving until something breaks.

--- a/include/fastrtps/rtps/attributes/HistoryAttributes.h
+++ b/include/fastrtps/rtps/attributes/HistoryAttributes.h
@@ -20,6 +20,10 @@
 #ifndef HISTORYATTRIBUTES_H_
 #define HISTORYATTRIBUTES_H_
 
+#include <cstdint>
+
+#include "../../fastrtps_dll.h"
+
 namespace eprosima{
 namespace fastrtps{
 namespace rtps{
@@ -37,7 +41,7 @@ public:
 		payloadMaxSize(500),
 		initialReservedCaches(500),
 		maximumReservedCaches(0)
-	{};
+	{}
 	/** Constructor
 	* @param payload Maximum payload size.
 	* @param initial Initial reserved caches.
@@ -46,9 +50,9 @@ public:
 	HistoryAttributes(uint32_t payload,int32_t initial,int32_t maxRes):
 		payloadMaxSize(payload),initialReservedCaches(initial),
 		maximumReservedCaches(maxRes){}
-	virtual ~HistoryAttributes(){};
 	//!Maximum payload size of the history, default value 500.
 	uint32_t payloadMaxSize;
+	virtual ~HistoryAttributes(){}
 	//!Number of the initial Reserved Caches, default value 500.
 	int32_t initialReservedCaches;
 	//!Maximum number of reserved caches. Default value is 0 that indicates to keep reserving until something breaks.

--- a/include/fastrtps/rtps/attributes/HistoryAttributes.h
+++ b/include/fastrtps/rtps/attributes/HistoryAttributes.h
@@ -38,21 +38,21 @@ class RTPS_DllAPI HistoryAttributes
 {
 public:
 	HistoryAttributes():
-		payloadMaxSize(500),
+		payloadInitialSize(500),
 		initialReservedCaches(500),
 		maximumReservedCaches(0)
 	{}
 	/** Constructor
-	* @param payload Maximum payload size.
+	* @param payload Initial payload size.
 	* @param initial Initial reserved caches.
 	* @param maxRes Maximum reserved caches.
 	*/
 	HistoryAttributes(uint32_t payload,int32_t initial,int32_t maxRes):
 		payloadMaxSize(payload),initialReservedCaches(initial),
 		maximumReservedCaches(maxRes){}
-	//!Maximum payload size of the history, default value 500.
-	uint32_t payloadMaxSize;
 	virtual ~HistoryAttributes(){}
+	//!Intial payload size of the history, default value 500.
+	uint32_t payloadInitialSize;
 	//!Number of the initial Reserved Caches, default value 500.
 	int32_t initialReservedCaches;
 	//!Maximum number of reserved caches. Default value is 0 that indicates to keep reserving until something breaks.

--- a/include/fastrtps/rtps/common/CacheChange.h
+++ b/include/fastrtps/rtps/common/CacheChange.h
@@ -98,11 +98,16 @@ namespace eprosima
                 /**
                  * Constructor with payload size
                  * @param payload_size Serialized payload size
+                 * @param allow_resize If true, the payload may be resized dynamically.
                  */
                 // TODO Check pass uint32_t to serializedPayload that needs int16_t.
-                CacheChange_t(uint32_t payload_size, bool is_untyped = false):
+                CacheChange_t(
+                    uint32_t payload_size,
+                    bool allow_resize = false,
+                    bool is_untyped = false)
+                :
                     kind(ALIVE),
-                    serializedPayload(payload_size),
+                    serializedPayload(payload_size, allow_resize),
                     isRead(false),
                     is_untyped_(is_untyped),
                     dataFragments_(new std::vector<uint32_t>()),

--- a/include/fastrtps/rtps/history/CacheChangePool.h
+++ b/include/fastrtps/rtps/history/CacheChangePool.h
@@ -49,9 +49,14 @@ public:
 	 * Constructor.
 	* @param pool_size The initial pool size
 	* @param payload_size The initial payload size associated with the pool.
+	* @param allow_payload_resize If true, allow the cache change payload to be resized.
 	* @param max_pool_size Maximum payload size. If set to 0 the pool will keep reserving until something breaks.
 	*/
-	CacheChangePool(int32_t pool_size, uint32_t payload_size, int32_t max_pool_size);
+	CacheChangePool(
+		int32_t pool_size,
+		uint32_t payload_size,
+		bool allow_payload_resize,
+		int32_t max_pool_size);
 	//!Reserve a Cache from the pool.
 	bool reserve_Cache(CacheChange_t** chan);
 	//!Release a Cache back to the pool.
@@ -64,6 +69,7 @@ public:
 	inline uint32_t getInitialPayloadSize(){return m_initial_payload_size;};
 private:
 	uint32_t m_initial_payload_size;
+	bool m_allow_payload_resize;
 	uint32_t m_pool_size;
 	uint32_t m_max_pool_size;
 	std::vector<CacheChange_t*> m_freeCaches;

--- a/include/fastrtps/rtps/history/CacheChangePool.h
+++ b/include/fastrtps/rtps/history/CacheChangePool.h
@@ -48,7 +48,7 @@ public:
 	/**
 	 * Constructor.
 	* @param pool_size The initial pool size
-	* @param payload_size The payload size associated with the pool.
+	* @param payload_size The initial payload size associated with the pool.
 	* @param max_pool_size Maximum payload size. If set to 0 the pool will keep reserving until something breaks.
 	*/
 	CacheChangePool(int32_t pool_size, uint32_t payload_size, int32_t max_pool_size);
@@ -60,10 +60,10 @@ public:
 	size_t get_allCachesSize(){return m_allCaches.size();}
 	//!Get the number of frre caches.
 	size_t get_freeCachesSize(){return m_freeCaches.size();}
-	//!Get the payload size associated with the Pool.
-	inline uint32_t getPayloadSize(){return m_payload_size;};
+	//!Get the initial payload size associated with the Pool.
+	inline uint32_t getInitialPayloadSize(){return m_initial_payload_size;};
 private:
-	uint32_t m_payload_size;
+	uint32_t m_initial_payload_size;
 	uint32_t m_pool_size;
 	uint32_t m_max_pool_size;
 	std::vector<CacheChange_t*> m_freeCaches;

--- a/include/fastrtps/rtps/history/History.h
+++ b/include/fastrtps/rtps/history/History.h
@@ -119,7 +119,7 @@ public:
 	 * Get the maximum serialized payload size
 	 * @return Maximum serialized payload size
 	 */
-	RTPS_DllAPI inline uint32_t getTypeMaxSerialized(){ return m_changePool.getPayloadSize(); }
+	RTPS_DllAPI inline uint32_t getTypeMaxSerialized(){ return m_changePool.getInitialPayloadSize(); }
 
 	/*!
 	 * Get the mutex

--- a/src/cpp/participant/ParticipantImpl.cpp
+++ b/src/cpp/participant/ParticipantImpl.cpp
@@ -126,12 +126,21 @@ Publisher* ParticipantImpl::createPublisher(PublisherAttributes& att,
 		logError(PARTICIPANT,"Keyed Topic needs getKey function");
 		return nullptr;
 	}
-    // Check the maximun size of the type and the asynchronous of the writer.
-    if(p_type->m_typeSize > PAYLOAD_MAX_SIZE && att.qos.m_publishMode.kind != ASYNCHRONOUS_PUBLISH_MODE)
-    {
-		logError(PARTICIPANT,"Big data has to be sent using an asynchronous publisher");
+	// Check the maximun size of the type and the asynchronous of the writer.
+	if(
+		// If the type is bounded in size and ...
+		p_type->m_typeSize != 0 &&
+		// If the type's maximum size is greater than the max payload size and ...
+		p_type->m_typeSize > PAYLOAD_MAX_SIZE &&
+		// ASYNCHRONOUS_PUBLISH_MODE is not being used, then it is an error case.
+		att.qos.m_publishMode.kind != ASYNCHRONOUS_PUBLISH_MODE)
+	{
+		logError(PARTICIPANT,
+			"Bounded type '" << p_type->getName() << "' has a maximum serialized size of '" <<
+			p_type->m_typeSize << "' which exceeds the maximum payload size of '" <<
+			PAYLOAD_MAX_SIZE << "' and therefore ASYNCHRONOUS_PUBLISH_MODE must be used.");
 		return nullptr;
-    }
+	}
 	if(m_att.rtps.builtin.use_STATIC_EndpointDiscoveryProtocol)
 	{
 		if(att.getUserDefinedID() <= 0)

--- a/src/cpp/participant/ParticipantImpl.cpp
+++ b/src/cpp/participant/ParticipantImpl.cpp
@@ -339,11 +339,6 @@ bool ParticipantImpl::getRegisteredType(const char* typeName, TopicDataType** ty
 bool ParticipantImpl::registerType(TopicDataType* type)
 {
 	const char* const METHOD_NAME = "registerType";
-	if (type->m_typeSize <= 0)
-	{
-		logError(PARTICIPANT, "Registered Type must have maximum byte size > 0");
-		return false;
-	}
 	if (std::string(type->getName()).size() <= 0)
 	{
 		logError(PARTICIPANT, "Registered Type must have a name");

--- a/src/cpp/publisher/PublisherHistory.cpp
+++ b/src/cpp/publisher/PublisherHistory.cpp
@@ -33,12 +33,15 @@ static const char* const CLASS_NAME = "PublisherHistory";
 namespace eprosima {
 namespace fastrtps {
 
-PublisherHistory::PublisherHistory(PublisherImpl* pimpl,uint32_t payloadMaxSize,HistoryQosPolicy& history,
-		ResourceLimitsQosPolicy& resource):
-										WriterHistory(HistoryAttributes(payloadMaxSize,resource.allocated_samples,resource.max_samples)),
-										m_historyQos(history),
-										m_resourceLimitsQos(resource),
-										mp_pubImpl(pimpl)
+PublisherHistory::PublisherHistory(
+	PublisherImpl* pimpl, uint32_t payloadInitialSize, bool allowPayloadResize,
+	HistoryQosPolicy& history, ResourceLimitsQosPolicy& resource)
+: WriterHistory(HistoryAttributes(
+		payloadInitialSize, allowPayloadResize,
+		resource.allocated_samples, resource.max_samples)),
+	m_historyQos(history),
+	m_resourceLimitsQos(resource),
+	mp_pubImpl(pimpl)
 {
 	// TODO Auto-generated constructor stub
 

--- a/src/cpp/publisher/PublisherImpl.cpp
+++ b/src/cpp/publisher/PublisherImpl.cpp
@@ -111,7 +111,9 @@ bool PublisherImpl::create_new_change_with_params(ChangeKind_t changeKind, void*
 			}
 			else if(ch->serializedPayload.length > mp_type->m_typeSize)
 			{
-				logWarning(RTPS_WRITER,"Serialized Payload length larger than maximum type size ("<<ch->serializedPayload.length<<"/"<< mp_type->m_typeSize<<")";);
+				logWarning(RTPS_WRITER,
+					"Serialized Payload length larger than maximum type size (" <<
+					ch->serializedPayload.length << "/" << mp_type->m_typeSize << ")");
 				m_history.release_Cache(ch);
 				return false;
 			}

--- a/src/cpp/publisher/PublisherImpl.cpp
+++ b/src/cpp/publisher/PublisherImpl.cpp
@@ -46,7 +46,13 @@ PublisherImpl::PublisherImpl(ParticipantImpl* p,TopicDataType*pdatatype,
 										mp_type(pdatatype),
 										m_att(att),
 #pragma warning (disable : 4355 )
-										m_history(this, pdatatype->m_typeSize, att.topic.historyQos, att.topic.resourceLimitsQos),
+										m_history(
+											this,
+											pdatatype->m_typeSize,
+											att.allowPayloadResize,
+											att.topic.historyQos,
+											att.topic.resourceLimitsQos
+										),
 										mp_listener(listen),
 #pragma warning (disable : 4355 )
 										m_writerListener(this),
@@ -109,7 +115,7 @@ bool PublisherImpl::create_new_change_with_params(ChangeKind_t changeKind, void*
 				m_history.release_Cache(ch);
 				return false;
 			}
-			else if(ch->serializedPayload.length > mp_type->m_typeSize)
+			else if(!m_att.allowPayloadResize && ch->serializedPayload.length > mp_type->m_typeSize)
 			{
 				logWarning(RTPS_WRITER,
 					"Serialized Payload length larger than maximum type size (" <<

--- a/src/cpp/rtps/builtin/discovery/endpoint/EDPSimple.cpp
+++ b/src/cpp/rtps/builtin/discovery/endpoint/EDPSimple.cpp
@@ -121,7 +121,7 @@ bool EDPSimple::createSEDPEndpoints()
 	{
 		hatt.initialReservedCaches = 100;
 		hatt.maximumReservedCaches = 5000;
-		hatt.payloadMaxSize = DISCOVERY_PUBLICATION_DATA_MAX_SIZE;
+		hatt.payloadInitialSize = DISCOVERY_PUBLICATION_DATA_MAX_SIZE;
 		mp_PubWriter.second = new WriterHistory(hatt);
 		//Wparam.pushMode = true;
 		watt.endpoint.reliabilityKind = RELIABLE;
@@ -142,7 +142,7 @@ bool EDPSimple::createSEDPEndpoints()
 		}
 		hatt.initialReservedCaches = 100;
 		hatt.maximumReservedCaches = 1000000;
-		hatt.payloadMaxSize = DISCOVERY_SUBSCRIPTION_DATA_MAX_SIZE;
+		hatt.payloadInitialSize = DISCOVERY_SUBSCRIPTION_DATA_MAX_SIZE;
 		mp_SubReader.second = new ReaderHistory(hatt);
 		//Rparam.historyMaxSize = 100;
 		ratt.expectsInlineQos = false;
@@ -170,7 +170,7 @@ bool EDPSimple::createSEDPEndpoints()
 	{
 		hatt.initialReservedCaches = 100;
 		hatt.maximumReservedCaches = 1000000;
-		hatt.payloadMaxSize = DISCOVERY_PUBLICATION_DATA_MAX_SIZE;
+		hatt.payloadInitialSize = DISCOVERY_PUBLICATION_DATA_MAX_SIZE;
 		mp_PubReader.second = new ReaderHistory(hatt);
 		//Rparam.historyMaxSize = 100;
 		ratt.expectsInlineQos = false;
@@ -196,7 +196,7 @@ bool EDPSimple::createSEDPEndpoints()
 		}
 		hatt.initialReservedCaches = 100;
 		hatt.maximumReservedCaches = 5000;
-		hatt.payloadMaxSize = DISCOVERY_SUBSCRIPTION_DATA_MAX_SIZE;
+		hatt.payloadInitialSize = DISCOVERY_SUBSCRIPTION_DATA_MAX_SIZE;
 		mp_SubWriter.second = new WriterHistory(hatt);
 		//Wparam.pushMode = true;
 		watt.endpoint.reliabilityKind = RELIABLE;

--- a/src/cpp/rtps/builtin/discovery/participant/PDPSimple.cpp
+++ b/src/cpp/rtps/builtin/discovery/participant/PDPSimple.cpp
@@ -312,7 +312,7 @@ bool PDPSimple::createSPDPEndpoints()
 	logInfo(RTPS_PDP,"Beginning",C_CYAN);
 	//SPDP BUILTIN RTPSParticipant WRITER
 	HistoryAttributes hatt;
-	hatt.payloadMaxSize = DISCOVERY_PARTICIPANT_DATA_MAX_SIZE;
+	hatt.payloadInitialSize = DISCOVERY_PARTICIPANT_DATA_MAX_SIZE;
 	hatt.initialReservedCaches = 20;
 	hatt.maximumReservedCaches = 100;
 	mp_SPDPWriterHistory = new WriterHistory(hatt);
@@ -339,7 +339,7 @@ bool PDPSimple::createSPDPEndpoints()
 		mp_SPDPWriterHistory = nullptr;
 		return false;
 	}
-	hatt.payloadMaxSize = DISCOVERY_PARTICIPANT_DATA_MAX_SIZE;
+	hatt.payloadInitialSize = DISCOVERY_PARTICIPANT_DATA_MAX_SIZE;
 	hatt.initialReservedCaches = 250;
 	hatt.maximumReservedCaches = 5000;
 	mp_SPDPReaderHistory = new ReaderHistory(hatt);

--- a/src/cpp/rtps/builtin/liveliness/WLP.cpp
+++ b/src/cpp/rtps/builtin/liveliness/WLP.cpp
@@ -91,7 +91,7 @@ bool WLP::createEndpoints()
 	HistoryAttributes hatt;
 	hatt.initialReservedCaches = 20;
 	hatt.maximumReservedCaches = 1000;
-	hatt.payloadMaxSize = BUILTIN_PARTICIPANT_DATA_MAX_SIZE;
+	hatt.payloadInitialSize = BUILTIN_PARTICIPANT_DATA_MAX_SIZE;
 	mp_builtinWriterHistory = new WriterHistory(hatt);
 	WriterAttributes watt;
 	watt.endpoint.unicastLocatorList = mp_builtinProtocols->m_metatrafficUnicastLocatorList;
@@ -116,7 +116,7 @@ bool WLP::createEndpoints()
 	}
 	hatt.initialReservedCaches = 100;
 	hatt.maximumReservedCaches = 2000;
-	hatt.payloadMaxSize = BUILTIN_PARTICIPANT_DATA_MAX_SIZE;
+	hatt.payloadInitialSize = BUILTIN_PARTICIPANT_DATA_MAX_SIZE;
 	mp_builtinReaderHistory = new ReaderHistory(hatt);
 	ReaderAttributes ratt;
 	ratt.endpoint.topicKind = WITH_KEY;

--- a/src/cpp/rtps/history/CacheChangePool.cpp
+++ b/src/cpp/rtps/history/CacheChangePool.cpp
@@ -42,7 +42,12 @@ CacheChangePool::~CacheChangePool()
 	delete(mp_mutex);
 }
 
-CacheChangePool::CacheChangePool(int32_t pool_size, uint32_t payload_size, int32_t max_pool_size) : mp_mutex(new boost::mutex())
+CacheChangePool::CacheChangePool(
+	int32_t pool_size,
+	uint32_t payload_size,
+	bool allow_payload_resize,
+	int32_t max_pool_size)
+: m_allow_payload_resize(allow_payload_resize), mp_mutex(new boost::mutex())
 {
 	boost::lock_guard<boost::mutex> guard(*this->mp_mutex);
 	const char* const METHOD_NAME = "CacheChangePool";
@@ -117,7 +122,7 @@ bool CacheChangePool::allocateGroup(uint32_t group_size)
 	}
 	for(uint32_t i = 0;i<reserved;i++)
 	{
-			CacheChange_t* ch = new CacheChange_t(m_payload_size);
+			CacheChange_t* ch = new CacheChange_t(m_initial_payload_size, m_allow_payload_resize);
 			m_allCaches.push_back(ch);
 			m_freeCaches.push_back(ch);
 			++m_pool_size;

--- a/src/cpp/rtps/history/CacheChangePool.cpp
+++ b/src/cpp/rtps/history/CacheChangePool.cpp
@@ -47,7 +47,7 @@ CacheChangePool::CacheChangePool(int32_t pool_size, uint32_t payload_size, int32
 	boost::lock_guard<boost::mutex> guard(*this->mp_mutex);
 	const char* const METHOD_NAME = "CacheChangePool";
 	logInfo(RTPS_UTILS,"Creating CacheChangePool of size: "<<pool_size << " with payload of size: " << payload_size);
-	m_payload_size = payload_size;
+	m_initial_payload_size = payload_size;
 	m_pool_size = 0;
 	if(max_pool_size > 0)
 	{

--- a/src/cpp/rtps/history/History.cpp
+++ b/src/cpp/rtps/history/History.cpp
@@ -41,7 +41,11 @@ namespace eprosima {
                 m_att(att),
                 m_isHistoryFull(false),
                 mp_invalidCache(nullptr),
-                m_changePool(att.initialReservedCaches,att.payloadMaxSize,att.maximumReservedCaches),
+                m_changePool(
+                    att.initialReservedCaches,
+                    att.payloadInitialSize,
+                    att.allowPayloadResize,
+                    att.maximumReservedCaches),
                 mp_minSeqCacheChange(nullptr),
                 mp_maxSeqCacheChange(nullptr),
                 mp_mutex(nullptr)

--- a/src/cpp/rtps/history/ReaderHistory.cpp
+++ b/src/cpp/rtps/history/ReaderHistory.cpp
@@ -91,7 +91,10 @@ bool ReaderHistory::add_change(CacheChange_t* a_change)
 	boost::lock_guard<boost::recursive_mutex> guard(*mp_mutex);
 	if(a_change->serializedPayload.length > m_att.payloadMaxSize)
 	{
-		logError(RTPS_HISTORY,"The Payload length is larger than the maximum payload size");
+		logError(RTPS_HISTORY,
+			"Change payload size of '" << a_change->serializedPayload.length <<
+			"' bytes is larger than the history payload size of '" << m_att.payloadInitialSize <<
+			"' bytes and cannot be resized.");
 		return false;
 	}
 	if(a_change->writerGUID == c_Guid_Unknown)

--- a/src/cpp/rtps/history/ReaderHistory.cpp
+++ b/src/cpp/rtps/history/ReaderHistory.cpp
@@ -89,7 +89,7 @@ bool ReaderHistory::add_change(CacheChange_t* a_change)
 	}
 
 	boost::lock_guard<boost::recursive_mutex> guard(*mp_mutex);
-	if(a_change->serializedPayload.length > m_att.payloadMaxSize)
+	if(!m_att.allowPayloadResize && a_change->serializedPayload.length > m_att.payloadInitialSize)
 	{
 		logError(RTPS_HISTORY,
 			"Change payload size of '" << a_change->serializedPayload.length <<

--- a/src/cpp/rtps/history/WriterHistory.cpp
+++ b/src/cpp/rtps/history/WriterHistory.cpp
@@ -65,7 +65,10 @@ bool WriterHistory::add_change(CacheChange_t* a_change)
 	}
 	if(a_change->serializedPayload.length > m_att.payloadMaxSize)
 	{
-		logError(RTPS_HISTORY,"The Payload length is larger than the maximum payload size");
+		logError(RTPS_HISTORY,
+			"Change payload size of '" << a_change->serializedPayload.length <<
+			"' bytes is larger than the history payload size of '" << m_att.payloadInitialSize <<
+			"' bytes and cannot be resized.");
 		return false;
 	}
 	++m_lastCacheChangeSeqNum;

--- a/src/cpp/rtps/history/WriterHistory.cpp
+++ b/src/cpp/rtps/history/WriterHistory.cpp
@@ -63,7 +63,7 @@ bool WriterHistory::add_change(CacheChange_t* a_change)
 		logError(RTPS_HISTORY,"Change writerGUID "<< a_change->writerGUID << " different than Writer GUID "<< mp_writer->getGuid());
 		return false;
 	}
-	if(a_change->serializedPayload.length > m_att.payloadMaxSize)
+	if(!m_att.allowPayloadResize && a_change->serializedPayload.length > m_att.payloadInitialSize)
 	{
 		logError(RTPS_HISTORY,
 			"Change payload size of '" << a_change->serializedPayload.length <<

--- a/src/cpp/rtps/reader/FragmentedChangePitStop.cpp
+++ b/src/cpp/rtps/reader/FragmentedChangePitStop.cpp
@@ -51,6 +51,7 @@ CacheChange_t* FragmentedChangePitStop::process(CacheChange_t* incoming_change, 
 
         // The length of the serialized payload has to be sample size.
         original_change->serializedPayload.length = sampleSize;
+        original_change->serializedPayload.reserve(sampleSize);
         original_change->setFragmentSize(incoming_change->getFragmentSize());
 
         // Insert

--- a/src/cpp/subscriber/SubscriberHistory.cpp
+++ b/src/cpp/subscriber/SubscriberHistory.cpp
@@ -42,7 +42,7 @@ inline bool sort_ReaderHistoryCache(CacheChange_t*c1,CacheChange_t*c2)
 SubscriberHistory::SubscriberHistory(SubscriberImpl* simpl,uint32_t payloadMaxSize,
 		HistoryQosPolicy& history,
 		ResourceLimitsQosPolicy& resource):
-								ReaderHistory(HistoryAttributes(payloadMaxSize,resource.allocated_samples,resource.max_samples)),
+								ReaderHistory(HistoryAttributes(payloadMaxSize,true,resource.allocated_samples,resource.max_samples)),
 								m_unreadCacheCount(0),
 								m_historyQos(history),
 								m_resourceLimitsQos(resource),

--- a/src/cpp/subscriber/SubscriberImpl.cpp
+++ b/src/cpp/subscriber/SubscriberImpl.cpp
@@ -44,7 +44,12 @@ SubscriberImpl::SubscriberImpl(ParticipantImpl* p,TopicDataType* ptype,
 												mp_type(ptype),
 												m_att(att),
 #pragma warning (disable : 4355 )
-												m_history(this,ptype->m_typeSize , att.topic.historyQos, att.topic.resourceLimitsQos),
+												m_history(
+													this,
+													ptype->m_typeSize,
+													att.topic.historyQos,
+													att.topic.resourceLimitsQos
+												),
 												mp_listener(listen),
 #pragma warning (disable : 4355 )
 												m_readerListener(this),

--- a/test/blackbox/RTPSAsSocketReader.hpp
+++ b/test/blackbox/RTPSAsSocketReader.hpp
@@ -106,7 +106,7 @@ class RTPSAsSocketReader
 
             //Create readerhistory
             eprosima::fastrtps::rtps::HistoryAttributes hattr;
-            hattr.payloadMaxSize = 255 + type_.m_typeSize;
+            hattr.payloadInitialSize = 255 + type_.m_typeSize;
             history_ = new eprosima::fastrtps::rtps::ReaderHistory(hattr);
             ASSERT_NE(history_, nullptr);
 

--- a/test/blackbox/RTPSAsSocketWriter.hpp
+++ b/test/blackbox/RTPSAsSocketWriter.hpp
@@ -76,7 +76,7 @@ class RTPSAsSocketWriter
 
             //Create writerhistory
             eprosima::fastrtps::rtps::HistoryAttributes hattr;
-            hattr.payloadMaxSize = 255 + type_.m_typeSize;
+            hattr.payloadInitialSize = 255 + type_.m_typeSize;
             history_ = new eprosima::fastrtps::rtps::WriterHistory(hattr);
 
             //Create writer

--- a/test/blackbox/RTPSWithRegistrationReader.hpp
+++ b/test/blackbox/RTPSWithRegistrationReader.hpp
@@ -40,6 +40,7 @@
 #include <condition_variable>
 #include <boost/asio.hpp>
 #include <boost/interprocess/detail/os_thread_functions.hpp>
+#include <boost/thread/lock_guard.hpp>
 #include <gtest/gtest.h>
 
 template<class TypeSupport>

--- a/test/blackbox/RTPSWithRegistrationReader.hpp
+++ b/test/blackbox/RTPSWithRegistrationReader.hpp
@@ -112,7 +112,7 @@ class RTPSWithRegistrationReader
 
             //Create readerhistory
             eprosima::fastrtps::rtps::HistoryAttributes hattr;
-            hattr.payloadMaxSize = type_.m_typeSize;
+            hattr.payloadInitialSize = type_.m_typeSize;
             history_ = new eprosima::fastrtps::rtps::ReaderHistory(hattr);
             ASSERT_NE(history_, nullptr);
 

--- a/test/blackbox/RTPSWithRegistrationWriter.hpp
+++ b/test/blackbox/RTPSWithRegistrationWriter.hpp
@@ -104,7 +104,7 @@ class RTPSWithRegistrationWriter
 
         //Create writerhistory
         HistoryAttributes hattr;
-        hattr.payloadMaxSize = type_.m_typeSize;
+        hattr.payloadInitialSize = type_.m_typeSize;
         history_ = new WriterHistory(hattr);
 
         //Create writer

--- a/test/profiling/RTPSAsSocketReader.cpp
+++ b/test/profiling/RTPSAsSocketReader.cpp
@@ -55,7 +55,7 @@ void RTPSAsSocketReader::init(std::string &ip, uint32_t port, uint16_t nmsgs)
 
 	//Create readerhistory
 	HistoryAttributes hattr;
-	hattr.payloadMaxSize = 255;
+	hattr.payloadInitialSize = 255;
 	history_ = new ReaderHistory(hattr);
 
 	//Create reader

--- a/test/profiling/RTPSAsSocketWriter.cpp
+++ b/test/profiling/RTPSAsSocketWriter.cpp
@@ -56,7 +56,7 @@ void RTPSAsSocketWriter::init(std::string ip, uint32_t port)
 
 	//Create writerhistory
 	HistoryAttributes hattr;
-	hattr.payloadMaxSize = 255;
+	hattr.payloadInitialSize = 255;
 	history_ = new WriterHistory(hattr);
 
 	//Create writer


### PR DESCRIPTION
See https://github.com/eProsima/ROS-RMW-Fast-RTPS-cpp/issues/36#issuecomment-229835500 for more background.

This pull request does a few things:

- changes the semantic of the "max payload size" like variables that are used throughout the code
  - now it's the initial size of the payload, which may or may not be increased later on demand
- changes the semantic of the "type size" variable in the TopicDataType class
  - it can now be 0 to indicate the type has no bounded size
- added an option to the parameter attributes (and the history attributes) called `allowPayloadResize`
  - this option defaults to `false`
  - when `true` it will allow the serialized payloads to be resized (increased) to accommodate larger messages than the initial payload size allowed
- removes a restriction that registered types must have a maximum bounded size specified

I have tested this with https://github.com/eProsima/ROS-RMW-Fast-RTPS-cpp/pull/47 and https://github.com/eProsima/Fast-CDR/pull/7 and it works well on Linux with the image demos for ROS 2.

However, I am just guessing at what the appropriate locations for most of the changes should be, so I can try to respond quickly to questions about the changes and make updates as required.

Connects to eProsima/ROS-RMW-Fast-RTPS-cpp#36.