### PR TITLE
fix deprecated openssl call

### DIFF
--- a/src/cpp/security/OpenSSLInit.cpp
+++ b/src/cpp/security/OpenSSLInit.cpp
@@ -14,7 +14,11 @@ class OpenSSLInit
 
         ~OpenSSLInit()
         {
+#if OPENSSL_VERSION_NUMBER < 0x10000000L
             ERR_remove_state(0);
+#elif OPENSSL_VERSION_NUMBER < 0x10100000L
+            ERR_remove_thread_state(NULL);
+#endif
             ENGINE_cleanup();
             RAND_cleanup();
             CRYPTO_cleanup_all_ex_data();


### PR DESCRIPTION
This function has been deprecated causing warning with recent versions of OpenSSL

https://www.openssl.org/docs/man1.1.0/crypto/ERR_remove_state.html