### PR TITLE
Remove samples on volatile publishers

### DIFF
--- a/examples/C++/SecureHelloWorldExample/HelloWorld.cxx
+++ b/examples/C++/SecureHelloWorldExample/HelloWorld.cxx
@@ -128,6 +128,5 @@ bool HelloWorld::isKeyDefined()
 
 void HelloWorld::serializeKey(eprosima::fastcdr::Cdr &scdr) const
 {
-	 
-	 
+    (void) scdr;
 }

--- a/include/fastrtps/rtps/writer/RTPSWriter.h
+++ b/include/fastrtps/rtps/writer/RTPSWriter.h
@@ -91,7 +91,7 @@ class RTPSWriter : public Endpoint
     * Is only useful in reliable Writer. In BE Writers returns false when pending to be sent.
     * @return True if acknowledged by all.
     */
-    RTPS_DllAPI virtual bool is_acked_by_all(CacheChange_t* /*a_change*/){ return false; }
+    RTPS_DllAPI virtual bool is_acked_by_all(const CacheChange_t* /*a_change*/) const { return false; }
 
     RTPS_DllAPI virtual bool wait_for_all_acked(const Duration_t& /*max_wait*/){ return true; }
 
@@ -150,7 +150,7 @@ class RTPSWriter : public Endpoint
      * Get the publication mode
      * @return publication mode
      */
-    RTPS_DllAPI inline bool isAsync(){ return is_async_; };
+    RTPS_DllAPI inline bool isAsync() const { return is_async_; };
 
     /**
      * Remove an specified max number of changes

--- a/include/fastrtps/rtps/writer/RTPSWriter.h
+++ b/include/fastrtps/rtps/writer/RTPSWriter.h
@@ -87,10 +87,10 @@ class RTPSWriter : public Endpoint
      */
     RTPS_DllAPI virtual bool matched_reader_is_matched(const RemoteReaderAttributes& ratt) = 0;
     /**
-     * Check if a specific change has been acknowledged by all Readers.
-     * Is only useful in reliable Writer. In BE Writers always returns false;
-     * @return True if acknowledged by all.
-     */
+    * Check if a specific change has been acknowledged by all Readers.
+    * Is only useful in reliable Writer. In BE Writers returns false when pending to be sent.
+    * @return True if acknowledged by all.
+    */
     RTPS_DllAPI virtual bool is_acked_by_all(CacheChange_t* /*a_change*/){ return false; }
 
     RTPS_DllAPI virtual bool wait_for_all_acked(const Duration_t& /*max_wait*/){ return true; }

--- a/include/fastrtps/rtps/writer/StatefulWriter.h
+++ b/include/fastrtps/rtps/writer/StatefulWriter.h
@@ -78,17 +78,17 @@ namespace eprosima
                  * Add a specific change to all ReaderLocators.
                  * @param p Pointer to the change.
                  */
-                void unsent_change_added_to_history(CacheChange_t* p);
+                void unsent_change_added_to_history(CacheChange_t* p) override;
                 /**
                  * Indicate the writer that a change has been removed by the history due to some HistoryQos requirement.
                  * @param a_change Pointer to the change that is going to be removed.
                  * @return True if removed correctly.
                  */
-                bool change_removed_by_history(CacheChange_t* a_change);
+                bool change_removed_by_history(CacheChange_t* a_change) override;
                 /**
                  * Method to indicate that there are changes not sent in some of all ReaderProxy.
                  */
-                void send_any_unsent_changes();
+                void send_any_unsent_changes() override;
 
                 //!Increment the HB count.
                 inline void incrementHBCount(){ ++m_heartbeatCount; };
@@ -97,36 +97,36 @@ namespace eprosima
                  * @param ratt Attributes of the reader to add.
                  * @return True if added.
                  */
-                bool matched_reader_add(const RemoteReaderAttributes& ratt);
+                bool matched_reader_add(const RemoteReaderAttributes& ratt) override;
                 /**
                  * Remove a matched reader.
                  * @param ratt Attributes of the reader to remove.
                  * @return True if removed.
                  */
-                bool matched_reader_remove(const RemoteReaderAttributes& ratt);
+                bool matched_reader_remove(const RemoteReaderAttributes& ratt) override;
                 /**
                  * Tells us if a specific Reader is matched against this writer
                  * @param ratt Attributes of the reader to remove.
                  * @return True if it was matched.
                  */
-                bool matched_reader_is_matched(const RemoteReaderAttributes& ratt);
+                bool matched_reader_is_matched(const RemoteReaderAttributes& ratt) override;
 
                 bool is_acked_by_all(const CacheChange_t* a_change) const override;
 
-                bool wait_for_all_acked(const Duration_t& max_wait);
+                bool wait_for_all_acked(const Duration_t& max_wait) override;
 
                 /**
                 * Remove the change with the minimum SequenceNumber
                 * @return True if removed.
                 */
                 bool try_remove_change(std::chrono::microseconds& microseconds,
-                        std::unique_lock<std::recursive_mutex>& lock);
+                        std::unique_lock<std::recursive_mutex>& lock) override;
 
                 /**
                  * Update the Attributes of the Writer.
                  * @param att New attributes
                  */
-                void updateAttributes(WriterAttributes& att);
+                void updateAttributes(WriterAttributes& att) override;
 
                 /**
                  * Find a Reader Proxy in this writer.
@@ -176,7 +176,7 @@ namespace eprosima
                  */
                 void updateTimes(WriterTimes& times);
 
-                void add_flow_controller(std::unique_ptr<FlowController> controller);
+                void add_flow_controller(std::unique_ptr<FlowController> controller) override;
 
                 SequenceNumber_t next_sequence_number() const;
 

--- a/include/fastrtps/rtps/writer/StatefulWriter.h
+++ b/include/fastrtps/rtps/writer/StatefulWriter.h
@@ -111,7 +111,7 @@ namespace eprosima
                  */
                 bool matched_reader_is_matched(const RemoteReaderAttributes& ratt);
 
-                bool is_acked_by_all(CacheChange_t* a_change);
+                bool is_acked_by_all(const CacheChange_t* a_change) const override;
 
                 bool wait_for_all_acked(const Duration_t& max_wait);
 

--- a/include/fastrtps/rtps/writer/StatefulWriter.h
+++ b/include/fastrtps/rtps/writer/StatefulWriter.h
@@ -110,14 +110,15 @@ namespace eprosima
                  * @return True if it was matched.
                  */
                 bool matched_reader_is_matched(const RemoteReaderAttributes& ratt);
-                /**
-                 * Remove the change with the minimum SequenceNumber
-                 * @return True if removed.
-                 */
+
                 bool is_acked_by_all(CacheChange_t* a_change);
 
                 bool wait_for_all_acked(const Duration_t& max_wait);
 
+                /**
+                * Remove the change with the minimum SequenceNumber
+                * @return True if removed.
+                */
                 bool try_remove_change(std::chrono::microseconds& microseconds,
                         std::unique_lock<std::recursive_mutex>& lock);
 

--- a/include/fastrtps/rtps/writer/StatelessWriter.h
+++ b/include/fastrtps/rtps/writer/StatelessWriter.h
@@ -102,6 +102,8 @@ class StatelessWriter : public RTPSWriter
      */
     inline size_t getMatchedReadersSize() const {return m_matched_readers.size();};
 
+    bool is_acked_by_all(CacheChange_t* a_change);
+
     bool try_remove_change(std::chrono::microseconds&, std::unique_lock<std::recursive_mutex>&) { return remove_older_changes(1); }
 
     void add_flow_controller(std::unique_ptr<FlowController> controller);

--- a/include/fastrtps/rtps/writer/StatelessWriter.h
+++ b/include/fastrtps/rtps/writer/StatelessWriter.h
@@ -102,7 +102,7 @@ class StatelessWriter : public RTPSWriter
      */
     inline size_t getMatchedReadersSize() const {return m_matched_readers.size();};
 
-    bool is_acked_by_all(CacheChange_t* a_change);
+    bool is_acked_by_all(const CacheChange_t* a_change) const override;
 
     bool try_remove_change(std::chrono::microseconds&, std::unique_lock<std::recursive_mutex>&) { return remove_older_changes(1); }
 

--- a/include/fastrtps/rtps/writer/StatelessWriter.h
+++ b/include/fastrtps/rtps/writer/StatelessWriter.h
@@ -48,45 +48,45 @@ class StatelessWriter : public RTPSWriter
      * Add a specific change to all ReaderLocators.
      * @param p Pointer to the change.
      */
-    void unsent_change_added_to_history(CacheChange_t* p);
+    void unsent_change_added_to_history(CacheChange_t* p) override;
 
     /**
      * Indicate the writer that a change has been removed by the history due to some HistoryQos requirement.
      * @param a_change Pointer to the change that is going to be removed.
      * @return True if removed correctly.
      */
-    bool change_removed_by_history(CacheChange_t* a_change);
+    bool change_removed_by_history(CacheChange_t* a_change) override;
     /**
      * Add a matched reader.
      * @param ratt Attributes of the reader to add.
      * @return True if added.
      */
-    bool matched_reader_add(const RemoteReaderAttributes& ratt);
+    bool matched_reader_add(const RemoteReaderAttributes& ratt) override;
     /**
      * Remove a matched reader.
      * @param ratt Attributes of the reader to remove.
      * @return True if removed.
      */
-    bool matched_reader_remove(const RemoteReaderAttributes& ratt);
+    bool matched_reader_remove(const RemoteReaderAttributes& ratt) override;
     /**
      * Tells us if a specific Reader is matched against this writer
      * @param ratt Attributes of the reader to check.
      * @return True if it was matched.
      */
-    bool matched_reader_is_matched(const RemoteReaderAttributes& ratt);
+    bool matched_reader_is_matched(const RemoteReaderAttributes& ratt) override;
     /**
      * Method to indicate that there are changes not sent in some of all ReaderProxy.
      */
-    void send_any_unsent_changes();
+    void send_any_unsent_changes() override;
 
     /**
      * Update the Attributes of the Writer.
      * @param att New attributes
      */
-    void updateAttributes(WriterAttributes& att){
+    void updateAttributes(WriterAttributes& att) override {
         (void)att;
         //FOR NOW THERE IS NOTHING TO UPDATE.
-    };
+    }
 
     bool add_locator(Locator_t& loc);
 
@@ -104,9 +104,11 @@ class StatelessWriter : public RTPSWriter
 
     bool is_acked_by_all(const CacheChange_t* a_change) const override;
 
-    bool try_remove_change(std::chrono::microseconds&, std::unique_lock<std::recursive_mutex>&) { return remove_older_changes(1); }
+    bool try_remove_change(std::chrono::microseconds&, std::unique_lock<std::recursive_mutex>&) override { 
+        return remove_older_changes(1); 
+    }
 
-    void add_flow_controller(std::unique_ptr<FlowController> controller);
+    void add_flow_controller(std::unique_ptr<FlowController> controller) override;
 
     private:
 

--- a/include/fastrtps/rtps/writer/WriterListener.h
+++ b/include/fastrtps/rtps/writer/WriterListener.h
@@ -27,6 +27,7 @@ namespace fastrtps{
 namespace rtps{
 
 class RTPSWriter;
+struct CacheChange_t;
 
 /**
 * Class WriterListener with virtual method so the user can implement callbacks to certain events.
@@ -43,7 +44,15 @@ public:
 	* @param writer Pointer to the RTPSWriter.
 	* @param info Matching Information.
 	*/
-	virtual void onWriterMatched(RTPSWriter* writer,MatchingInfo& info){(void)writer; (void)info;};
+	virtual void onWriterMatched(RTPSWriter* writer,MatchingInfo& info){(void)writer; (void)info;}
+
+    /**
+    * This method is called when all the readers matched with this Writer acknowledge that a cache 
+    * change has been received.
+    * @param writer Pointer to the RTPSWriter.
+    * @param change Pointer to the affected CacheChange_t.
+    */
+    virtual void onWriterChangeReceivedByAll(RTPSWriter* writer, CacheChange_t* change) { (void)writer; (void)change; }
 };
 }
 }

--- a/src/cpp/publisher/PublisherImpl.cpp
+++ b/src/cpp/publisher/PublisherImpl.cpp
@@ -297,6 +297,14 @@ void PublisherImpl::PublisherWriterListener::onWriterMatched(RTPSWriter* /*write
         mp_publisherImpl->mp_listener->onPublicationMatched(mp_publisherImpl->mp_userPublisher,info);
 }
 
+void PublisherImpl::PublisherWriterListener::onWriterChangeReceivedByAll(RTPSWriter* /*writer*/, CacheChange_t* ch)
+{
+    if (mp_publisherImpl->m_att.qos.m_durability.kind == VOLATILE_DURABILITY_QOS)
+    {
+        mp_publisherImpl->m_history.remove_change_g(ch);
+    }
+}
+
 bool PublisherImpl::try_remove_change(std::unique_lock<std::recursive_mutex>& lock)
 {
     std::chrono::microseconds max_w(::TimeConv::Time_t2MicroSecondsInt64(m_att.qos.m_reliability.max_blocking_time));

--- a/src/cpp/publisher/PublisherImpl.cpp
+++ b/src/cpp/publisher/PublisherImpl.cpp
@@ -178,12 +178,6 @@ bool PublisherImpl::create_new_change_with_params(ChangeKind_t changeKind, void*
             return false;
         }
 
-        if(m_att.qos.m_durability.kind == VOLATILE_DURABILITY_QOS &&
-                mp_writer->is_acked_by_all(ch))
-        {
-            m_history.remove_change_g(ch);
-        }
-
         return true;
     }
 

--- a/src/cpp/publisher/PublisherImpl.h
+++ b/src/cpp/publisher/PublisherImpl.h
@@ -142,6 +142,7 @@ class PublisherImpl
             PublisherWriterListener(PublisherImpl* p):mp_publisherImpl(p){};
             virtual ~PublisherWriterListener(){};
             void onWriterMatched(rtps::RTPSWriter* writer, rtps::MatchingInfo& info);
+            void onWriterChangeReceivedByAll(rtps::RTPSWriter* writer, rtps::CacheChange_t* change);
             PublisherImpl* mp_publisherImpl;
     }m_writerListener;
 

--- a/src/cpp/rtps/writer/ReaderProxy.cpp
+++ b/src/cpp/rtps/writer/ReaderProxy.cpp
@@ -79,6 +79,7 @@ void ReaderProxy::addChange(const ChangeForReader_t& change)
             change.getSequenceNumber() > m_changesForReader.rbegin()->getSequenceNumber() :
             true);
 
+    // For best effort readers, changes are acked when being sent
     if(m_changesForReader.size() == 0 && change.getStatus() == ACKNOWLEDGED)
     {
         changesFromRLowMark_ = change.getSequenceNumber();
@@ -264,7 +265,6 @@ bool ReaderProxy::mark_fragment_as_sent_for_change(const CacheChange_t* change, 
         newch.markFragmentsAsSent(fragment);
         if (newch.getUnsentFragments().isSetEmpty())
         {
-            newch.setStatus(UNDERWAY); //TODO (Ricardo) Check
             allFragmentsSent = true;
         }
         else

--- a/src/cpp/rtps/writer/StatefulWriter.cpp
+++ b/src/cpp/rtps/writer/StatefulWriter.cpp
@@ -389,6 +389,9 @@ void StatefulWriter::send_any_unsent_changes()
         send_heartbeat_nts_(mAllRemoteReaders, mAllShrinkedLocatorList, group, true);
     }
 
+    // On VOLATILE writers, remove auto-acked (best effort readers) changes
+    check_acked_status();
+
     logInfo(RTPS_WRITER, "Finish sending unsent changes");
 }
 

--- a/src/cpp/rtps/writer/StatefulWriter.cpp
+++ b/src/cpp/rtps/writer/StatefulWriter.cpp
@@ -296,7 +296,17 @@ void StatefulWriter::send_any_unsent_changes()
                             activateHeartbeatPeriod = true;
                             assert(remoteReader->mp_nackSupression != nullptr);
                             if(allFragmentsSent)
+                            {
+                                remoteReader->set_change_to_status(changeToSend.sequenceNumber, UNDERWAY);
                                 remoteReader->mp_nackSupression->restart_timer();
+                            }
+                        }
+                        else
+                        {
+                            if(allFragmentsSent)
+                            {
+                                remoteReader->set_change_to_status(changeToSend.sequenceNumber, ACKNOWLEDGED);
+                            }
                         }
                     }
                 }

--- a/src/cpp/rtps/writer/StatefulWriter.cpp
+++ b/src/cpp/rtps/writer/StatefulWriter.cpp
@@ -18,6 +18,7 @@
  */
 
 #include <fastrtps/rtps/writer/StatefulWriter.h>
+#include <fastrtps/rtps/writer/WriterListener.h>
 #include <fastrtps/rtps/writer/ReaderProxy.h>
 #include <fastrtps/rtps/resources/AsyncWriterThread.h>
 
@@ -49,7 +50,7 @@ StatefulWriter::StatefulWriter(RTPSParticipantImpl* pimpl,GUID_t& guid,
         WriterAttributes& att,WriterHistory* hist,WriterListener* listen):
     RTPSWriter(pimpl, guid, att, hist, listen),
     mp_periodicHB(nullptr), m_times(att.times),
-    all_acked_(false), may_remove_change_(false),
+    all_acked_(false), may_remove_change_(0),
     disableHeartbeatPiggyback_(att.disableHeartbeatPiggyback),
     sendBufferSize_(pimpl->get_min_network_send_buffer_size()),
     currentUsageSendBufferSize_(static_cast<int32_t>(pimpl->get_min_network_send_buffer_size()))
@@ -670,10 +671,10 @@ void StatefulWriter::check_acked_status()
 
     if(get_seq_num_min() != SequenceNumber_t::unknown())
     {
-        // If VOLATILE, remove samples acked.
-        if(m_att.durabilityKind == VOLATILE)
+        // Inform of samples acked.
+        if(mp_listener != nullptr)
         {
-            std::vector<CacheChange_t*> to_remove;
+            std::vector<CacheChange_t*> all_acked_changes;
             for(SequenceNumber_t current_seq = get_seq_num_min(); current_seq <= min_low_mark; ++current_seq)
             {
                 for(std::vector<CacheChange_t*>::iterator cit = mp_history->changesBegin();
@@ -681,26 +682,23 @@ void StatefulWriter::check_acked_status()
                 {
                     if((*cit)->sequenceNumber == current_seq)
                     {
-                        to_remove.push_back(*cit);
+                        all_acked_changes.push_back(*cit);
                     }
                 }
             }
-            for(auto cit = to_remove.begin(); cit != to_remove.end(); ++cit)
+            for(auto cit = all_acked_changes.begin(); cit != all_acked_changes.end(); ++cit)
             {
-                mp_history->remove_change_g(*cit);
+                mp_listener->onWriterChangeReceivedByAll(this, *cit);
             }
         }
-        else
+        
+        SequenceNumber_t calc = min_low_mark < get_seq_num_min() ? SequenceNumber_t() :
+            (min_low_mark - get_seq_num_min()) + 1;
+        if (calc > SequenceNumber_t())
         {
-            SequenceNumber_t calc = min_low_mark < get_seq_num_min() ? SequenceNumber_t() :
-                (min_low_mark - get_seq_num_min()) + 1;
-
-            if(calc > SequenceNumber_t())
-            {
-                std::unique_lock<std::mutex> may_lock(may_remove_change_mutex_);
-                may_remove_change_ = 1;
-                may_remove_change_cond_.notify_one();
-            }
+            std::unique_lock<std::mutex> may_lock(may_remove_change_mutex_);
+            may_remove_change_ = 1;
+            may_remove_change_cond_.notify_one();
         }
     }
 

--- a/src/cpp/rtps/writer/StatefulWriter.cpp
+++ b/src/cpp/rtps/writer/StatefulWriter.cpp
@@ -164,6 +164,10 @@ void StatefulWriter::unsent_change_added_to_history(CacheChange_t* change)
             }
 
             this->mp_periodicHB->restart_timer();
+            if ( (mp_listener != nullptr) && this->is_acked_by_all(change) )
+            {
+                mp_listener->onWriterChangeReceivedByAll(this, change);
+            }
         }
         else
         {
@@ -189,6 +193,10 @@ void StatefulWriter::unsent_change_added_to_history(CacheChange_t* change)
     else
     {
         logInfo(RTPS_WRITER,"No reader proxy to add change.");
+        if (mp_listener != nullptr)
+        {
+            mp_listener->onWriterChangeReceivedByAll(this, change);
+        }
     }
 }
 

--- a/src/cpp/rtps/writer/StatefulWriter.cpp
+++ b/src/cpp/rtps/writer/StatefulWriter.cpp
@@ -606,7 +606,7 @@ bool StatefulWriter::matched_reader_lookup(GUID_t& readerGuid,ReaderProxy** RP)
     return false;
 }
 
-bool StatefulWriter::is_acked_by_all(CacheChange_t* change)
+bool StatefulWriter::is_acked_by_all(const CacheChange_t* change) const
 {
     std::lock_guard<std::recursive_mutex> guard(*mp_mutex);
 

--- a/src/cpp/rtps/writer/StatelessWriter.cpp
+++ b/src/cpp/rtps/writer/StatelessWriter.cpp
@@ -128,7 +128,7 @@ bool StatelessWriter::change_removed_by_history(CacheChange_t* change)
     return true;
 }
 
-bool StatelessWriter::is_acked_by_all(CacheChange_t* change)
+bool StatelessWriter::is_acked_by_all(const CacheChange_t* change) const
 {
     // Only asynchronous writers may have unacked (i.e. unsent changes)
     if (isAsync())

--- a/test/blackbox/BlackboxTests.cpp
+++ b/test/blackbox/BlackboxTests.cpp
@@ -2225,7 +2225,7 @@ BLACKBOXTEST(BlackBox, RTPSAsReliableVolatileSocket)
     writer.reliability(eprosima::fastrtps::rtps::ReliabilityKind_t::RELIABLE).
         durability(eprosima::fastrtps::rtps::DurabilityKind_t::VOLATILE).
         add_to_multicast_locator_list(ip, global_port).
-		auto_remove_on_volatile().init();
+        auto_remove_on_volatile().init();
 
     ASSERT_TRUE(writer.isInitialized());
 
@@ -5131,7 +5131,7 @@ BLACKBOXTEST(BlackBox, AsyncPubSubAsNonReliableVolatileKeepAllHelloworld)
     writer.reliability(eprosima::fastrtps::rtps::ReliabilityKind_t::BEST_EFFORT).
         durability(eprosima::fastrtps::rtps::DurabilityKind_t::VOLATILE).
         add_to_multicast_locator_list(ip, global_port).
-		auto_remove_on_volatile().init();
+        auto_remove_on_volatile().init();
 
     ASSERT_TRUE(writer.isInitialized());
 

--- a/test/blackbox/BlackboxTests.cpp
+++ b/test/blackbox/BlackboxTests.cpp
@@ -5114,6 +5114,116 @@ BLACKBOXTEST(BlackBox, AsyncPubSubAsNonReliableVolatileHelloworld)
     reader.block_for_at_least(2);
 }
 
+// Test created to check bug #3290 (ROS2 #539)
+BLACKBOXTEST(BlackBox, AsyncVolatileKeepAllPubReliableSubNonReliable300Kb)
+{
+    PubSubReader<Data1mbType> reader(TEST_TOPIC_NAME);
+    PubSubWriter<Data1mbType> writer(TEST_TOPIC_NAME);
+
+    reader.history_kind(eprosima::fastrtps::KEEP_ALL_HISTORY_QOS).
+        reliability(eprosima::fastrtps::BEST_EFFORT_RELIABILITY_QOS).
+        init();
+
+    ASSERT_TRUE(reader.isInitialized());
+
+    writer.history_kind(eprosima::fastrtps::KEEP_ALL_HISTORY_QOS).
+        reliability(eprosima::fastrtps::RELIABLE_RELIABILITY_QOS).
+        durability_kind(eprosima::fastrtps::VOLATILE_DURABILITY_QOS).
+        resource_limits_allocated_samples(9).
+        resource_limits_max_samples(9).
+        asynchronously(eprosima::fastrtps::ASYNCHRONOUS_PUBLISH_MODE).
+        init();
+
+    ASSERT_TRUE(writer.isInitialized());
+
+    // Wait for discovery.
+    writer.waitDiscovery();
+    reader.waitDiscovery();
+
+    auto data = default_data300kb_data_generator(10);
+
+    reader.startReception(data);
+    // Send data
+    writer.send(data);
+    // In this test all data should be sent.
+    ASSERT_TRUE(data.empty());
+    // Block reader until reception finished or timeout.
+    reader.block_for_at_least(2);
+}
+
+// Test created to check bug #3290 (ROS2 #539)
+BLACKBOXTEST(BlackBox, VolatileKeepAllPubReliableSubNonReliableHelloWorld)
+{
+    PubSubReader<HelloWorldType> reader(TEST_TOPIC_NAME);
+    PubSubWriter<HelloWorldType> writer(TEST_TOPIC_NAME);
+
+    reader.history_kind(eprosima::fastrtps::KEEP_ALL_HISTORY_QOS).
+        reliability(eprosima::fastrtps::BEST_EFFORT_RELIABILITY_QOS).
+        init();
+
+    ASSERT_TRUE(reader.isInitialized());
+
+    writer.history_kind(eprosima::fastrtps::KEEP_ALL_HISTORY_QOS).
+        reliability(eprosima::fastrtps::RELIABLE_RELIABILITY_QOS).
+        durability_kind(eprosima::fastrtps::VOLATILE_DURABILITY_QOS).
+        resource_limits_allocated_samples(9).
+        resource_limits_max_samples(9).
+        init();
+
+    ASSERT_TRUE(writer.isInitialized());
+
+    // Wait for discovery.
+    writer.waitDiscovery();
+    reader.waitDiscovery();
+
+    auto data = default_helloworld_data_generator(10);
+
+    reader.startReception(data);
+    // Send data
+    writer.send(data);
+    // In this test all data should be sent.
+    ASSERT_TRUE(data.empty());
+    // Block reader until reception finished or timeout.
+    reader.block_for_at_least(2);
+}
+
+// Test created to check bug #3290 (ROS2 #539)
+BLACKBOXTEST(BlackBox, AsyncVolatileKeepAllPubReliableSubNonReliableHelloWorld)
+{
+    PubSubReader<HelloWorldType> reader(TEST_TOPIC_NAME);
+    PubSubWriter<HelloWorldType> writer(TEST_TOPIC_NAME);
+
+    reader.history_kind(eprosima::fastrtps::KEEP_ALL_HISTORY_QOS).
+        reliability(eprosima::fastrtps::BEST_EFFORT_RELIABILITY_QOS).
+        init();
+
+    ASSERT_TRUE(reader.isInitialized());
+
+    writer.history_kind(eprosima::fastrtps::KEEP_ALL_HISTORY_QOS).
+        reliability(eprosima::fastrtps::RELIABLE_RELIABILITY_QOS).
+        durability_kind(eprosima::fastrtps::VOLATILE_DURABILITY_QOS).
+        resource_limits_allocated_samples(9).
+        resource_limits_max_samples(9).
+        asynchronously(eprosima::fastrtps::ASYNCHRONOUS_PUBLISH_MODE).
+        init();
+
+    ASSERT_TRUE(writer.isInitialized());
+
+    // Wait for discovery.
+    writer.waitDiscovery();
+    reader.waitDiscovery();
+
+    auto data = default_helloworld_data_generator(10);
+
+    reader.startReception(data);
+    // Send data
+    writer.send(data);
+    // In this test all data should be sent.
+    ASSERT_TRUE(data.empty());
+    // Block reader until reception finished or timeout.
+    reader.block_for_at_least(2);
+}
+
 int main(int argc, char **argv)
 {
     testing::InitGoogleTest(&argc, argv);

--- a/test/blackbox/BlackboxTests.cpp
+++ b/test/blackbox/BlackboxTests.cpp
@@ -93,6 +93,7 @@ void default_send_print(const Data1mb& data)
 #include "PubSubWriterReader.hpp"
 
 #include <fastrtps/rtps/RTPSDomain.h>
+#include <fastrtps/rtps/writer/WriterListener.h>
 #include <fastrtps/rtps/flowcontrol/ThroughputControllerDescriptor.h>
 #include <fastrtps/transport/UDPv4Transport.h>
 #include <fastrtps/transport/test_UDPv4Transport.h>
@@ -2223,7 +2224,8 @@ BLACKBOXTEST(BlackBox, RTPSAsReliableVolatileSocket)
 
     writer.reliability(eprosima::fastrtps::rtps::ReliabilityKind_t::RELIABLE).
         durability(eprosima::fastrtps::rtps::DurabilityKind_t::VOLATILE).
-        add_to_multicast_locator_list(ip, global_port).init();
+        add_to_multicast_locator_list(ip, global_port).
+		auto_remove_on_volatile().init();
 
     ASSERT_TRUE(writer.isInitialized());
 
@@ -5128,7 +5130,8 @@ BLACKBOXTEST(BlackBox, AsyncPubSubAsNonReliableVolatileKeepAllHelloworld)
 
     writer.reliability(eprosima::fastrtps::rtps::ReliabilityKind_t::BEST_EFFORT).
         durability(eprosima::fastrtps::rtps::DurabilityKind_t::VOLATILE).
-        add_to_multicast_locator_list(ip, global_port).init();
+        add_to_multicast_locator_list(ip, global_port).
+		auto_remove_on_volatile().init();
 
     ASSERT_TRUE(writer.isInitialized());
 

--- a/test/blackbox/BlackboxTests.cpp
+++ b/test/blackbox/BlackboxTests.cpp
@@ -5165,12 +5165,18 @@ BLACKBOXTEST(BlackBox, AsyncVolatileKeepAllPubReliableSubNonReliable300Kb)
 
     ASSERT_TRUE(reader.isInitialized());
 
+    // When doing fragmentation, it is necessary to have some degree of
+    // flow control not to overrun the receive buffer.
+    uint32_t bytesPerPeriod = 65536;
+    uint32_t periodInMs = 50;
+
     writer.history_kind(eprosima::fastrtps::KEEP_ALL_HISTORY_QOS).
         reliability(eprosima::fastrtps::RELIABLE_RELIABILITY_QOS).
         durability_kind(eprosima::fastrtps::VOLATILE_DURABILITY_QOS).
         resource_limits_allocated_samples(9).
         resource_limits_max_samples(9).
         asynchronously(eprosima::fastrtps::ASYNCHRONOUS_PUBLISH_MODE).
+        add_throughput_controller_descriptor_to_pparams(bytesPerPeriod, periodInMs).
         init();
 
     ASSERT_TRUE(writer.isInitialized());
@@ -5182,8 +5188,8 @@ BLACKBOXTEST(BlackBox, AsyncVolatileKeepAllPubReliableSubNonReliable300Kb)
     auto data = default_data300kb_data_generator(10);
 
     reader.startReception(data);
-    // Send data
-    writer.send(data);
+    // Send data with some interval, to let async writer thread send samples
+    writer.send(data,300);
     // In this test all data should be sent.
     ASSERT_TRUE(data.empty());
     // Block reader until reception finished or timeout.
@@ -5255,8 +5261,8 @@ BLACKBOXTEST(BlackBox, AsyncVolatileKeepAllPubReliableSubNonReliableHelloWorld)
     auto data = default_helloworld_data_generator(10);
 
     reader.startReception(data);
-    // Send data
-    writer.send(data);
+    // Send data with some interval, to let async writer thread send samples
+    writer.send(data,300);
     // In this test all data should be sent.
     ASSERT_TRUE(data.empty());
     // Block reader until reception finished or timeout.

--- a/test/blackbox/BlackboxTests.cpp
+++ b/test/blackbox/BlackboxTests.cpp
@@ -1297,7 +1297,7 @@ BLACKBOXTEST_F(BlackBoxPersistence, RTPSAsNonReliableWithPersistence)
 
     // Stop and start reader and writer
     std::this_thread::sleep_for(std::chrono::seconds(1));
-    
+
     std::cout << "First round finished." << std::endl;
 
     reader.init();
@@ -5112,6 +5112,42 @@ BLACKBOXTEST(BlackBox, AsyncPubSubAsNonReliableVolatileHelloworld)
     ASSERT_TRUE(data.empty());
     // Block reader until reception finished or timeout.
     reader.block_for_at_least(2);
+}
+
+// Test created to check a bug with writers that use BEST_EFFORT WITH VOLATILE that don't remove messages from history.
+BLACKBOXTEST(BlackBox, AsyncPubSubAsNonReliableVolatileKeepAllHelloworld)
+{
+    RTPSAsSocketReader<HelloWorldType> reader(TEST_TOPIC_NAME);
+    RTPSAsSocketWriter<HelloWorldType> writer(TEST_TOPIC_NAME);
+    std::string ip("239.255.1.4");
+
+    reader.reliability(eprosima::fastrtps::rtps::ReliabilityKind_t::BEST_EFFORT).
+        add_to_multicast_locator_list(ip, global_port).init();
+
+    ASSERT_TRUE(reader.isInitialized());
+
+    writer.reliability(eprosima::fastrtps::rtps::ReliabilityKind_t::BEST_EFFORT).
+        durability(eprosima::fastrtps::rtps::DurabilityKind_t::VOLATILE).
+        add_to_multicast_locator_list(ip, global_port).init();
+
+    ASSERT_TRUE(writer.isInitialized());
+
+    auto data = default_helloworld_data_generator();
+
+    reader.expected_data(data);
+    reader.startReception();
+
+    // Send data
+    writer.send(data);
+    // In this test all data should be sent.
+    ASSERT_TRUE(data.empty());
+    // Block reader until reception finished or timeout.
+    reader.block_for_all();
+
+    // Wait for acks to be sent and check writer history is empty
+    std::this_thread::sleep_for(std::chrono::seconds(1));
+
+    ASSERT_TRUE(writer.is_history_empty());
 }
 
 // Test created to check bug #3290 (ROS2 #539)

--- a/test/blackbox/PubSubWriter.hpp
+++ b/test/blackbox/PubSubWriter.hpp
@@ -319,7 +319,7 @@ class PubSubWriter
         }
     }
 
-    void send(std::list<type>& msgs)
+    void send(std::list<type>& msgs, uint32_t milliseconds = 0)
     {
         auto it = msgs.begin();
 
@@ -329,6 +329,8 @@ class PubSubWriter
             {
                 default_send_print<type>(*it);
                 it = msgs.erase(it);
+                if(milliseconds > 0)
+                    std::this_thread::sleep_for(std::chrono::milliseconds(milliseconds));
             }
             else
                 break;

--- a/test/blackbox/RTPSAsSocketWriter.hpp
+++ b/test/blackbox/RTPSAsSocketWriter.hpp
@@ -40,7 +40,7 @@
 
 
 template<class TypeSupport>
-class RTPSAsSocketWriter : public WriterListener
+class RTPSAsSocketWriter : public eprosima::fastrtps::rtps::WriterListener
 {
     public:
 
@@ -48,7 +48,7 @@ class RTPSAsSocketWriter : public WriterListener
         typedef typename type_support::type type;
 
         RTPSAsSocketWriter(const std::string& magicword) : participant_(nullptr),
-        writer_(nullptr), history_(nullptr), initialized_(false), port_(0), auto_remove_(false)
+        writer_(nullptr), history_(nullptr), initialized_(false), auto_remove_(false), port_(0)
         {
             std::ostringstream mw;
             mw << magicword << "_" << asio::ip::host_name() << "_" << GET_PID();
@@ -77,14 +77,14 @@ class RTPSAsSocketWriter : public WriterListener
                 delete(history_);
         }
 
-		void onWriterChangeReceivedByAll(eprosima::fastrtps::rtps::RTPSWriter* /*writer*/, eprosima::fastrtps::rtps::CacheChange_t* change)
-		{
+        void onWriterChangeReceivedByAll(eprosima::fastrtps::rtps::RTPSWriter* /*writer*/, eprosima::fastrtps::rtps::CacheChange_t* change)
+        {
             if(writer_attr_.endpoint.durabilityKind == eprosima::fastrtps::rtps::VOLATILE)
-			{
-				history_->remove_change_g(change);
-			}
-		}
-		
+            {
+                history_->remove_change_g(change);
+            }
+        }
+        
         void init()
         {
             //Create participant
@@ -101,7 +101,7 @@ class RTPSAsSocketWriter : public WriterListener
             history_ = new eprosima::fastrtps::rtps::WriterHistory(hattr_);
 
             //Create writer
-			WriterListener* listener = auto_remove_ ? this : nullptr;
+            eprosima::fastrtps::rtps::WriterListener* listener = auto_remove_ ? this : nullptr;
             writer_ = eprosima::fastrtps::rtps::RTPSDomain::createRTPSWriter(participant_, writer_attr_, history_, listener);
             ASSERT_NE(writer_, nullptr);
 
@@ -121,7 +121,7 @@ class RTPSAsSocketWriter : public WriterListener
                 eprosima::fastrtps::rtps::CacheChange_t * ch = writer_->new_change([&]() -> uint32_t
                                 {
                                    size_t current_alignment =  4 + magicword_.size() + 1;
-				   return (uint32_t)(current_alignment + type::getCdrSerializedSize(*it, current_alignment));
+                   return (uint32_t)(current_alignment + type::getCdrSerializedSize(*it, current_alignment));
                                 }
                                 , eprosima::fastrtps::rtps::ALIVE);
 
@@ -133,12 +133,12 @@ class RTPSAsSocketWriter : public WriterListener
                 ch->serializedPayload.length = static_cast<uint32_t>(cdr.getSerializedDataLength());
 
                 history_->add_change(ch);
-				if(auto_remove_ && 
-				   (writer_attr_.endpoint.durabilityKind == eprosima::fastrtps::rtps::VOLATILE) && 
-				   writer_->is_acked_by_all(ch) )
-				{
-					history_->remove_change_g(ch);
-				}
+                if(auto_remove_ && 
+                   (writer_attr_.endpoint.durabilityKind == eprosima::fastrtps::rtps::VOLATILE) && 
+                   writer_->is_acked_by_all(ch) )
+                {
+                    history_->remove_change_g(ch);
+                }
                 it = msgs.erase(it);
             }
         }
@@ -147,12 +147,12 @@ class RTPSAsSocketWriter : public WriterListener
         {
             return history_->getHistorySize() == 0;
         }
-		
-		RTPSAsSocketWriter& auto_remove_on_volatile()
-		{
-			auto_remove_ = true;
-			return *this;
-		}
+        
+        RTPSAsSocketWriter& auto_remove_on_volatile()
+        {
+            auto_remove_ = true;
+            return *this;
+        }
 
         /*** Function to change QoS ***/
         RTPSAsSocketWriter& reliability(const eprosima::fastrtps::rtps::ReliabilityKind_t kind)
@@ -257,7 +257,7 @@ class RTPSAsSocketWriter : public WriterListener
         eprosima::fastrtps::rtps::WriterHistory *history_;
         eprosima::fastrtps::rtps::HistoryAttributes hattr_;
         bool initialized_;
-		bool auto_remove_;
+        bool auto_remove_;
         std::string magicword_;
         type_support type_;
         std::string ip_;

--- a/test/blackbox/RTPSAsSocketWriter.hpp
+++ b/test/blackbox/RTPSAsSocketWriter.hpp
@@ -133,12 +133,6 @@ class RTPSAsSocketWriter : public eprosima::fastrtps::rtps::WriterListener
                 ch->serializedPayload.length = static_cast<uint32_t>(cdr.getSerializedDataLength());
 
                 history_->add_change(ch);
-                if(auto_remove_ && 
-                   (writer_attr_.endpoint.durabilityKind == eprosima::fastrtps::rtps::VOLATILE) && 
-                   writer_->is_acked_by_all(ch) )
-                {
-                    history_->remove_change_g(ch);
-                }
                 it = msgs.erase(it);
             }
         }


### PR DESCRIPTION
This PR correctly handles the removal of changes from the publisher history when the durability QOS is set to VOLATILE.

This should fix ros2/ros2#539