### PR TITLE
Set default durability for WriterQos to match documentation

### DIFF
--- a/src/cpp/qos/WriterQos.cpp
+++ b/src/cpp/qos/WriterQos.cpp
@@ -28,6 +28,7 @@ static const char* const CLASS_NAME = "WriterQos";
 WriterQos::WriterQos()
 {
 	this->m_reliability.kind = RELIABLE_RELIABILITY_QOS;
+	this->m_durability.kind = TRANSIENT_LOCAL_DURABILITY_QOS;
 }
 
 WriterQos::~WriterQos()


### PR DESCRIPTION
The documentation specifies [here](https://github.com/eProsima/Fast-RTPS/blob/3cf7996c9cea21a4bdc4ee5f8dc6763069cd85f2/include/fastrtps/qos/QosPolicies.h#L60) that the default durability QoS for publishers/writers should be `TRANSIENT_LOCAL_DURABILITY_QOS` however it is not currently being set. As a result publishers currently have the default durability settings of `VOLATILE_DURABILITY_QOS` due to https://github.com/eProsima/Fast-RTPS/blob/3cf7996c9cea21a4bdc4ee5f8dc6763069cd85f2/include/fastrtps/qos/QosPolicies.h#L74
