### PR TITLE
(dev) expose getParticipantNames function in API

### DIFF
--- a/include/fastrtps/participant/Participant.h
+++ b/include/fastrtps/participant/Participant.h
@@ -87,6 +87,8 @@ public:
 	 * */	
 	std::pair<StatefulReader*,StatefulReader*> getEDPReaders();
 
+	std::vector<std::string> getParticipantNames();
+
 	/**
 	 * This method returns the number of Publishers that currently belong to the Participant that have 
 	 * a given topic name

--- a/include/fastrtps/rtps/participant/RTPSParticipant.h
+++ b/include/fastrtps/rtps/participant/RTPSParticipant.h
@@ -128,6 +128,8 @@ class RTPS_DllAPI RTPSParticipant
      */
     std::pair<StatefulReader*,StatefulReader*> getEDPReaders();
 
+    std::vector<std::string> getParticipantNames();
+
     /**
      * Get a copy of the actual state of the RTPSParticipantParameters
      * @return RTPSParticipantAttributes copy of the params.

--- a/src/cpp/participant/Participant.cpp
+++ b/src/cpp/participant/Participant.cpp
@@ -56,6 +56,10 @@ std::pair<StatefulReader*,StatefulReader*> Participant::getEDPReaders(){
 	return mp_impl->getEDPReaders();
 }
 
+std::vector<std::string> Participant::getParticipantNames(){
+  return mp_impl->getParticipantNames();
+}
+
 int Participant::get_no_publishers(char *target_topic){
 	return mp_impl->get_no_publishers(target_topic);
 }

--- a/src/cpp/participant/ParticipantImpl.cpp
+++ b/src/cpp/participant/ParticipantImpl.cpp
@@ -208,6 +208,10 @@ std::pair<StatefulReader*,StatefulReader*> ParticipantImpl::getEDPReaders(){
     return mp_rtpsParticipant->getEDPReaders();
 }
 
+std::vector<std::string> ParticipantImpl::getParticipantNames(){
+    return mp_rtpsParticipant->getParticipantNames();
+}
+
 int ParticipantImpl::get_no_publishers(char *target_topic){
     int count = 0;
     std::string target_string(target_topic);

--- a/src/cpp/participant/ParticipantImpl.h
+++ b/src/cpp/participant/ParticipantImpl.h
@@ -123,6 +123,8 @@ class ParticipantImpl
 
     std::pair<StatefulReader*,StatefulReader*> getEDPReaders();
 
+    std::vector<std::string> getParticipantNames();
+
     int get_no_publishers(char *target_topic);
     int get_no_subscribers(char *target_topic);
     /**

--- a/src/cpp/rtps/participant/RTPSParticipant.cpp
+++ b/src/cpp/rtps/participant/RTPSParticipant.cpp
@@ -91,6 +91,10 @@ std::pair<StatefulReader*,StatefulReader*> RTPSParticipant::getEDPReaders(){
     return mp_impl->getEDPReaders();
 }
 
+std::vector<std::string> RTPSParticipant::getParticipantNames(){
+    return mp_impl->getParticipantNames();
+}
+
 RTPSParticipantAttributes RTPSParticipant::getRTPSParticipantAttributes(){
     return mp_impl->getRTPSParticipantAttributes();
 }

--- a/src/cpp/rtps/participant/RTPSParticipantImpl.cpp
+++ b/src/cpp/rtps/participant/RTPSParticipantImpl.cpp
@@ -40,6 +40,7 @@
 
 #include <fastrtps/rtps/builtin/BuiltinProtocols.h>
 #include <fastrtps/rtps/builtin/discovery/participant/PDPSimple.h>
+#include <fastrtps/rtps/builtin/data/ParticipantProxyData.h>
 
 #include <fastrtps/utils/IPFinder.h>
 #include <fastrtps/utils/eClock.h>
@@ -787,6 +788,18 @@ std::pair<StatefulReader*,StatefulReader*> RTPSParticipantImpl::getEDPReaders(){
     }
     return buffer;
 
+}
+
+std::vector<std::string> RTPSParticipantImpl::getParticipantNames(){
+    std::vector<std::string> participant_names;
+    auto pdp = mp_builtinProtocols->mp_PDP;
+    for (auto it = pdp->ParticipantProxiesBegin();
+        it != pdp->ParticipantProxiesEnd();
+        ++it)
+    {
+      participant_names.emplace_back((*it)->m_participantName);
+    }
+    return participant_names;
 }
 
 void RTPSParticipantImpl::sendSync(CDRMessage_t* msg, Endpoint *pend, const Locator_t& destination_loc)

--- a/src/cpp/rtps/participant/RTPSParticipantImpl.h
+++ b/src/cpp/rtps/participant/RTPSParticipantImpl.h
@@ -184,6 +184,8 @@ class RTPSParticipantImpl
          */
         std::pair<StatefulReader*,StatefulReader*> getEDPReaders();
 
+        std::vector<std::string> getParticipantNames();
+
         /**
          * Get the participant
          * @return participant


### PR DESCRIPTION
I expose a new function for getting the names of existing participants inside a network. Useful for introspection.
https://github.com/Karsten1987/fastrtps_introspection/blob/master/src/fastrtps_info.cpp

I only expose the names for now, but it can be edited towards exposing (all) participantinfo.  
