### PR TITLE
Check the CMake registry for pre-configured Asio and TinyXML2 packages.

### DIFF
--- a/cmake/modules/FindAsio.cmake
+++ b/cmake/modules/FindAsio.cmake
@@ -3,7 +3,7 @@
 
 find_package(Asio CONFIG QUIET)
 if(Asio_FOUND)
-    message(STATUS "Using Asio package from CMake registry")
+    message(STATUS "Found Asio")
 else()
     set(NO_FIND_ROOT_PATH_ "")
     if(ANDROID)

--- a/cmake/modules/FindAsio.cmake
+++ b/cmake/modules/FindAsio.cmake
@@ -1,14 +1,19 @@
 # ASIO_FOUND
 # ASIO_INCLUDE_DIR
 
-set(NO_FIND_ROOT_PATH_ "")
-if(ANDROID)
-    set(NO_FIND_ROOT_PATH_ NO_CMAKE_FIND_ROOT_PATH)
+find_package(Asio CONFIG QUIET)
+if(Asio_FOUND)
+    message(STATUS "Using Asio package from CMake registry")
+else()
+    set(NO_FIND_ROOT_PATH_ "")
+    if(ANDROID)
+        set(NO_FIND_ROOT_PATH_ NO_CMAKE_FIND_ROOT_PATH)
+    endif()
+
+    find_path(ASIO_INCLUDE_DIR NAMES asio.hpp ${NO_FIND_ROOT_PATH_})
+
+    include(FindPackageHandleStandardArgs)
+    find_package_handle_standard_args(asio DEFAULT_MSG ASIO_INCLUDE_DIR)
+
+    mark_as_advanced(ASIO_INCLUDE_DIR)
 endif()
-
-find_path(ASIO_INCLUDE_DIR NAMES asio.hpp ${NO_FIND_ROOT_PATH_})
-
-include(FindPackageHandleStandardArgs)
-find_package_handle_standard_args(asio DEFAULT_MSG ASIO_INCLUDE_DIR)
-
-mark_as_advanced(ASIO_INCLUDE_DIR)

--- a/cmake/modules/FindTinyXML2.cmake
+++ b/cmake/modules/FindTinyXML2.cmake
@@ -4,7 +4,7 @@
 
 find_package(TinyXML2 CONFIG QUIET)
 if(TinyXML2_FOUND)
-    message(STATUS "Using TinyXML2 package from CMake registry")
+    message(STATUS "Found TinyXML2")
 else()
     set(NO_FIND_ROOT_PATH_ "")
     if(ANDROID)

--- a/cmake/modules/FindTinyXML2.cmake
+++ b/cmake/modules/FindTinyXML2.cmake
@@ -2,27 +2,32 @@
 # TINYXML2_INCLUDE_DIR
 # TINYXML2_SOURCE_DIR
 
-set(NO_FIND_ROOT_PATH_ "")
-if(ANDROID)
-    set(NO_FIND_ROOT_PATH_ NO_CMAKE_FIND_ROOT_PATH)
-endif()
-
-find_path(TINYXML2_INCLUDE_DIR NAMES tinyxml2.h ${NO_FIND_ROOT_PATH_})
-
-if(THIRDPARTY)
-    find_path(TINYXML2_SOURCE_DIR NAMES tinyxml2.cpp ${NO_FIND_ROOT_PATH_})
+find_package(TinyXML2 CONFIG QUIET)
+if(TinyXML2_FOUND)
+    message(STATUS "Using TinyXML2 package from CMake registry")
 else()
-    find_library(TINYXML2_LIBRARY tinyxml2)
-endif()
+    set(NO_FIND_ROOT_PATH_ "")
+    if(ANDROID)
+        set(NO_FIND_ROOT_PATH_ NO_CMAKE_FIND_ROOT_PATH)
+    endif()
 
-include(FindPackageHandleStandardArgs)
+    find_path(TINYXML2_INCLUDE_DIR NAMES tinyxml2.h ${NO_FIND_ROOT_PATH_})
 
-if(THIRDPARTY)
-    find_package_handle_standard_args(tinyxml2 DEFAULT_MSG TINYXML2_SOURCE_DIR TINYXML2_INCLUDE_DIR)
+    if(THIRDPARTY)
+        find_path(TINYXML2_SOURCE_DIR NAMES tinyxml2.cpp ${NO_FIND_ROOT_PATH_})
+    else()
+        find_library(TINYXML2_LIBRARY tinyxml2)
+    endif()
 
-    mark_as_advanced(TINYXML2_INCLUDE_DIR TINYXML2_SOURCE_DIR)
-else()
-    find_package_handle_standard_args(tinyxml2 DEFAULT_MSG TINYXML2_LIBRARY TINYXML2_INCLUDE_DIR)
+    include(FindPackageHandleStandardArgs)
 
-    mark_as_advanced(TINYXML2_INCLUDE_DIR TINYXML2_LIBRARY)
+    if(THIRDPARTY)
+        find_package_handle_standard_args(tinyxml2 DEFAULT_MSG TINYXML2_SOURCE_DIR TINYXML2_INCLUDE_DIR)
+
+        mark_as_advanced(TINYXML2_INCLUDE_DIR TINYXML2_SOURCE_DIR)
+    else()
+        find_package_handle_standard_args(tinyxml2 DEFAULT_MSG TINYXML2_LIBRARY TINYXML2_INCLUDE_DIR)
+
+        mark_as_advanced(TINYXML2_INCLUDE_DIR TINYXML2_LIBRARY)
+    endif()
 endif()


### PR DESCRIPTION
Find modules override the CMake package registry by default.  On Windows, we have no standard file system hierarchy to check for installed libraries and using the CMake package registry [[1]] is the easiest way to advertise installed dependencies to dependents.

These changes will force CMake to look in the package registry by passing the CONFIG directive to find_package, if no package is found, the existing find module logic will be used.

This change should not affect builds on systems where the existing logic is successful unless those systems also include entries in the CMake package registry and those entries are invalid.

[1]: https://cmake.org/cmake/help/v3.5/manual/cmake-packages.7.html#id20