### PR TITLE
add thirdparty directory to CMAKE_PREFIX_PATH only if THIRDPARTY optio…

### DIFF
--- a/cmake/common/eprosima_libraries.cmake
+++ b/cmake/common/eprosima_libraries.cmake
@@ -85,10 +85,10 @@ macro(eprosima_find_thirdparty package thirdparty_name)
             else()
                 message(FATAL_ERROR "Cannot configure Git submodule ${package}")
             endif()
+            set(CMAKE_PREFIX_PATH ${CMAKE_PREFIX_PATH} ${PROJECT_SOURCE_DIR}/thirdparty/${thirdparty_name})
+            set(CMAKE_PREFIX_PATH ${CMAKE_PREFIX_PATH} ${PROJECT_SOURCE_DIR}/thirdparty/${thirdparty_name}/${thirdparty_name})
         endif()
 
-        set(CMAKE_PREFIX_PATH ${CMAKE_PREFIX_PATH} ${PROJECT_SOURCE_DIR}/thirdparty/${thirdparty_name})
-        set(CMAKE_PREFIX_PATH ${CMAKE_PREFIX_PATH} ${PROJECT_SOURCE_DIR}/thirdparty/${thirdparty_name}/${thirdparty_name})
         find_package(${package} REQUIRED QUIET)
 
     endif()


### PR DESCRIPTION
…n is specified

Otherwise it will use the local clone instead of the system version of the dependency.

Without the patch:
```
-- Found asio: /tmp/fastrtps_test/src/eProsima/Fast-RTPS/thirdparty/asio/asio/include
```

With this patch:
```
-- Found asio: /usr/include 
```

@richiware FYI