### PR TITLE
Fix test env

### DIFF
--- a/test/communication/CMakeLists.txt
+++ b/test/communication/CMakeLists.txt
@@ -43,15 +43,15 @@ if(NOT ((MSVC OR MSVC_IDE) AND EPROSIMA_INSTALLER) AND fastcdr_FOUND)
         # Set test with label NoMemoryCheck
         set_property(TEST SimpleCommunication PROPERTY LABELS "NoMemoryCheck")
 
-        if(WIN32)
-            string(REPLACE ";" "\\;" WIN_PATH "$ENV{PATH}")
-            set_property(TEST SimpleCommunication PROPERTY ENVIRONMENT
-                "PATH=$<TARGET_FILE_DIR:${PROJECT_NAME}>\\;$<TARGET_FILE_DIR:fastcdr>\\;${BOOST_LIBRARYDIR}\\;${WIN_PATH}")
-        endif()
-        set_property(TEST SimpleCommunication APPEND PROPERTY ENVIRONMENT
+        set_property(TEST SimpleCommunication PROPERTY ENVIRONMENT
             "SIMPLE_COMMUNICATION_PUBLISHER_BIN=$<TARGET_FILE:SimpleCommunicationPublisher>")
         set_property(TEST SimpleCommunication APPEND PROPERTY ENVIRONMENT
             "SIMPLE_COMMUNICATION_SUBSCRIBER_BIN=$<TARGET_FILE:SimpleCommunicationSubscriber>")
+        if(WIN32)
+            string(REPLACE ";" "\\;" WIN_PATH "$ENV{PATH}")
+            set_property(TEST SimpleCommunication APPEND PROPERTY ENVIRONMENT
+                "PATH=$<TARGET_FILE_DIR:${PROJECT_NAME}>\\;$<TARGET_FILE_DIR:fastcdr>\\;${BOOST_LIBRARYDIR}\\;${WIN_PATH}")
+        endif()
 
         add_test(NAME LivelinessAssertion
             COMMAND ${PYTHON_EXECUTABLE} ${CMAKE_CURRENT_SOURCE_DIR}/liveliness_assertion.py)
@@ -59,14 +59,14 @@ if(NOT ((MSVC OR MSVC_IDE) AND EPROSIMA_INSTALLER) AND fastcdr_FOUND)
         # Set test with label NoMemoryCheck
         set_property(TEST LivelinessAssertion PROPERTY LABELS "NoMemoryCheck")
 
-        if(WIN32)
-            string(REPLACE ";" "\\;" WIN_PATH "$ENV{PATH}")
-            set_property(TEST LivelinessAssertion PROPERTY ENVIRONMENT
-                "PATH=$<TARGET_FILE_DIR:${PROJECT_NAME}>\\;$<TARGET_FILE_DIR:fastcdr>\\;${BOOST_LIBRARYDIR}\\;${WIN_PATH}")
-        endif()
-        set_property(TEST LivelinessAssertion APPEND PROPERTY ENVIRONMENT
+        set_property(TEST LivelinessAssertion PROPERTY ENVIRONMENT
             "SIMPLE_COMMUNICATION_PUBLISHER_BIN=$<TARGET_FILE:SimpleCommunicationPublisher>")
         set_property(TEST LivelinessAssertion APPEND PROPERTY ENVIRONMENT
             "SIMPLE_COMMUNICATION_SUBSCRIBER_BIN=$<TARGET_FILE:SimpleCommunicationSubscriber>")
+        if(WIN32)
+            string(REPLACE ";" "\\;" WIN_PATH "$ENV{PATH}")
+            set_property(TEST LivelinessAssertion APPEND PROPERTY ENVIRONMENT
+                "PATH=$<TARGET_FILE_DIR:${PROJECT_NAME}>\\;$<TARGET_FILE_DIR:fastcdr>\\;${BOOST_LIBRARYDIR}\\;${WIN_PATH}")
+        endif()
     endif()
 endif()

--- a/test/communication/liveliness_assertion.py
+++ b/test/communication/liveliness_assertion.py
@@ -15,7 +15,9 @@
 import sys, os, subprocess
 
 publisher_command = os.environ.get("SIMPLE_COMMUNICATION_PUBLISHER_BIN")
+assert publisher_command
 subscriber_command = os.environ.get("SIMPLE_COMMUNICATION_SUBSCRIBER_BIN")
+assert subscriber_command
 
 subscriber_proc = subprocess.Popen([subscriber_command, "--notexit"])
 publisher_proc = subprocess.Popen([publisher_command, "--exit_on_lost_liveliness"], stdout=subprocess.PIPE)

--- a/test/communication/simple_communication.py
+++ b/test/communication/simple_communication.py
@@ -15,7 +15,9 @@
 import sys, os, subprocess
 
 publisher_command = os.environ.get("SIMPLE_COMMUNICATION_PUBLISHER_BIN")
+assert publisher_command
 subscriber_command = os.environ.get("SIMPLE_COMMUNICATION_SUBSCRIBER_BIN")
+assert subscriber_command
 
 subscriber_proc = subprocess.Popen([subscriber_command])
 publisher_proc = subprocess.Popen([publisher_command])


### PR DESCRIPTION
The first commits adds assertions to ensure that the environment variables are set. Currently that is not the case due to a regression introduced in a recent change (https://github.com/eProsima/Fast-RTPS/commit/e2cdc510c6580b84f7e212dbf02604fbc400260f#diff-fbc16c4a3512de5bc6e9f097923f254aR47).

With that change the test fails with an `AssertionError` and doesn't try to invoke a subprocess with `None` which results in infinite hangs on our buidllarm (e.g. http://ci.ros2.org/job/ci_windows/2384/).

---

The second commit simply moves the important environment variables above the `PATH` which makes the tests pass cleanly.

---

But the logic to append the `PATH` should still be revised since it doesn't work correctly. It seems that the same pattern exists in other CMake files too.