### PR TITLE
Fix on linux autotools installer (#3294)

### DIFF
--- a/src/cpp/CMakeLists.txt
+++ b/src/cpp/CMakeLists.txt
@@ -167,10 +167,14 @@ endif()
 
 # External sources
 if(TINYXML2_SOURCE_DIR)
+    set(TINYXML2_SOURCE_DIR_ ${TINYXML2_SOURCE_DIR})
+    if(UNIX AND EPROSIMA_INSTALLER)
+        file(RELATIVE_PATH TINYXML2_SOURCE_DIR_ ${CMAKE_CURRENT_SOURCE_DIR} ${TINYXML2_SOURCE_DIR})
+    endif()
     list(APPEND ${PROJECT_NAME}_source_files
-        ${TINYXML2_SOURCE_DIR}/tinyxml2.cpp
+        ${TINYXML2_SOURCE_DIR_}/tinyxml2.cpp
         )
-    set_sources(${TINYXML2_SOURCE_DIR}/tinyxml2.cpp)
+    set_sources(${TINYXML2_SOURCE_DIR_}/tinyxml2.cpp)
 endif()
 
 if(ANDROID)


### PR DESCRIPTION
This PR solves an issue with generated linux installer (autotools installer). Before this patch the generated installer contains absolute path to tinyxml2 from the origin machine. This patch changes that absolute path with a relative path.