### PR TITLE
fastcdr is now required if security is on

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -209,6 +209,7 @@ option(SECURITY "Activate security" OFF)
 
 if(SECURITY)
     find_package(OpenSSL REQUIRED)
+    find_package(fastcdr REQUIRED)
 endif()
 
 ###############################################################################


### PR DESCRIPTION
Fast-RTPS now requires fastcdr to compile the security plugins https://github.com/eProsima/Fast-RTPS/blob/8d89897fc9ec3f7e49057bfb2fbaa0d10b7abcf4/src/cpp/security/cryptography/AESGCMGMAC_Transform.h#L24

So it needs to be find_package with the "REQUIRED" option if `SECURITY` is passed to cmake.

Without this patch Fast-RTPS cmake prints `-- fastcdr library not found...` and then fails at compilation time:
```
In file included from /tmp/fastrtps_ws/src/eProsima/Fast-RTPS/src/cpp/rtps/security/../../security/cryptography/AESGCMGMAC.h:27:0,
                 from /tmp/fastrtps_ws/src/eProsima/Fast-RTPS/src/cpp/rtps/security/SecurityPluginFactory.cpp:22:
/tmp/fastrtps_ws/src/eProsima/Fast-RTPS/src/cpp/rtps/security/../../security/cryptography/AESGCMGMAC_Transform.h:24:25: fatal error: fastcdr/Cdr.h: No such file or directory
```