### PR TITLE
Making 'max' tag optional

### DIFF
--- a/src/cpp/security/accesscontrol/CommonParser.cpp
+++ b/src/cpp/security/accesscontrol/CommonParser.cpp
@@ -88,33 +88,29 @@ bool eprosima::fastrtps::rtps::security::parse_domain_id_set(tinyxml2::XMLElemen
 
                     if(returned_value && (subnode = subnode->NextSiblingElement()) != nullptr)
                     {
+                        // "Max" parameter is optional
                         if(strcmp(subnode->Name(), Max_str) == 0)
                         {
                             uint32_t max_domain_id = 0;
-
                             if(tinyxml2::XMLError::XML_SUCCESS == subnode->QueryUnsignedText(&max_domain_id))
                             {
                                 domains.ranges.push_back(std::make_pair(min_domain_id, max_domain_id));
                             }
                             else
                             {
-                                logError(XMLPARSER, "Invalid value of " << DomainId_str <<
+                                logError(XMLPARSER, "Invalid max value of " << DomainId_str <<
                                         " tag. Line " << PRINTLINE(subnode));
                                 returned_value = false;
                             }
                         }
                         else
                         {
-                            logError(XMLPARSER, "Expected " << Max_str << " tag. Line " <<
-                                    PRINTLINE(subnode));
-                            returned_value = false;
+                            domains.ranges.push_back(std::make_pair(min_domain_id, 0));
                         }
                     }
                     else
                     {
-                        logError(XMLPARSER, "Expected " << Max_str << " tag. Line " <<
-                                PRINTLINE(node));
-                        returned_value = false;
+                        domains.ranges.push_back(std::make_pair(min_domain_id, 0));
                     }
                 }
                 else


### PR DESCRIPTION
This fixes #245 making domains->id_range->max optional on the governance file