### PR TITLE
add missing override to fix clang warnings

### DIFF
--- a/include/fastrtps/rtps/builtin/discovery/endpoint/EDPSimple.h
+++ b/include/fastrtps/rtps/builtin/discovery/endpoint/EDPSimple.h
@@ -136,10 +136,10 @@ class EDPSimple : public EDP
     bool create_sedp_secure_endpoints();
 
     bool pairing_remote_writer_with_local_builtin_reader_after_security(const GUID_t& local_reader,
-                const WriterProxyData& remote_writer_data);
+                const WriterProxyData& remote_writer_data) override;
 
     bool pairing_remote_reader_with_local_builtin_writer_after_security(const GUID_t& local_writer,
-                const ReaderProxyData& remote_reader_data);
+                const ReaderProxyData& remote_reader_data) override;
 #endif
 
 };


### PR DESCRIPTION
Last commit introduced new warnings:
https://ci.ros2.org/job/ci_osx/3559/warnings11Result/
With this patch: [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_osx&build=3561)](http://ci.ros2.org/job/ci_osx/3561/)