### PR TITLE
make RTPSDomain a singleton

### DIFF
--- a/include/fastrtps/rtps/RTPSDomain.h
+++ b/include/fastrtps/rtps/RTPSDomain.h
@@ -27,6 +27,7 @@
 
 #include <set>
 #include <mutex>
+#include <atomic>
 
 namespace eprosima{
 namespace fastrtps{
@@ -136,7 +137,7 @@ class RTPSDomain
 
     std::mutex m_mutex;
     std::set<uint32_t> m_RTPSParticipantIDs;
-    uint32_t m_maxRTPSParticipantID;
+    std::atomic<uint32_t> m_maxRTPSParticipantID;
     std::vector<t_p_RTPSParticipant> m_RTPSParticipants;
 
 };

--- a/include/fastrtps/rtps/RTPSDomain.h
+++ b/include/fastrtps/rtps/RTPSDomain.h
@@ -26,7 +26,7 @@
 #include "attributes/RTPSParticipantAttributes.h"
 
 #include <set>
-
+#include <mutex>
 
 namespace eprosima{
 namespace fastrtps{
@@ -53,15 +53,6 @@ class ReaderListener;
 class RTPSDomain
 {
     typedef std::pair<RTPSParticipant*,RTPSParticipantImpl*> t_p_RTPSParticipant;
-
-    private:
-
-    RTPSDomain();
-
-    /**
-     * DomainRTPSParticipant destructor
-     */
-    ~RTPSDomain();
 
     public:
     /**
@@ -124,23 +115,29 @@ class RTPSDomain
      * @param maxRTPSParticipantId ID.
      */
     static inline void setMaxRTPSParticipantId(uint32_t maxRTPSParticipantId) {
-        m_maxRTPSParticipantID = maxRTPSParticipantId;
+        getInstance().m_maxRTPSParticipantID = maxRTPSParticipantId;
     }
 
 
 
     private:
-    static uint32_t m_maxRTPSParticipantID;
+    RTPSDomain();
+    ~RTPSDomain();
 
-    static std::vector<t_p_RTPSParticipant> m_RTPSParticipants;
+    RTPSDomain(RTPSDomain const&) = delete;
+    RTPSDomain& operator=(const RTPSDomain&) = delete;
+    static RTPSDomain& getInstance();
 
     /**
      * @brief Get Id to create a RTPSParticipant.
      * @return Different ID for each call.
      */
-    static inline uint32_t getNewId() {return m_maxRTPSParticipantID++;}
+    static inline uint32_t getNewId() {return getInstance().m_maxRTPSParticipantID++;}
 
-    static std::set<uint32_t> m_RTPSParticipantIDs;
+    std::mutex m_mutex;
+    std::set<uint32_t> m_RTPSParticipantIDs;
+    uint32_t m_maxRTPSParticipantID;
+    std::vector<t_p_RTPSParticipant> m_RTPSParticipants;
 
 };
 

--- a/src/cpp/rtps/RTPSDomain.cpp
+++ b/src/cpp/rtps/RTPSDomain.cpp
@@ -46,7 +46,7 @@ RTPSDomain& RTPSDomain::getInstance()
   return s_instance;
 }
 
-RTPSDomain::RTPSDomain()
+RTPSDomain::RTPSDomain() : m_maxRTPSParticipantID(0)
 {
     srand (static_cast <unsigned> (time(0)));
 }

--- a/src/cpp/rtps/RTPSDomain.cpp
+++ b/src/cpp/rtps/RTPSDomain.cpp
@@ -38,9 +38,7 @@ namespace eprosima {
 namespace fastrtps{
 namespace rtps {
 
-//---------------------------------------------------------------------------------------------------------------------
 RTPSDomain& RTPSDomain::getInstance()
-//---------------------------------------------------------------------------------------------------------------------
 {
   static RTPSDomain s_instance;
   return s_instance;

--- a/src/cpp/rtps/RTPSDomain.cpp
+++ b/src/cpp/rtps/RTPSDomain.cpp
@@ -38,9 +38,13 @@ namespace eprosima {
 namespace fastrtps{
 namespace rtps {
 
-uint32_t RTPSDomain::m_maxRTPSParticipantID = 0;
-std::vector<RTPSDomain::t_p_RTPSParticipant> RTPSDomain::m_RTPSParticipants;
-std::set<uint32_t> RTPSDomain::m_RTPSParticipantIDs;
+//---------------------------------------------------------------------------------------------------------------------
+RTPSDomain& RTPSDomain::getInstance()
+//---------------------------------------------------------------------------------------------------------------------
+{
+  static RTPSDomain s_instance;
+  return s_instance;
+}
 
 RTPSDomain::RTPSDomain()
 {
@@ -54,11 +58,13 @@ RTPSDomain::~RTPSDomain()
 
 void RTPSDomain::stopAll()
 {
+    auto& inst = getInstance();
+    std::lock_guard<std::mutex> guard(inst.m_mutex);
     logInfo(RTPS_PARTICIPANT,"DELETING ALL ENDPOINTS IN THIS DOMAIN");
 
-    while(m_RTPSParticipants.size()>0)
+    while(inst.m_RTPSParticipants.size()>0)
     {
-        RTPSDomain::removeRTPSParticipant(m_RTPSParticipants.begin()->first);
+        RTPSDomain::removeRTPSParticipant(inst.m_RTPSParticipants.begin()->first);
     }
     logInfo(RTPS_PARTICIPANT,"RTPSParticipants deleted correctly ");
     eClock::my_sleep(100);
@@ -67,6 +73,8 @@ void RTPSDomain::stopAll()
 RTPSParticipant* RTPSDomain::createParticipant(RTPSParticipantAttributes& PParam,
         RTPSParticipantListener* listen)
 {
+    auto& inst = getInstance();
+    std::lock_guard<std::mutex> guard(inst.m_mutex);
     logInfo(RTPS_PARTICIPANT,"");
 
     if(PParam.builtin.leaseDuration < c_TimeInfinite && PParam.builtin.leaseDuration <= PParam.builtin.leaseDuration_announcementperiod) //TODO CHeckear si puedo ser infinito
@@ -83,13 +91,13 @@ RTPSParticipant* RTPSDomain::createParticipant(RTPSParticipantAttributes& PParam
     if(PParam.participantID < 0)
     {
         ID = getNewId();
-        while(m_RTPSParticipantIDs.insert(ID).second == false)
+        while(inst.m_RTPSParticipantIDs.insert(ID).second == false)
             ID = getNewId();
     }
     else
     {
         ID = PParam.participantID;
-        if(m_RTPSParticipantIDs.insert(ID).second == false)
+        if(inst.m_RTPSParticipantIDs.insert(ID).second == false)
         {
             logError(RTPS_PARTICIPANT,"RTPSParticipant with the same ID already exists");
             return nullptr;
@@ -162,21 +170,23 @@ RTPSParticipant* RTPSDomain::createParticipant(RTPSParticipantAttributes& PParam
         return nullptr;
     }
 
-    m_RTPSParticipants.push_back(t_p_RTPSParticipant(p,pimpl));
+    inst.m_RTPSParticipants.push_back(t_p_RTPSParticipant(p,pimpl));
     return p;
 }
 
 bool RTPSDomain::removeRTPSParticipant(RTPSParticipant* p)
 {
+    auto& inst = getInstance();
+    std::lock_guard<std::mutex> guard(inst.m_mutex);
     if(p!=nullptr)
     {
-        for(auto it = m_RTPSParticipants.begin();it!= m_RTPSParticipants.end();++it)
+        for(auto it = inst.m_RTPSParticipants.begin();it!= inst.m_RTPSParticipants.end();++it)
         {
             if(it->second->getGuid().guidPrefix == p->getGuid().guidPrefix)
             {
-                m_RTPSParticipantIDs.erase(m_RTPSParticipantIDs.find(it->second->getRTPSParticipantID()));
+                inst.m_RTPSParticipantIDs.erase(inst.m_RTPSParticipantIDs.find(it->second->getRTPSParticipantID()));
                 delete(it->second);
-                m_RTPSParticipants.erase(it);
+                inst.m_RTPSParticipants.erase(it);
                 return true;
             }
         }
@@ -187,7 +197,10 @@ bool RTPSDomain::removeRTPSParticipant(RTPSParticipant* p)
 
 RTPSWriter* RTPSDomain::createRTPSWriter(RTPSParticipant* p, WriterAttributes& watt, WriterHistory* hist, WriterListener* listen)
 {
-    for(auto it= m_RTPSParticipants.begin();it!=m_RTPSParticipants.end();++it)
+    auto& inst = getInstance();
+    std::lock_guard<std::mutex> guard(inst.m_mutex);
+
+    for(auto it= inst.m_RTPSParticipants.begin();it!=inst.m_RTPSParticipants.end();++it)
     {
         if(it->first->getGuid().guidPrefix == p->getGuid().guidPrefix)
         {
@@ -204,9 +217,11 @@ RTPSWriter* RTPSDomain::createRTPSWriter(RTPSParticipant* p, WriterAttributes& w
 
 bool RTPSDomain::removeRTPSWriter(RTPSWriter* writer)
 {
+    auto& inst = getInstance();
+    std::lock_guard<std::mutex> guard(inst.m_mutex);
     if(writer!=nullptr)
     {
-        for(auto it= m_RTPSParticipants.begin();it!=m_RTPSParticipants.end();++it)
+        for(auto it= inst.m_RTPSParticipants.begin();it!=inst.m_RTPSParticipants.end();++it)
         {
             if(it->first->getGuid().guidPrefix == writer->getGuid().guidPrefix)
             {
@@ -220,7 +235,9 @@ bool RTPSDomain::removeRTPSWriter(RTPSWriter* writer)
 RTPSReader* RTPSDomain::createRTPSReader(RTPSParticipant* p, ReaderAttributes& ratt,
         ReaderHistory* rhist, ReaderListener* rlisten)
 {
-    for(auto it= m_RTPSParticipants.begin();it!=m_RTPSParticipants.end();++it)
+    auto& inst = getInstance();
+    std::lock_guard<std::mutex> guard(inst.m_mutex);
+    for(auto it= inst.m_RTPSParticipants.begin();it!=inst.m_RTPSParticipants.end();++it)
     {
         if(it->first->getGuid().guidPrefix == p->getGuid().guidPrefix)
         {
@@ -238,9 +255,11 @@ RTPSReader* RTPSDomain::createRTPSReader(RTPSParticipant* p, ReaderAttributes& r
 
 bool RTPSDomain::removeRTPSReader(RTPSReader* reader)
 {
+    auto& inst = getInstance();
+    std::lock_guard<std::mutex> guard(inst.m_mutex);
     if(reader !=  nullptr)
     {
-        for(auto it= m_RTPSParticipants.begin();it!=m_RTPSParticipants.end();++it)
+        for(auto it= inst.m_RTPSParticipants.begin();it!=inst.m_RTPSParticipants.end();++it)
         {
             if(it->first->getGuid().guidPrefix == reader->getGuid().guidPrefix)
             {


### PR DESCRIPTION
[rtps_multiparticipant_test.zip](https://github.com/eProsima/Fast-RTPS/files/2048714/rtps_multiparticipant_test.zip)

The attached example program highlights an issue where createRTPSReader() or createRTPSWriter() fails *sometimes* when trying to create a reader and writer attached to different participants in the same process. Could you please investigate? The example program creates one reader and one writer and runs them in separate threads. Each endpoint is attached to a unique participant. To reproduce the problem, just run the executable a couple of times.  A segfault will occur due to create...() returning null. 

The pull request converts RTPSDomain into a singleton, and protects access to calls via a mutex. This seems to fix the issue.