### PR TITLE
Quiet a warning about "minor" being doubly defined.

### DIFF
--- a/include/fastrtps/rtps/exceptions/Exception.h
+++ b/include/fastrtps/rtps/exceptions/Exception.h
@@ -20,6 +20,8 @@
 #include <string>
 #include <cstdint>
 
+#undef minor
+
 namespace eprosima {
 namespace fastrtps {
 namespace rtps {


### PR DESCRIPTION
Modern gcc/glibc prints this warning when building
Fast-RTPS:

Fast-RTPS/src/cpp/rtps/exceptions/Exception.cpp:58:13: warning: In the GNU C Library, "minor" is defined
 by <sys/sysmacros.h>. For historical compatibility, it is
 currently defined by <sys/types.h> as well, but we plan to
 remove this soon. To use "minor", include <sys/sysmacros.h>
 directly. If you did not intend to use a system-defined macro
 "minor", you should undefine it after including <sys/types.h>.
 void Exception::minor(const int32_t &minor)

I follwed the latter advice and undefined the minor
macro, which quiets down the warning.

This should fix #127 

Signed-off-by: Chris Lalancette <clalancette@gmail.com>