### PR TITLE
Incorrect gapList.base field in GAP submessage

### DIFF
--- a/include/fastrtps/rtps/common/CacheChange.h
+++ b/include/fastrtps/rtps/common/CacheChange.h
@@ -323,7 +323,7 @@ namespace eprosima
 
                 void markAllFragmentsAsUnsent()
                 {
-                   if (change_->getFragmentSize() != 0)
+                   if (change_ != nullptr && change_->getFragmentSize() != 0)
                     for (uint32_t i = 1; i != change_->getFragmentCount() + 1; i++)
                        unsent_fragments_.insert(i); // Indexed on 1
                 }

--- a/src/cpp/rtps/messages/RTPSMessageGroup.cpp
+++ b/src/cpp/rtps/messages/RTPSMessageGroup.cpp
@@ -74,7 +74,7 @@ void prepare_SequenceNumberSet(std::set<SequenceNumber_t>& changesSeqNum,
         {
             if(seqnumset_init) //FIRST TIME SINCE it was continuous
             {
-                sequences.back().second.base = *(std::prev(it));
+                sequences.back().second.base = (*(std::prev(it)) + 1);
                 seqnumset_init = false;
             }
             // Try to add, If it fails the diference between *it and base is greater than 255.

--- a/src/cpp/rtps/writer/ReaderProxy.cpp
+++ b/src/cpp/rtps/writer/ReaderProxy.cpp
@@ -172,7 +172,7 @@ bool ReaderProxy::requested_changes_set(std::vector<SequenceNumber_t>& seqNumSet
     {
         auto chit = m_changesForReader.find(ChangeForReader_t(*sit));
 
-        if(chit != m_changesForReader.end() && chit->isValid())
+        if(chit != m_changesForReader.end())
         {
             ChangeForReader_t newch(*chit);
             newch.setStatus(REQUESTED);
@@ -189,6 +189,11 @@ bool ReaderProxy::requested_changes_set(std::vector<SequenceNumber_t>& seqNumSet
     if(isSomeoneWasSetRequested)
     {
         logInfo(RTPS_WRITER,"Requested Changes: " << seqNumSet);
+    }
+    else if(!seqNumSet.empty())
+    {
+        logWarning(RTPS_WRITER,"Requested Changes: " << seqNumSet
+                   << " not found (low mark: " << changesFromRLowMark_ << ")");
     }
 
     return isSomeoneWasSetRequested;


### PR DESCRIPTION
Given a gap list of sequence numbers 8, 9, 10, 15, 16, 19, 20, 23, 27, 28
The gapList.base field for the gap message was not set correctly causing the first gap sequence to be skipped by teh receiver.

This change correctly set the gapList.base to be +1 from the gapStart value. in our example: gapStart==8, gapList.base==11 gapList.set[15, 16, 19, 20, 23, 27, 28]
Previously, the gap values would be set incorrectly as such: gapStart==8, gapList.base==8 gapList.set[9, 10, 15, 16, 19, 20, 23, 27, 28] causing the gap seqnum 8 to be missed by the receiver.

Issue: #182