### PR TITLE
Refs #3376. Fixed set of WriteParams with volatile durability.

### DIFF
--- a/include/fastrtps/rtps/common/WriteParams.h
+++ b/include/fastrtps/rtps/common/WriteParams.h
@@ -121,6 +121,8 @@ namespace eprosima
                         return related_sample_identity_;
                     }
 
+                    static WriteParams WRITE_PARAM_DEFAULT;
+
                 private:
 
                     SampleIdentity sample_identity_;

--- a/include/fastrtps/rtps/history/WriterHistory.h
+++ b/include/fastrtps/rtps/history/WriterHistory.h
@@ -27,6 +27,7 @@ namespace fastrtps{
 namespace rtps {
 
 class RTPSWriter;
+class WriteParams;
 
 /**
  * Class WriterHistory, container of the different CacheChanges of a writer
@@ -55,6 +56,9 @@ class WriterHistory : public History
      * @return True if added.
      */
     RTPS_DllAPI bool add_change(CacheChange_t* a_change);
+
+    RTPS_DllAPI bool add_change(CacheChange_t* a_change, WriteParams &wparams);
+
     /**
      * Remove a specific change from the history.
      * @param a_change Pointer to the CacheChange_t.

--- a/src/cpp/publisher/PublisherHistory.cpp
+++ b/src/cpp/publisher/PublisherHistory.cpp
@@ -90,7 +90,7 @@ bool PublisherHistory::add_pub_change(CacheChange_t* change, WriteParams &wparam
     //NO KEY HISTORY
     if(mp_pubImpl->getAttributes().topic.getTopicKind() == NO_KEY)
     {
-        if(this->add_change(change))
+        if(this->add_change(change, wparams))
         {
             returnedValue = true;
         }
@@ -131,7 +131,7 @@ bool PublisherHistory::add_pub_change(CacheChange_t* change, WriteParams &wparam
 
             if(add)
             {
-                if(this->add_change(change))
+                if(this->add_change(change, wparams))
                 {
                     logInfo(RTPS_HISTORY,this->mp_pubImpl->getGuid().entityId <<" Change "
                             << change->sequenceNumber << " added with key: "<<change->instanceHandle
@@ -141,13 +141,6 @@ bool PublisherHistory::add_pub_change(CacheChange_t* change, WriteParams &wparam
                 }
             }
         }
-    }
-
-    // Updated sample identity
-    if(returnedValue && &wparams != &WRITE_PARAM_DEFAULT)
-    {
-        wparams.sample_identity().writer_guid(change->writerGUID);
-        wparams.sample_identity().sequence_number(change->sequenceNumber);
     }
 
 

--- a/src/cpp/publisher/PublisherImpl.cpp
+++ b/src/cpp/publisher/PublisherImpl.cpp
@@ -35,10 +35,6 @@
 using namespace eprosima::fastrtps;
 using namespace ::rtps;
 
-
-
-::rtps::WriteParams WRITE_PARAM_DEFAULT;
-
 PublisherImpl::PublisherImpl(ParticipantImpl* p,TopicDataType*pdatatype,
         PublisherAttributes& att,PublisherListener* listen ):
     mp_participant(p),
@@ -77,7 +73,7 @@ PublisherImpl::~PublisherImpl()
 
 bool PublisherImpl::create_new_change(ChangeKind_t changeKind, void* data)
 {
-    return create_new_change_with_params(changeKind, data, WRITE_PARAM_DEFAULT);
+    return create_new_change_with_params(changeKind, data, WriteParams::WRITE_PARAM_DEFAULT);
 }
 
 bool PublisherImpl::create_new_change_with_params(ChangeKind_t changeKind, void* data, WriteParams &wparams)
@@ -165,11 +161,6 @@ bool PublisherImpl::create_new_change_with_params(ChangeKind_t changeKind, void*
             // Set the fragment size to the cachechange.
             // Note: high_mark will always be a value that can be casted to uint16_t)
             ch->setFragmentSize((uint16_t)final_high_mark_for_frag);
-        }
-
-        if(&wparams != &WRITE_PARAM_DEFAULT)
-        {
-            ch->write_params = wparams;
         }
 
         if(!this->m_history.add_pub_change(ch, wparams, lock))

--- a/test/blackbox/BlackboxTests.cpp
+++ b/test/blackbox/BlackboxTests.cpp
@@ -5269,6 +5269,23 @@ BLACKBOXTEST(BlackBox, AsyncVolatileKeepAllPubReliableSubNonReliableHelloWorld)
     reader.block_for_at_least(2);
 }
 
+// Regression test of Refs #3376, github ros2/rmw_fastrtps #226
+BLACKBOXTEST(BlackBox, ReqRepVolatileHelloworldRequesterCheckWriteParams)
+{
+    ReqRepAsReliableHelloWorldRequester requester;
+    ReqRepAsReliableHelloWorldReplier replier;
+
+    requester.durability_kind(eprosima::fastrtps::VOLATILE_DURABILITY_QOS).init();
+
+    ASSERT_TRUE(requester.isInitialized());
+
+    replier.init();
+
+    ASSERT_TRUE(replier.isInitialized());
+
+    requester.send(1);
+}
+
 int main(int argc, char **argv)
 {
     testing::InitGoogleTest(&argc, argv);

--- a/test/blackbox/ReqRepAsReliableHelloWorldRequester.hpp
+++ b/test/blackbox/ReqRepAsReliableHelloWorldRequester.hpp
@@ -54,6 +54,13 @@ class ReqRepAsReliableHelloWorldRequester : public ReqRepHelloWorldRequester
 
             puattr.topic.topicName = t.str();
         }
+
+        ReqRepAsReliableHelloWorldRequester& durability_kind(const eprosima::fastrtps::DurabilityQosPolicyKind kind)
+        {
+            puattr.qos.m_durability.kind = kind;
+            sattr.qos.m_durability.kind = kind;
+            return *this;
+        }
 };
 
 #endif // _TEST_BLACKBOX_REQREPASRELIABLEHELLOWORLDREQUESTER_HPP_

--- a/test/blackbox/ReqRepHelloWorldRequester.cpp
+++ b/test/blackbox/ReqRepHelloWorldRequester.cpp
@@ -153,5 +153,6 @@ void ReqRepHelloWorldRequester::send(const uint16_t number)
 
     ASSERT_EQ(request_publisher_->write((void*)&hello, wparams), true);
     related_sample_identity_ = wparams.sample_identity();
+    ASSERT_NE(related_sample_identity_.sequence_number(), SequenceNumber_t());
     current_number_ = number;
 }


### PR DESCRIPTION
After fixed in eProsima/Fast-RTPS@7b2c5b9 a incorrect behavior (removing samples) when a publisher's durability is set to volatile, the old code for getting WriteParams with this configuration (volatile durability) stops working. This PR updates this code to work properly.

This error was detected in ros2/rmw_fastrtps#226.