### PR TITLE
Fix compilation issue with gcc v7.1

### DIFF
--- a/include/fastrtps/rtps/writer/RTPSWriter.h
+++ b/include/fastrtps/rtps/writer/RTPSWriter.h
@@ -24,6 +24,7 @@
 #include "../attributes/WriterAttributes.h"
 #include <vector>
 #include <memory>
+#include <functional>
 
 namespace eprosima {
 namespace fastrtps{


### PR DESCRIPTION
When compiling with gcc v7.1 the following error message gets
trggered:
```
  /home/rojkov/work/ros/build/tmp-glibc/work/i586-oe-linux/fastrtps/git-r0/git/include/fastrtps/rtps/writer/RTPSWriter.h:66:54: error: 'function' in namespace 'std' does not name a template type
       RTPS_DllAPI CacheChange_t* new_change(const std::function<uint32_t()>& dataCdrSerializedSize,
                                                        ^~~~~~~~
```
The patch adds a missing header required by the compiler.