### PR TITLE
remove unused private member

### DIFF
--- a/include/fastrtps/rtps/messages/RTPSMessageGroup.h
+++ b/include/fastrtps/rtps/messages/RTPSMessageGroup.h
@@ -131,8 +131,6 @@ class RTPSMessageGroup
 
         Endpoint* endpoint_;
 
-        ENDPOINT_TYPE type_;
-
         CDRMessage_t* full_msg_;
 
         CDRMessage_t* submessage_msg_;


### PR DESCRIPTION
Since updating to using the latest version of Fast-RTPS again on ci.ros2.org, we noticed a new warning on macOS:

http://ci.ros2.org/job/ci_osx/1882/warnings10Result/

The member was introduced in this commit:

https://github.com/eProsima/Fast-RTPS/commit/2d07bdac258f8140ceebca99588bb1c100976cf9#diff-667a9e1219bfacd17199a05bcced6d75R125

I think the member can just be removed, or otherwise we'd appreciate it if the warning was addressed. I can test out any patch you have on our build farm if you do not have macOS handy to test this.

Related discussion:

https://github.com/ros2/ros2/pull/332#issuecomment-293606286

Thanks!