### PR TITLE
introduce user transport option to set time to live

### DIFF
--- a/include/fastrtps/transport/UDPv4Transport.h
+++ b/include/fastrtps/transport/UDPv4Transport.h
@@ -170,6 +170,7 @@ protected:
    uint32_t mMaxMessageSize;
    uint32_t mSendBufferSize;
    uint32_t mReceiveBufferSize;
+   uint8_t mTTL;
 
    boost::asio::io_service mService;
    std::unique_ptr<boost::thread> ioServiceThread;

--- a/include/fastrtps/transport/UDPv4TransportDescriptor.h
+++ b/include/fastrtps/transport/UDPv4TransportDescriptor.h
@@ -38,6 +38,8 @@ typedef struct UDPv4TransportDescriptor: public TransportDescriptorInterface {
    uint32_t receiveBufferSize;
    //! Allowed interfaces in an IP string format.
    std::vector<std::string> interfaceWhiteList;
+   //! Specified time to live (8bit - 255 max TTL)
+   uint8_t TTL = 1;
 
    virtual ~UDPv4TransportDescriptor(){}
    RTPS_DllAPI UDPv4TransportDescriptor();

--- a/include/fastrtps/transport/UDPv6Transport.h
+++ b/include/fastrtps/transport/UDPv6Transport.h
@@ -169,6 +169,7 @@ private:
    uint32_t mMaxMessageSize;
    uint32_t mSendBufferSize;
    uint32_t mReceiveBufferSize;
+   uint8_t mTTL;
 
    // For UDPv6, the notion of channel corresponds to a port + direction tuple.
 	boost::asio::io_service mService;

--- a/include/fastrtps/transport/UDPv6TransportDescriptor.h
+++ b/include/fastrtps/transport/UDPv6TransportDescriptor.h
@@ -38,6 +38,8 @@ typedef struct UDPv6TransportDescriptor: public TransportDescriptorInterface {
    uint32_t receiveBufferSize;
    //! Allowed interfaces in an IP string format.
    std::vector<std::string> interfaceWhiteList;
+   //! Specified time to live (8bit - 255 max TTL)
+   uint8_t TTL = 1;
 
    virtual ~UDPv6TransportDescriptor(){}
    RTPS_DllAPI UDPv6TransportDescriptor();


### PR DESCRIPTION
I extended the `UDPv*TransportDescriptor.h` of a field called `TTL` in order to specify the time to live for each packet.
By default it's set to 1, but totally up to discussing whether or not this should be done like that or not.

Addresses the conflicts in https://github.com/eProsima/Fast-RTPS/issues/64
