### PR TITLE
use windows.h rather than afxres.h

### DIFF
--- a/src/cpp/fastrtps.rc
+++ b/src/cpp/fastrtps.rc
@@ -30,7 +30,7 @@
 //
 // Generated from the TEXTINCLUDE 2 resource.
 //
-#include "afxres.h"
+#include "windows.h"
 
 /////////////////////////////////////////////////////////////////////////////
 #undef APSTUDIO_READONLY_SYMBOLS


### PR DESCRIPTION
If I try to build this project on Windows without MFC installed, then I get this error:

```
C:\dev\ros2\src\eProsima\Fast-RTPS\src\cpp\fastrtps.rc(33): fatal error RC1015: cannot open include file 'afxres.h'. [C:\dev\ros2\build\fastrtps\src\cpp\fastrtps_static.vcxproj]
```

According to this SO post, this can safely be replaced with #include "windows.h":

http://stackoverflow.com/questions/3566018/cannot-open-include-file-afxres-h-in-vc2010-express

This does fix the problem on my machine.