### PR TITLE
Fix typo in XML API

### DIFF
--- a/include/fastrtps/xmlparser/XMLProfileParser.h
+++ b/include/fastrtps/xmlparser/XMLProfileParser.h
@@ -65,14 +65,14 @@ public:
     * @param atts Structure to be filled.
     * @return XMLP_ret::XML_OK on success, XMLP_ret::XML_ERROR in other case.
     */
-    RTPS_DllAPI static XMLP_ret fillPublishertAttributes(const std::string &profile_name, PublisherAttributes &atts);
+    RTPS_DllAPI static XMLP_ret fillPublisherAttributes(const std::string &profile_name, PublisherAttributes &atts);
     /**
     * Search for the profile specified and fill the structure.
     * @param profile_name Name for the profile to be used to fill the structure.
     * @param atts Structure to be filled.
     * @return XMLP_ret::XML_OK on success, XMLP_ret::XML_ERROR in other case.
     */
-    RTPS_DllAPI static XMLP_ret fillSubscribertAttributes(const std::string &profile_name, SubscriberAttributes &atts);
+    RTPS_DllAPI static XMLP_ret fillSubscriberAttributes(const std::string &profile_name, SubscriberAttributes &atts);
 
 protected:
 

--- a/src/cpp/Domain.cpp
+++ b/src/cpp/Domain.cpp
@@ -155,7 +155,7 @@ Participant* Domain::createParticipant(ParticipantAttributes& att,ParticipantLis
 Publisher* Domain::createPublisher(Participant *part, const std::string &publisher_profile, PublisherListener *listen)
 {
     PublisherAttributes publisher_att;
-    if ( XMLP_ret::XML_ERROR == XMLProfileParser::fillPublishertAttributes(publisher_profile, publisher_att))
+    if ( XMLP_ret::XML_ERROR == XMLProfileParser::fillPublisherAttributes(publisher_profile, publisher_att))
     {
         logError(PUBLISHER, "Problem loading profile '" << publisher_profile << "'");
         return nullptr;
@@ -179,7 +179,7 @@ Publisher* Domain::createPublisher(Participant *part, PublisherAttributes &att, 
 Subscriber* Domain::createSubscriber(Participant *part, const std::string &subscriber_profile, SubscriberListener *listen)
 {
     SubscriberAttributes subscriber_att;
-    if ( XMLP_ret::XML_ERROR == XMLProfileParser::fillSubscribertAttributes(subscriber_profile, subscriber_att))
+    if ( XMLP_ret::XML_ERROR == XMLProfileParser::fillSubscriberAttributes(subscriber_profile, subscriber_att))
     {
         logError(PUBLISHER, "Problem loading profile '" << subscriber_profile << "'");
         return nullptr;

--- a/src/cpp/xmlparser/XMLProfileParser.cpp
+++ b/src/cpp/xmlparser/XMLProfileParser.cpp
@@ -23,7 +23,7 @@ XMLP_ret XMLProfileParser::fillParticipantAttributes(const std::string &profile_
     return XMLP_ret::XML_OK;
 }
 
-XMLP_ret XMLProfileParser::fillPublishertAttributes(const std::string &profile_name, PublisherAttributes &atts)
+XMLP_ret XMLProfileParser::fillPublisherAttributes(const std::string &profile_name, PublisherAttributes &atts)
 {
     publ_map_iterator_t it = m_publisher_profiles.find(profile_name);
     if (it == m_publisher_profiles.end())
@@ -35,7 +35,7 @@ XMLP_ret XMLProfileParser::fillPublishertAttributes(const std::string &profile_n
     return XMLP_ret::XML_OK;
 }
 
-XMLP_ret XMLProfileParser::fillSubscribertAttributes(const std::string &profile_name, SubscriberAttributes &atts)
+XMLP_ret XMLProfileParser::fillSubscriberAttributes(const std::string &profile_name, SubscriberAttributes &atts)
 {
     subs_map_iterator_t it = m_subscriber_profiles.find(profile_name);
     if (it == m_subscriber_profiles.end())

--- a/test/unittest/xmlparser/XMLProfileParserTests.cpp
+++ b/test/unittest/xmlparser/XMLProfileParserTests.cpp
@@ -116,7 +116,7 @@ TEST_F(XMLProfileParserTests, XMLParserPublisher)
     ASSERT_EQ(  xmlparser::XMLP_ret::XML_OK,
                 xmlparser::XMLProfileParser::loadXMLFile("test_xml_profiles.xml"));
     EXPECT_EQ(  xmlparser::XMLP_ret::XML_OK,
-                xmlparser::XMLProfileParser::fillPublishertAttributes(publisher_profile, publisher_atts));
+                xmlparser::XMLProfileParser::fillPublisherAttributes(publisher_profile, publisher_atts));
 
     TopicAttributes &pub_topic = publisher_atts.topic;
     WriterQos &pub_qos = publisher_atts.qos;
@@ -172,7 +172,7 @@ TEST_F(XMLProfileParserTests, XMLParserSubscriber)
     ASSERT_EQ(  xmlparser::XMLP_ret::XML_OK,
                 xmlparser::XMLProfileParser::loadXMLFile("test_xml_profiles.xml"));
     EXPECT_EQ(  xmlparser::XMLP_ret::XML_OK,
-                xmlparser::XMLProfileParser::fillSubscribertAttributes(subscriber_profile, subscriber_atts));
+                xmlparser::XMLProfileParser::fillSubscriberAttributes(subscriber_profile, subscriber_atts));
 
     TopicAttributes &sub_topic = subscriber_atts.topic;
     ReaderQos &sub_qos = subscriber_atts.qos;
@@ -248,7 +248,7 @@ TEST_F(XMLProfileParserTests, XMLParserSecurity)
     std::string publisher_profile = std::string("test_publisher_security_profile");
     PublisherAttributes publisher_atts;
     EXPECT_EQ(  xmlparser::XMLP_ret::XML_OK,
-                xmlparser::XMLProfileParser::fillPublishertAttributes(publisher_profile, publisher_atts));
+                xmlparser::XMLProfileParser::fillPublisherAttributes(publisher_profile, publisher_atts));
 
     PropertySeq &pub_props = publisher_atts.properties.properties();
     BinaryPropertySeq &pub_bin_props = publisher_atts.properties.binary_properties();
@@ -269,7 +269,7 @@ TEST_F(XMLProfileParserTests, XMLParserSecurity)
     SubscriberAttributes subscriber_atts;
 
     EXPECT_EQ(xmlparser::XMLP_ret::XML_OK,
-                xmlparser::XMLProfileParser::fillSubscribertAttributes(subscriber_profile, subscriber_atts));
+                xmlparser::XMLProfileParser::fillSubscriberAttributes(subscriber_profile, subscriber_atts));
 
     PropertySeq &sub_props = subscriber_atts.properties.properties();
     BinaryPropertySeq &sub_bin_props = subscriber_atts.properties.binary_properties();


### PR DESCRIPTION
Was using the XML endpoint the other day, and ran across "fillSubscribertAttributes" and "fillPublishertAttributes" methods which looked to be typos (extra T in each).

Feel free to ignore if intentional.
