### PR TITLE
Fixed clang undefined behavior warning

### DIFF
--- a/include/fastrtps/log/Log.h
+++ b/include/fastrtps/log/Log.h
@@ -184,7 +184,12 @@ public:
    #define logWarning_(cat, msg) 
 #endif
 
-#define COMPOSITE_LOG_NO_INFO (defined(__INTERNALDEBUG) || defined(_INTERNALDEBUG)) && (defined(_DEBUG) || defined(__DEBUG)) && (!defined(LOG_NO_INFO))
+#if (defined(__INTERNALDEBUG) || defined(_INTERNALDEBUG)) && (defined(_DEBUG) || defined(__DEBUG)) && (!defined(LOG_NO_INFO))
+    #define COMPOSITE_LOG_NO_INFO 1
+#else
+    #define COMPOSITE_LOG_NO_INFO 0
+#endif
+
 #if COMPOSITE_LOG_NO_INFO 
    #define logInfo_(cat, msg) { if (Log::GetVerbosity() >= Log::Kind::Info) { std::stringstream ss; ss << msg; Log::QueueLog(ss.str(), Log::Context{__FILE__, __LINE__, __func__, #cat}, Log::Kind::Info); } }
 #else


### PR DESCRIPTION
This PR fixes a warning issued by clang regarding undefined behavior in the macro expansion of COMPOSITE_LOG_NO_INFO:

```sh
In file included from /builds/openrov/fastrtps-build/Fast-RTPS/src/cpp/rtps/builtin/liveliness/WLP.cpp:34:
In file included from /builds/openrov/fastrtps-build/Fast-RTPS/include/fastrtps/rtps/builtin/data/WriterProxyData.h:24:
In file included from /builds/openrov/fastrtps-build/Fast-RTPS/include/fastrtps/rtps/builtin/data/../../../attributes/TopicAttributes.h:27:
/builds/openrov/fastrtps-build/Fast-RTPS/include/fastrtps/rtps/builtin/data/../../../attributes/../log/Log.h:188:5: warning: macro expansion producing 'defined' has undefined behavior [-Wexpansion-to-defined]
#if COMPOSITE_LOG_NO_INFO 
    ^
/builds/openrov/fastrtps-build/Fast-RTPS/include/fastrtps/rtps/builtin/data/../../../attributes/../log/Log.h:187:32: note: expanded from macro 'COMPOSITE_LOG_NO_INFO'
#define COMPOSITE_LOG_NO_INFO (defined(__INTERNALDEBUG) || defined(_INTERNALDEBUG)) && (defined(_DEBUG) || defined(__DEBUG)) && (!defined(LOG_NO_INFO))
```