### PR TITLE
Quiet signed overflow warning on gcc 7.1

### DIFF
--- a/include/fastrtps/rtps/common/SequenceNumber.h
+++ b/include/fastrtps/rtps/common/SequenceNumber.h
@@ -378,7 +378,8 @@ class SequenceNumberSet_t
          */
         bool add(const SequenceNumber_t& in)
         {
-            if(in >= base && in < base + 255)
+            SequenceNumber_t max = base + 255;
+            if(in >= base && in < max)
                 set.push_back(in);
             else
                 return false;


### PR DESCRIPTION
When compiling Fast-RTPS with gcc 7.1 and -O2, a warning is issued:

Fast-RTPS/include/fastrtps/rtps/messages/../common/SequenceNumber.h:190:5: warning: assuming signed overflow does not occur when assuming that (X + c) < X is always false [-Wstrict-overflow]
     if(seq1.high > seq2.high)

I believe that this is actually a bogus warning, but it
has real consequences; the outcome of this warning is
that gcc optimizes away the check.  We can workaround
this problem by assigning the result of the base + 255
to an intermediate variable, then comparing against this
intermediate variable instead.  This gets rid of the warning.

This should fix #126 

Signed-off-by: Chris Lalancette <clalancette@gmail.com>