### PR TITLE
Fix localhost

### DIFF
--- a/src/cpp/transport/UDPv4Transport.cpp
+++ b/src/cpp/transport/UDPv4Transport.cpp
@@ -543,7 +543,7 @@ LocatorList_t UDPv4Transport::NormalizeLocator(const Locator_t& locator)
             locator.address[14] == 0x0 && locator.address[15] == 0x0)
     {
         std::vector<IPFinder::info_IP> locNames;
-        GetIP4s(locNames);
+        GetIP4s(locNames, true);
         for (const auto& infoIP : locNames)
         {
             Locator_t newloc(locator);

--- a/src/cpp/utils/IPFinder.cpp
+++ b/src/cpp/utils/IPFinder.cpp
@@ -83,7 +83,6 @@ bool IPFinder::getIPs(std::vector<info_IP>* vec_name, bool return_loopback)
 
                 if (family == AF_INET || family == AF_INET6) //IP4
                 {
-                    //printf("\t%s ",  family == AF_INET ? "IPv4":"IPv6");
                     memset(buf, 0, BUFSIZ);
                     getnameinfo(ua->Address.lpSockaddr, ua->Address.iSockaddrLength, buf, sizeof(buf), NULL, 0, NI_NUMERICHOST);
                     info_IP info;
@@ -132,7 +131,7 @@ bool IPFinder::getIPs(std::vector<info_IP>* vec_name, bool return_loopback)
 
     if (getifaddrs(&ifaddr) == -1) {
         perror("getifaddrs");
-        exit(EXIT_FAILURE);
+	return false;
     }
 
     for (ifa = ifaddr; ifa != NULL; ifa = ifa->ifa_next)
@@ -149,7 +148,7 @@ bool IPFinder::getIPs(std::vector<info_IP>* vec_name, bool return_loopback)
             if (s != 0) {
                 printf("getnameinfo() failed: %s\n", gai_strerror(s));
                 freeifaddrs(ifaddr);
-                exit(EXIT_FAILURE);
+		return false;
             }
             info_IP info;
             info.type = IP4;
@@ -167,7 +166,7 @@ bool IPFinder::getIPs(std::vector<info_IP>* vec_name, bool return_loopback)
             if (s != 0) {
                 printf("getnameinfo() failed: %s\n", gai_strerror(s));
                 freeifaddrs(ifaddr);
-                exit(EXIT_FAILURE);
+		return false;
             }
             struct sockaddr_in6 * so = (struct sockaddr_in6 *)ifa->ifa_addr;
             info_IP info;
@@ -181,7 +180,6 @@ bool IPFinder::getIPs(std::vector<info_IP>* vec_name, bool return_loopback)
                 if (return_loopback || info.type != IP6_LOCAL)
                     vec_name->push_back(info);
             }
-            //printf("<Interface>: %s \t <Address> %s\n", ifa->ifa_name, host);
         }
     }
 

--- a/src/cpp/utils/IPFinder.cpp
+++ b/src/cpp/utils/IPFinder.cpp
@@ -191,14 +191,14 @@ bool IPFinder::getIPs(std::vector<info_IP>* vec_name, bool return_loopback)
 bool IPFinder::getIP4Address(LocatorList_t* locators)
 {
     std::vector<info_IP> ip_names;
-    if(IPFinder::getIPs(&ip_names))
+    if(IPFinder::getIPs(&ip_names, true))
     {
 
         locators->clear();
         for(auto it=ip_names.begin();
                 it!=ip_names.end();++it)
         {
-            if (it->type == IP4)
+            if (it->type == IP4 || it->type == IP4_LOCAL)
             {
                 locators->push_back(it->locator);
             }

--- a/src/cpp/utils/IPFinder.cpp
+++ b/src/cpp/utils/IPFinder.cpp
@@ -131,7 +131,7 @@ bool IPFinder::getIPs(std::vector<info_IP>* vec_name, bool return_loopback)
 
     if (getifaddrs(&ifaddr) == -1) {
         perror("getifaddrs");
-	return false;
+        return false;
     }
 
     for (ifa = ifaddr; ifa != NULL; ifa = ifa->ifa_next)
@@ -148,7 +148,7 @@ bool IPFinder::getIPs(std::vector<info_IP>* vec_name, bool return_loopback)
             if (s != 0) {
                 printf("getnameinfo() failed: %s\n", gai_strerror(s));
                 freeifaddrs(ifaddr);
-		return false;
+                return false;
             }
             info_IP info;
             info.type = IP4;
@@ -166,7 +166,7 @@ bool IPFinder::getIPs(std::vector<info_IP>* vec_name, bool return_loopback)
             if (s != 0) {
                 printf("getnameinfo() failed: %s\n", gai_strerror(s));
                 freeifaddrs(ifaddr);
-		return false;
+                return false;
             }
             struct sockaddr_in6 * so = (struct sockaddr_in6 *)ifa->ifa_addr;
             info_IP info;


### PR DESCRIPTION
We were running into a situation where Fast-RTPS would not pass any data when all network interfaces were down except for localhost.  It turns out that Fast-RTPS was ignoring localhost as a valid communications interface in some circumstances.  These fixes things so that Fast-RTPS will now consider localhost
as a communications interface, allowing this to work.

I've run the basic tests against this patchset, and they seem to pass.  I also ran this patchset as part of the ROS2 CI ([linux](https://ci.ros2.org/job/ci_linux/5248), [windows](https://ci.ros2.org/job/ci_windows/5221), [osx](https://ci.ros2.org/job/ci_osx/4362)), and things seem to be happy there as well.  I don't know what other knock-on effects this might have, so thoughts/review on that would be appreciated.  Finally, I'm pretty sure there is a similar problem in UDPv6, but I'm much less familiar with IPv6 and I don't have time to debug it right now.