### PR TITLE
Add pthread, needed on some ARM platforms

### DIFF
--- a/examples/C++/DeadlineQoSExample/CMakeLists.txt
+++ b/examples/C++/DeadlineQoSExample/CMakeLists.txt
@@ -37,7 +37,11 @@ file(GLOB DEADLINEQOS_EXAMPLE_SOURCES "*.cxx")
 
 add_executable(DeadlineQoSExample ${DEADLINEQOS_EXAMPLE_SOURCES})
 target_include_directories(DeadlineQoSExample PRIVATE ${Boost_INCLUDE_DIR})
-target_link_libraries(DeadlineQoSExample fastrtps fastcdr ${Boost_LIBRARIES})
+if(UNIX)
+  target_link_libraries(DeadlineQoSExample fastrtps fastcdr ${Boost_LIBRARIES} pthread)
+else()
+  target_link_libraries(DeadlineQoSExample fastrtps fastcdr ${Boost_LIBRARIES})
+endif()
 install(TARGETS DeadlineQoSExample
     RUNTIME DESTINATION examples/C++/DeadlineQoSExample/${BIN_INSTALL_DIR}
     )


### PR DESCRIPTION
As reported in ros2/ros2#260, `-lpthread` is needed when linking one of the examples on some ARM/Linux machines (e.g., rpi3).
