### PR TITLE
XMLParser for datawriter and datareader

### DIFF
--- a/include/fastrtps/attributes/ParticipantAttributes.h
+++ b/include/fastrtps/attributes/ParticipantAttributes.h
@@ -36,8 +36,14 @@ namespace fastrtps{
 class ParticipantAttributes
 {
 public:
-	ParticipantAttributes(){};
-	virtual ~ParticipantAttributes(){};
+    ParticipantAttributes() {}
+    virtual ~ParticipantAttributes() {}
+
+    bool operator==(const ParticipantAttributes& b) const
+    {
+        return (this->rtps == b.rtps);
+    }
+
 	//!Attributes of the associated RTPSParticipant.
 	rtps::RTPSParticipantAttributes rtps;
 };

--- a/include/fastrtps/attributes/PublisherAttributes.h
+++ b/include/fastrtps/attributes/PublisherAttributes.h
@@ -58,7 +58,9 @@ public:
                (this->times == b.times) &&
                (this->unicastLocatorList == b.unicastLocatorList) &&
                (this->multicastLocatorList == b.multicastLocatorList) &&
-               (this->remoteLocatorList == b.remoteLocatorList);
+               (this->remoteLocatorList == b.remoteLocatorList) &&
+               (this->historyMemoryPolicy == b.historyMemoryPolicy) &&
+               (this->properties == b.properties);
     }
 
     //!Topic Attributes for the Publisher

--- a/include/fastrtps/attributes/PublisherAttributes.h
+++ b/include/fastrtps/attributes/PublisherAttributes.h
@@ -34,68 +34,79 @@
 namespace eprosima {
 namespace fastrtps{
 
-
 /**
  * Class PublisherAttributes, used by the user to define the attributes of a Publisher.
  * @ingroup FASTRTPS_ATTRIBUTES_MODULE
  */
 class PublisherAttributes
 {
-    public:
+public:
+    PublisherAttributes() :
+        historyMemoryPolicy(rtps::PREALLOCATED_MEMORY_MODE),
+        m_userDefinedID(-1),
+        m_entityID(-1)
+    {}
 
-        PublisherAttributes()
-        {
-            m_userDefinedID = -1;
-            m_entityID = -1;
-            historyMemoryPolicy = rtps::PREALLOCATED_MEMORY_MODE;
-        }
-        virtual ~PublisherAttributes() {}
-        //!Topic Attributes for the Publisher
-        TopicAttributes topic;
-        //!QOS for the Publisher
-        WriterQos qos;
-        //!Writer Attributes
-        rtps::WriterTimes times;
-        //!Unicast locator list
-        rtps::LocatorList_t unicastLocatorList;
-        //!Multicast locator list
-        rtps::LocatorList_t multicastLocatorList;
-        //!Remote locator list
-        rtps::LocatorList_t remoteLocatorList;
-        //!Throughput controller
-        rtps::ThroughputControllerDescriptor throughputController;
-        //!Underlying History memory policy
-        rtps::MemoryManagementPolicy_t historyMemoryPolicy;
-        rtps::PropertyPolicy properties;
+    virtual ~PublisherAttributes(){}
 
-        /**
-         * Get the user defined ID
-         * @return User defined ID
-         */
-        inline int16_t getUserDefinedID() const { return m_userDefinedID; }
+    bool operator==(const PublisherAttributes& b) const
+    {
+        return (this->m_userDefinedID == b.m_userDefinedID) &&
+               (this->m_entityID == b.m_entityID) &&
+               (this->topic == b.topic) &&
+               (this->qos == b.qos) &&
+               (this->times == b.times) &&
+               (this->unicastLocatorList == b.unicastLocatorList) &&
+               (this->multicastLocatorList == b.multicastLocatorList) &&
+               (this->remoteLocatorList == b.remoteLocatorList);
+    }
 
-        /**
-         * Get the entity defined ID
-         * @return Entity ID
-         */
-        inline int16_t getEntityID() const { return m_entityID; }
+    //!Topic Attributes for the Publisher
+    TopicAttributes topic;
+    //!QOS for the Publisher
+    WriterQos qos;
+    //!Writer Attributes
+    rtps::WriterTimes times;
+    //!Unicast locator list
+    rtps::LocatorList_t unicastLocatorList;
+    //!Multicast locator list
+    rtps::LocatorList_t multicastLocatorList;
+    //!Remote locator list
+    rtps::LocatorList_t remoteLocatorList;
+    //!Throughput controller
+    rtps::ThroughputControllerDescriptor throughputController;
+    //!Underlying History memory policy
+    rtps::MemoryManagementPolicy_t historyMemoryPolicy;
+    rtps::PropertyPolicy properties;
 
-        /**
-         * Set the user defined ID
-         * @param id User defined ID to be set
-         */
-        inline void setUserDefinedID(uint8_t id) { m_userDefinedID = id; }
+    /**
+     * Get the user defined ID
+     * @return User defined ID
+     */
+    inline int16_t getUserDefinedID() const {return m_userDefinedID;}
 
-        /**
-         * Set the entity ID
-         * @param id Entity ID to be set
-         */
-        inline void setEntityID(uint8_t id) { m_entityID = id; }
-    private:
-        //!User Defined ID, used for StaticEndpointDiscovery, default value -1.
-        int16_t m_userDefinedID;
-        //!Entity ID, if the user want to specify the EntityID of the enpoint, default value -1.
-        int16_t m_entityID;
+    /**
+     * Get the entity defined ID
+     * @return Entity ID
+     */
+    inline int16_t getEntityID() const {return m_entityID;}
+
+    /**
+     * Set the user defined ID
+     * @param id User defined ID to be set
+     */
+    inline void setUserDefinedID(uint8_t id) { m_userDefinedID = id; }
+
+    /**
+     * Set the entity ID
+     * @param id Entity ID to be set
+     */
+    inline void setEntityID(uint8_t id) { m_entityID = id; }
+private:
+    //!User Defined ID, used for StaticEndpointDiscovery, default value -1.
+    int16_t m_userDefinedID;
+    //!Entity ID, if the user want to specify the EntityID of the enpoint, default value -1.
+    int16_t m_entityID;
 };
 
 }

--- a/include/fastrtps/attributes/SubscriberAttributes.h
+++ b/include/fastrtps/attributes/SubscriberAttributes.h
@@ -56,7 +56,9 @@ public:
                (this->times == b.times) &&
                (this->unicastLocatorList == b.unicastLocatorList) &&
                (this->multicastLocatorList == b.multicastLocatorList) &&
-               (this->remoteLocatorList == b.remoteLocatorList);
+               (this->remoteLocatorList == b.remoteLocatorList) &&
+               (this->historyMemoryPolicy == b.historyMemoryPolicy) &&
+               (this->properties == b.properties);
     }
 
     //!Topic Attributes

--- a/include/fastrtps/attributes/SubscriberAttributes.h
+++ b/include/fastrtps/attributes/SubscriberAttributes.h
@@ -39,61 +39,72 @@ namespace fastrtps {
  */
 class SubscriberAttributes
 {
-    public:
-        SubscriberAttributes()
-        {
-            m_userDefinedID = -1;
-            m_entityID = -1;
-            expectsInlineQos = false;
-            historyMemoryPolicy = rtps::PREALLOCATED_MEMORY_MODE;
-        };
-        virtual ~SubscriberAttributes() {};
-        //!Topic Attributes
-        TopicAttributes topic;
-        //!Reader QOs.
-        ReaderQos qos;
-        //!Times for a RELIABLE Reader
-        rtps::ReaderTimes times;
-        //!Unicast locator list
-        rtps::LocatorList_t unicastLocatorList;
-        //!Multicast locator list
-        rtps::LocatorList_t multicastLocatorList;
-        //!Remote locator list
-        rtps::LocatorList_t remoteLocatorList;
-        //!Expects Inline QOS
-        bool expectsInlineQos;
-        //!Underlying History memory policy
-        rtps::MemoryManagementPolicy_t historyMemoryPolicy;
-        rtps::PropertyPolicy properties;
+public:
+    SubscriberAttributes()
+        : expectsInlineQos(false),
+          historyMemoryPolicy(rtps::PREALLOCATED_MEMORY_MODE),
+          m_userDefinedID(-1),
+          m_entityID(-1)
+    {}
 
-        /**
-         * Get the user defined ID
-         * @return User defined ID
-         */
-        inline int16_t getUserDefinedID() const { return m_userDefinedID; }
+    virtual ~SubscriberAttributes(){}
 
-        /**
-         * Get the entity defined ID
-         * @return Entity ID
-         */
-        inline int16_t getEntityID() const { return m_entityID; }
+    bool operator==(const SubscriberAttributes& b) const
+    {
+        return (this->topic == b.topic) &&
+               (this->qos == b.qos) &&
+               (this->times == b.times) &&
+               (this->unicastLocatorList == b.unicastLocatorList) &&
+               (this->multicastLocatorList == b.multicastLocatorList) &&
+               (this->remoteLocatorList == b.remoteLocatorList);
+    }
 
-        /**
-         * Set the user defined ID
-         * @param id User defined ID to be set
-         */
-        inline void setUserDefinedID(uint8_t id) { m_userDefinedID = id; };
+    //!Topic Attributes
+    TopicAttributes topic;
+    //!Reader QOs.
+    ReaderQos qos;
+    //!Times for a RELIABLE Reader
+    rtps::ReaderTimes times;
+    //!Unicast locator list
+    rtps::LocatorList_t unicastLocatorList;
+    //!Multicast locator list
+    rtps::LocatorList_t multicastLocatorList;
+    //!Remote locator list
+    rtps::LocatorList_t remoteLocatorList;
+    //!Expects Inline QOS
+    bool expectsInlineQos;
+    //!Underlying History memory policy
+    rtps::MemoryManagementPolicy_t historyMemoryPolicy;
+    rtps::PropertyPolicy properties;
 
-        /**
-         * Set the entity ID
-         * @param id Entity ID to be set
-         */
-        inline void setEntityID(uint8_t id) { m_entityID = id; };
-    private:
-        //!User Defined ID, used for StaticEndpointDiscovery, default value -1.
-        int16_t m_userDefinedID;
-        //!Entity ID, if the user want to specify the EntityID of the enpoint, default value -1.
-        int16_t m_entityID;
+    /**
+     * Get the user defined ID
+     * @return User defined ID
+     */
+    inline int16_t getUserDefinedID() const {return m_userDefinedID;}
+
+    /**
+     * Get the entity defined ID
+     * @return Entity ID
+     */
+    inline int16_t getEntityID() const {return m_entityID;}
+
+    /**
+     * Set the user defined ID
+     * @param id User defined ID to be set
+     */
+    inline void setUserDefinedID(uint8_t id){ m_userDefinedID = id; }
+
+    /**
+     * Set the entity ID
+     * @param id Entity ID to be set
+     */
+    inline void setEntityID(uint8_t id){ m_entityID = id; }
+private:
+    //!User Defined ID, used for StaticEndpointDiscovery, default value -1.
+    int16_t m_userDefinedID;
+    //!Entity ID, if the user want to specify the EntityID of the enpoint, default value -1.
+    int16_t m_entityID;
 };
 
 } /* namespace fastrtps */

--- a/include/fastrtps/attributes/TopicAttributes.h
+++ b/include/fastrtps/attributes/TopicAttributes.h
@@ -42,19 +42,26 @@ class TopicAttributes
          * Default constructor
          */
         TopicAttributes()
-        {
-            topicKind = rtps::NO_KEY;
-            topicName = "UNDEF";
-            topicDataType = "UNDEF";
-        }
+            : topicKind(rtps::NO_KEY),
+              topicName("UNDEF"),
+              topicDataType("UNDEF")
+        {}
+
         //!Constructor, you need to provide the topic name and the topic data type.
         TopicAttributes(const char* name, const char* dataType, rtps::TopicKind_t tKind= rtps::NO_KEY)
+            : topicKind(tKind),
+              topicName(std::string(name)),
+              topicDataType(std::string(dataType))
+        {}
+
+        virtual ~TopicAttributes() {}
+
+        bool operator==(const TopicAttributes& b) const
         {
-            topicKind = tKind;
-            topicName = std::string(name);
-            topicDataType = std::string(dataType);
-        }
-        virtual ~TopicAttributes() {
+            return (this->topicKind == b.topicKind) &&
+                   (this->topicName == b.topicName) &&
+                   (this->topicDataType == b.topicDataType) &&
+                   (this->historyQos == b.historyQos);
         }
 
         /**
@@ -136,8 +143,8 @@ class TopicAttributes
 
 /**
  * Check if two topic attributes are not equal
- * @param t1 First instance of TopicAttributes to compare 
- * @param t2 Second instance of TopicAttributes to compare 
+ * @param t1 First instance of TopicAttributes to compare
+ * @param t2 Second instance of TopicAttributes to compare
  * @return True if the instances are not equal. False if the instances are equal.
  */
 bool inline operator!=(const TopicAttributes& t1, const TopicAttributes& t2)

--- a/include/fastrtps/qos/ParameterTypes.h
+++ b/include/fastrtps/qos/ParameterTypes.h
@@ -113,26 +113,37 @@ enum ParameterId_t	: uint16_t
 
 //!Base Parameter class with parameter PID and parameter length in bytes.
 //!@ingroup PARAMETER_MODULE
-class Parameter_t {
-    public:
-        //!Parameter ID
-        ParameterId_t Pid;
-        //!Parameter length
-        uint16_t length;
-        RTPS_DllAPI Parameter_t();
-        virtual RTPS_DllAPI ~Parameter_t();
-        /**
-         * Constructor using a parameter PID and the parameter length
-         * @param pid Pid of the parameter
-         * @param length Its associated length
-         */
-        RTPS_DllAPI Parameter_t(ParameterId_t pid,uint16_t length);
-        /**
-         * Virtual method used to add the parameter to a CDRMessage_t message.
-         * @param[in,out] msg Pointer to the message where the parameter should be added.
-         * @return True if the parameter was correctly added.
-         */
-        virtual bool addToCDRMessage(rtps::CDRMessage_t* msg) = 0;
+class Parameter_t
+{
+public:
+    RTPS_DllAPI Parameter_t();
+    /**
+     * Constructor using a parameter PID and the parameter length
+     * @param pid Pid of the parameter
+     * @param length Its associated length
+     */
+    RTPS_DllAPI Parameter_t(ParameterId_t pid,uint16_t length);
+
+    virtual RTPS_DllAPI ~Parameter_t();
+
+    bool operator==(const Parameter_t& b) const
+    {
+        return (this->Pid == b.Pid) &&
+               (this->length == b.length);
+    }
+
+    /**
+     * Virtual method used to add the parameter to a CDRMessage_t message.
+     * @param[in,out] msg Pointer to the message where the parameter should be added.
+     * @return True if the parameter was correctly added.
+     */
+    virtual bool addToCDRMessage(rtps::CDRMessage_t* msg) = 0;
+
+public:
+    //!Parameter ID
+    ParameterId_t Pid;
+    //!Parameter length
+    uint16_t length;
 };
 
 /**

--- a/include/fastrtps/qos/QosPolicies.h
+++ b/include/fastrtps/qos/QosPolicies.h
@@ -35,21 +35,38 @@ class EDP;
 /**
  * Class QosPolicy, base for all QoS policies defined for Writers and Readers.
  */
-class QosPolicy{
-    public:
-        QosPolicy():hasChanged(false),m_sendAlways(false){};
-        QosPolicy(bool b_sendAlways):hasChanged(false),m_sendAlways(b_sendAlways){};
-        virtual ~ QosPolicy(){};
-        bool hasChanged;
-        /**
-         * Whether it should always be sent.
-         * @return True if it should always be sent.
-         */
-        virtual bool sendAlways() const {return m_sendAlways;}
-    protected:
-        bool m_sendAlways;
+class QosPolicy
+{
+public:
+    QosPolicy()
+        : hasChanged(false),
+          m_sendAlways(false)
+    {}
+    QosPolicy(bool b_sendAlways)
+        : hasChanged(false),
+          m_sendAlways(b_sendAlways)
+    {}
+    virtual ~ QosPolicy(){}
 
+    bool operator==(const QosPolicy& b) const
+    {
+        return (this->hasChanged == b.hasChanged) &&
+               (this->m_sendAlways == b.m_sendAlways);
+    }
+
+    /**
+     * Whether it should always be sent.
+     * @return True if it should always be sent.
+     */
+    virtual bool sendAlways() const {return m_sendAlways;}
+
+public:
+    bool hasChanged;
+
+protected:
+    bool m_sendAlways;
 };
+
 /**
  * Enum DurabilityQosPolicyKind_t, different kinds of durability for DurabilityQosPolicy.
  */
@@ -68,48 +85,61 @@ typedef enum DurabilityQosPolicyKind: rtps::octet{
  */
 class DurabilityQosPolicy : private Parameter_t, public QosPolicy
 {
-    public:
-        RTPS_DllAPI DurabilityQosPolicy():Parameter_t(PID_DURABILITY,PARAMETER_KIND_LENGTH),QosPolicy(true),kind(VOLATILE_DURABILITY_QOS){};
-        virtual RTPS_DllAPI ~DurabilityQosPolicy(){};
-        DurabilityQosPolicyKind_t kind;
+public:
+    RTPS_DllAPI DurabilityQosPolicy()
+        : Parameter_t(PID_DURABILITY, PARAMETER_KIND_LENGTH),
+          QosPolicy(true),
+          kind(VOLATILE_DURABILITY_QOS) {}
 
-        /** 
-         * Translates kind to rtps layer equivalent
-         */
-        inline rtps::DurabilityKind_t durabilityKind() const
-        {
-            switch (kind)
-            {
-                default:
-                case VOLATILE_DURABILITY_QOS: return rtps::VOLATILE;
-                case TRANSIENT_LOCAL_DURABILITY_QOS: return rtps::TRANSIENT_LOCAL;
-                case TRANSIENT_DURABILITY_QOS: return rtps::TRANSIENT;
-                case PERSISTENT_DURABILITY_QOS: return rtps::PERSISTENT;
-            }
-        }
+    virtual RTPS_DllAPI ~DurabilityQosPolicy() {}
 
-        /**
-        * Set kind from rtps layer equivalent
-        */
-        inline void durabilityKind(const rtps::DurabilityKind_t new_kind)
+    bool operator==(const DurabilityQosPolicy& b) const
+    {
+        return (this->kind == b.kind) &&
+               Parameter_t::operator==(b) &&
+               QosPolicy::operator==(b);
+    }
+
+    /**
+     * Translates kind to rtps layer equivalent
+     */
+    inline rtps::DurabilityKind_t durabilityKind() const
+    {
+        switch (kind)
         {
-            switch (new_kind)
-            {
             default:
-            case rtps::VOLATILE: kind = VOLATILE_DURABILITY_QOS; break;
-            case rtps::TRANSIENT_LOCAL: kind = TRANSIENT_LOCAL_DURABILITY_QOS; break;
-            case rtps::TRANSIENT: kind = TRANSIENT_DURABILITY_QOS; break;
-            case rtps::PERSISTENT: kind = PERSISTENT_DURABILITY_QOS; break;
-            }
+            case VOLATILE_DURABILITY_QOS: return rtps::VOLATILE;
+            case TRANSIENT_LOCAL_DURABILITY_QOS: return rtps::TRANSIENT_LOCAL;
+            case TRANSIENT_DURABILITY_QOS: return rtps::TRANSIENT;
+            case PERSISTENT_DURABILITY_QOS: return rtps::PERSISTENT;
+        }
+    }
 
+    /**
+    * Set kind from rtps layer equivalent
+    */
+    inline void durabilityKind(const rtps::DurabilityKind_t new_kind)
+    {
+        switch (new_kind)
+        {
+        default:
+        case rtps::VOLATILE: kind = VOLATILE_DURABILITY_QOS; break;
+        case rtps::TRANSIENT_LOCAL: kind = TRANSIENT_LOCAL_DURABILITY_QOS; break;
+        case rtps::TRANSIENT: kind = TRANSIENT_DURABILITY_QOS; break;
+        case rtps::PERSISTENT: kind = PERSISTENT_DURABILITY_QOS; break;
         }
 
-        /**
-         * Appends QoS to the specified CDR message.
-         * @param msg Message to append the QoS Policy to.
-         * @return True if the modified CDRMessage is valid.
-         */
-        bool addToCDRMessage(rtps::CDRMessage_t* msg) override;
+    }
+
+    /**
+     * Appends QoS to the specified CDR message.
+     * @param msg Message to append the QoS Policy to.
+     * @return True if the modified CDRMessage is valid.
+     */
+    bool addToCDRMessage(rtps::CDRMessage_t* msg) override;
+
+public:
+    DurabilityQosPolicyKind_t kind;
 };
 
 /**
@@ -117,17 +147,33 @@ class DurabilityQosPolicy : private Parameter_t, public QosPolicy
  * This QosPolicy can be defined and is transmitted to the rest of the network but is not implemented in this version.
  * period: Default value c_TimeInifinite.
  */
-class DeadlineQosPolicy : private Parameter_t, public QosPolicy {
-    public:
-        RTPS_DllAPI DeadlineQosPolicy():Parameter_t(PID_DEADLINE,PARAMETER_TIME_LENGTH),QosPolicy(true),period(rtps::c_TimeInfinite){	};
-        virtual RTPS_DllAPI ~DeadlineQosPolicy(){};
-        rtps::Duration_t period;
-        /**
-         * Appends QoS to the specified CDR message.
-         * @param msg Message to append the QoS Policy to.
-         * @return True if the modified CDRMessage is valid.
-         */
-        bool addToCDRMessage(rtps::CDRMessage_t* msg) override;
+class DeadlineQosPolicy : private Parameter_t, public QosPolicy
+{
+public:
+    RTPS_DllAPI DeadlineQosPolicy()
+        : Parameter_t(PID_DEADLINE, PARAMETER_TIME_LENGTH),
+          QosPolicy(true),
+          period(rtps::c_TimeInfinite)
+    {}
+
+    virtual RTPS_DllAPI ~DeadlineQosPolicy(){}
+
+    bool operator==(const DeadlineQosPolicy& b) const
+    {
+        return (this->period == b.period) &&
+               Parameter_t::operator==(b) &&
+               QosPolicy::operator==(b);
+    }
+
+    /**
+     * Appends QoS to the specified CDR message.
+     * @param msg Message to append the QoS Policy to.
+     * @return True if the modified CDRMessage is valid.
+     */
+    bool addToCDRMessage(rtps::CDRMessage_t* msg) override;
+
+public:
+    rtps::Duration_t period;
 };
 
 /**
@@ -136,16 +182,30 @@ class DeadlineQosPolicy : private Parameter_t, public QosPolicy {
  * period: Default value c_TimeZero.
  */
 class LatencyBudgetQosPolicy : private Parameter_t, public QosPolicy {
-    public:
-        RTPS_DllAPI LatencyBudgetQosPolicy():Parameter_t(PID_LATENCY_BUDGET,PARAMETER_TIME_LENGTH),QosPolicy(true),duration(rtps::c_TimeZero){};
-        virtual RTPS_DllAPI ~LatencyBudgetQosPolicy(){};
-        rtps::Duration_t duration;
-        /**
-         * Appends QoS to the specified CDR message.
-         * @param msg Message to append the QoS Policy to.
-         * @return True if the modified CDRMessage is valid.
-         */
-        bool addToCDRMessage(rtps::CDRMessage_t* msg) override;
+public:
+    RTPS_DllAPI LatencyBudgetQosPolicy()
+        : Parameter_t(PID_LATENCY_BUDGET,PARAMETER_TIME_LENGTH),
+          QosPolicy(true),
+          duration(rtps::c_TimeZero)
+    {}
+    virtual RTPS_DllAPI ~LatencyBudgetQosPolicy() {}
+
+    bool operator==(const LatencyBudgetQosPolicy& b) const
+    {
+        return (this->duration == b.duration) &&
+               Parameter_t::operator==(b) &&
+               QosPolicy::operator==(b);
+    }
+
+    /**
+     * Appends QoS to the specified CDR message.
+     * @param msg Message to append the QoS Policy to.
+     * @return True if the modified CDRMessage is valid.
+     */
+    bool addToCDRMessage(rtps::CDRMessage_t* msg) override;
+
+public:
+    rtps::Duration_t duration;
 };
 
 /**
@@ -167,20 +227,39 @@ typedef enum LivelinessQosPolicyKind:rtps::octet {
  * lease_duration: Default value c_TimeInfinite.
  * announcement_period: Default value c_TimeInfinite (must be < lease_duration).
  */
-class LivelinessQosPolicy : private Parameter_t, public QosPolicy {
-    public:
-        RTPS_DllAPI LivelinessQosPolicy():Parameter_t(PID_LIVELINESS,PARAMETER_KIND_LENGTH+PARAMETER_TIME_LENGTH),QosPolicy(true),
-        kind(AUTOMATIC_LIVELINESS_QOS){lease_duration = rtps::c_TimeInfinite; announcement_period = rtps::c_TimeInfinite;};
-        virtual RTPS_DllAPI ~LivelinessQosPolicy(){};
-        LivelinessQosPolicyKind kind;
-        rtps::Duration_t lease_duration;
-        rtps::Duration_t announcement_period;
-        /**
-         * Appends QoS to the specified CDR message.
-         * @param msg Message to append the QoS Policy to.
-         * @return True if the modified CDRMessage is valid.
-         */
-        bool addToCDRMessage(rtps::CDRMessage_t* msg) override;
+class LivelinessQosPolicy : private Parameter_t, public QosPolicy
+{
+public:
+    RTPS_DllAPI LivelinessQosPolicy()
+        : Parameter_t(PID_LIVELINESS,PARAMETER_KIND_LENGTH+PARAMETER_TIME_LENGTH),
+          QosPolicy(true),
+          kind(AUTOMATIC_LIVELINESS_QOS),
+          lease_duration(rtps::c_TimeInfinite),
+          announcement_period(rtps::c_TimeInfinite)
+    {}
+
+    virtual RTPS_DllAPI ~LivelinessQosPolicy() {}
+
+    bool operator==(const LivelinessQosPolicy& b) const
+    {
+        return (this->kind == b.kind) &&
+               (this->lease_duration == b.lease_duration) &&
+               (this->announcement_period == b.announcement_period) &&
+               Parameter_t::operator==(b) &&
+               QosPolicy::operator==(b);
+    }
+
+    /**
+     * Appends QoS to the specified CDR message.
+     * @param msg Message to append the QoS Policy to.
+     * @return True if the modified CDRMessage is valid.
+     */
+    bool addToCDRMessage(rtps::CDRMessage_t* msg) override;
+
+public:
+    LivelinessQosPolicyKind kind;
+    rtps::Duration_t lease_duration;
+    rtps::Duration_t announcement_period;
 };
 
 /**
@@ -198,21 +277,35 @@ typedef enum ReliabilityQosPolicyKind:rtps::octet {
  */
 class ReliabilityQosPolicy : private Parameter_t, public QosPolicy
 {
-    public:
-        RTPS_DllAPI ReliabilityQosPolicy() : Parameter_t(PID_RELIABILITY,PARAMETER_KIND_LENGTH+PARAMETER_TIME_LENGTH),
-        QosPolicy(true), //indicate send always
-        kind(BEST_EFFORT_RELIABILITY_QOS),
-        // max_blocking_time = 100ms
-        max_blocking_time{0, 4294967100}  {}
-        virtual RTPS_DllAPI ~ReliabilityQosPolicy(){}
-        ReliabilityQosPolicyKind kind;
-        rtps::Duration_t max_blocking_time;
-        /**
-         * Appends QoS to the specified CDR message.
-         * @param msg Message to append the QoS Policy to.
-         * @return True if the modified CDRMessage is valid.
-         */
-        bool addToCDRMessage(rtps::CDRMessage_t* msg) override;
+public:
+    RTPS_DllAPI ReliabilityQosPolicy()
+        : Parameter_t(PID_RELIABILITY,PARAMETER_KIND_LENGTH+PARAMETER_TIME_LENGTH),
+          QosPolicy(true), //indicate send always
+          kind(BEST_EFFORT_RELIABILITY_QOS),
+          // max_blocking_time = 100ms
+          max_blocking_time{0, 4294967100}
+    {}
+
+    virtual RTPS_DllAPI ~ReliabilityQosPolicy() {}
+
+    bool operator==(const ReliabilityQosPolicy& b) const
+    {
+        return (this->kind == b.kind) &&
+               (this->max_blocking_time == b.max_blocking_time) &&
+               Parameter_t::operator==(b) &&
+               QosPolicy::operator==(b);
+    }
+
+    /**
+     * Appends QoS to the specified CDR message.
+     * @param msg Message to append the QoS Policy to.
+     * @return True if the modified CDRMessage is valid.
+     */
+    bool addToCDRMessage(rtps::CDRMessage_t* msg) override;
+
+public:
+    ReliabilityQosPolicyKind kind;
+    rtps::Duration_t max_blocking_time;
 };
 
 
@@ -229,18 +322,33 @@ enum OwnershipQosPolicyKind:rtps::octet {
  * Class OwnershipQosPolicy, to indicate the ownership kind of the endpoints.
  * kind: Default value SHARED_OWNERSHIP_QOS.
  */
-class OwnershipQosPolicy : private Parameter_t, public QosPolicy {
-    public:
-        RTPS_DllAPI OwnershipQosPolicy():Parameter_t(PID_OWNERSHIP,PARAMETER_KIND_LENGTH),QosPolicy(true),
-        kind(SHARED_OWNERSHIP_QOS){};
-        virtual RTPS_DllAPI ~OwnershipQosPolicy(){};
-        OwnershipQosPolicyKind kind;
-        /**
-         * Appends QoS to the specified CDR message.
-         * @param msg Message to append the QoS Policy to.
-         * @return True if the modified CDRMessage is valid.
-         */
-        bool addToCDRMessage(rtps::CDRMessage_t* msg) override;
+class OwnershipQosPolicy : private Parameter_t, public QosPolicy
+{
+public:
+    RTPS_DllAPI OwnershipQosPolicy()
+        : Parameter_t(PID_OWNERSHIP,PARAMETER_KIND_LENGTH),
+          QosPolicy(true),
+          kind(SHARED_OWNERSHIP_QOS)
+    {}
+
+    virtual RTPS_DllAPI ~OwnershipQosPolicy() {}
+
+    bool operator==(const OwnershipQosPolicy& b) const
+    {
+        return (this->kind == b.kind) &&
+               Parameter_t::operator==(b) &&
+               QosPolicy::operator==(b);
+    }
+
+    /**
+     * Appends QoS to the specified CDR message.
+     * @param msg Message to append the QoS Policy to.
+     * @return True if the modified CDRMessage is valid.
+     */
+    bool addToCDRMessage(rtps::CDRMessage_t* msg) override;
+
+public:
+    OwnershipQosPolicyKind kind;
 };
 
 /**
@@ -258,29 +366,57 @@ enum DestinationOrderQosPolicyKind :rtps::octet{
  * This QosPolicy can be defined and is transmitted to the rest of the network but is not implemented in this version.
  * kind: Default value BY_RECEPTION_TIMESTAMP_DESTINATIONORDER_QOS
  */
-class DestinationOrderQosPolicy : private Parameter_t, public QosPolicy {
-    public:
-        DestinationOrderQosPolicyKind kind;
-        RTPS_DllAPI DestinationOrderQosPolicy():Parameter_t(PID_DESTINATION_ORDER,PARAMETER_KIND_LENGTH),QosPolicy(true),
-        kind(BY_RECEPTION_TIMESTAMP_DESTINATIONORDER_QOS){};
-        virtual RTPS_DllAPI ~DestinationOrderQosPolicy(){};
-        /**
-         * Appends QoS to the specified CDR message.
-         * @param msg Message to append the QoS Policy to.
-         * @return True if the modified CDRMessage is valid.
-         */
-        bool addToCDRMessage(rtps::CDRMessage_t* msg) override;
+class DestinationOrderQosPolicy : private Parameter_t, public QosPolicy
+{
+public:
+    RTPS_DllAPI DestinationOrderQosPolicy()
+        : Parameter_t(PID_DESTINATION_ORDER,PARAMETER_KIND_LENGTH),
+          QosPolicy(true),
+          kind(BY_RECEPTION_TIMESTAMP_DESTINATIONORDER_QOS)
+    {}
+
+    virtual RTPS_DllAPI ~DestinationOrderQosPolicy() {}
+
+    bool operator==(const DestinationOrderQosPolicy& b) const
+    {
+        return (this->kind == b.kind) &&
+               Parameter_t::operator==(b) &&
+               QosPolicy::operator==(b);
+    }
+
+    /**
+     * Appends QoS to the specified CDR message.
+     * @param msg Message to append the QoS Policy to.
+     * @return True if the modified CDRMessage is valid.
+     */
+    bool addToCDRMessage(rtps::CDRMessage_t* msg) override;
+
+public:
+    DestinationOrderQosPolicyKind kind;
 };
 
 
 /**
  * Class UserDataQosPolicy, to transmit user data during the discovery phase.
  */
-class UserDataQosPolicy : private Parameter_t, public QosPolicy{
+class UserDataQosPolicy : private Parameter_t, public QosPolicy
+{
     friend class ParameterList;
-    public:
-    RTPS_DllAPI UserDataQosPolicy() :Parameter_t(PID_USER_DATA, 0), QosPolicy(false){};
-    virtual RTPS_DllAPI ~UserDataQosPolicy(){};
+public:
+    RTPS_DllAPI UserDataQosPolicy() :
+        Parameter_t(PID_USER_DATA, 0),
+        QosPolicy(false),
+        dataVec{}
+    {}
+
+    virtual RTPS_DllAPI ~UserDataQosPolicy() {}
+
+    bool operator==(const UserDataQosPolicy& b) const
+    {
+        return (this->dataVec == b.dataVec) &&
+               Parameter_t::operator==(b) &&
+               QosPolicy::operator==(b);
+    }
 
     /**
      * Appends QoS to the specified CDR message.
@@ -293,15 +429,14 @@ class UserDataQosPolicy : private Parameter_t, public QosPolicy{
      * Returns raw data vector.
      * @return raw data as vector of octets.
      * */
-    RTPS_DllAPI inline std::vector<rtps::octet> getDataVec() const { return dataVec; };
+    RTPS_DllAPI inline std::vector<rtps::octet> getDataVec() const { return dataVec; }
     /**
      * Sets raw data vector.
      * @param vec raw data to set.
      * */
-    RTPS_DllAPI inline void setDataVec(const std::vector<rtps::octet>& vec){ dataVec = vec; };
+    RTPS_DllAPI inline void setDataVec(const std::vector<rtps::octet>& vec){ dataVec = vec; }
 
-    private:
-
+private:
     std::vector<rtps::octet> dataVec;
 };
 
@@ -310,18 +445,34 @@ class UserDataQosPolicy : private Parameter_t, public QosPolicy{
  * This QosPolicy can be defined and is transmitted to the rest of the network but is not implemented in this version.
  * minimum_separation: Default value c_TimeZero
  */
-class TimeBasedFilterQosPolicy : private Parameter_t, public QosPolicy {
-    public:
+class TimeBasedFilterQosPolicy : private Parameter_t, public QosPolicy
+{
+public:
 
-        RTPS_DllAPI TimeBasedFilterQosPolicy():Parameter_t(PID_TIME_BASED_FILTER,PARAMETER_TIME_LENGTH),QosPolicy(false),minimum_separation(rtps::c_TimeZero){};
-        virtual RTPS_DllAPI ~TimeBasedFilterQosPolicy(){};
-        rtps::Duration_t minimum_separation;
-        /**
-         * Appends QoS to the specified CDR message.
-         * @param msg Message to append the QoS Policy to.
-         * @return True if the modified CDRMessage is valid.
-         */
-        bool addToCDRMessage(rtps::CDRMessage_t* msg) override;
+    RTPS_DllAPI TimeBasedFilterQosPolicy()
+        : Parameter_t(PID_TIME_BASED_FILTER,PARAMETER_TIME_LENGTH),
+          QosPolicy(false),
+          minimum_separation(rtps::c_TimeZero)
+    {}
+
+    virtual RTPS_DllAPI ~TimeBasedFilterQosPolicy() {}
+
+    bool operator==(const TimeBasedFilterQosPolicy& b) const
+    {
+        return (this->minimum_separation == b.minimum_separation) &&
+               Parameter_t::operator==(b) &&
+               QosPolicy::operator==(b);
+    }
+
+    /**
+     * Appends QoS to the specified CDR message.
+     * @param msg Message to append the QoS Policy to.
+     * @return True if the modified CDRMessage is valid.
+     */
+    bool addToCDRMessage(rtps::CDRMessage_t* msg) override;
+
+public:
+    rtps::Duration_t minimum_separation;
 };
 
 /**
@@ -345,20 +496,37 @@ enum PresentationQosPolicyAccessScopeKind:rtps::octet
  */
 class PresentationQosPolicy : private Parameter_t, public QosPolicy
 {
-    public:
-        PresentationQosPolicyAccessScopeKind access_scope;
-        bool coherent_access;
-        bool ordered_access;
-        RTPS_DllAPI PresentationQosPolicy():Parameter_t(PID_PRESENTATION,PARAMETER_PRESENTATION_LENGTH),QosPolicy(false),
-        access_scope(INSTANCE_PRESENTATION_QOS),
-        coherent_access(false),ordered_access(false){};
-        virtual RTPS_DllAPI ~PresentationQosPolicy(){};
-        /**
-         * Appends QoS to the specified CDR message.
-         * @param msg Message to append the QoS Policy to.
-         * @return True if the modified CDRMessage is valid.
-         */
-        bool addToCDRMessage(rtps::CDRMessage_t* msg) override;
+public:
+    RTPS_DllAPI PresentationQosPolicy()
+        : Parameter_t(PID_PRESENTATION,PARAMETER_PRESENTATION_LENGTH),
+          QosPolicy(false),
+          access_scope(INSTANCE_PRESENTATION_QOS),
+          coherent_access(false),
+          ordered_access(false)
+    {}
+
+    virtual RTPS_DllAPI ~PresentationQosPolicy() {}
+
+    bool operator==(const PresentationQosPolicy& b) const
+    {
+        return (this->access_scope == b.access_scope) &&
+               (this->coherent_access == b.coherent_access) &&
+               (this->ordered_access == b.ordered_access) &&
+               Parameter_t::operator==(b) &&
+               QosPolicy::operator==(b);
+    }
+
+    /**
+     * Appends QoS to the specified CDR message.
+     * @param msg Message to append the QoS Policy to.
+     * @return True if the modified CDRMessage is valid.
+     */
+    bool addToCDRMessage(rtps::CDRMessage_t* msg) override;
+
+public:
+    PresentationQosPolicyAccessScopeKind access_scope;
+    bool coherent_access;
+    bool ordered_access;
 };
 
 
@@ -369,9 +537,22 @@ class  PartitionQosPolicy : private Parameter_t, public QosPolicy
 {
     friend class ParameterList;
     friend class rtps::EDP;
-    public:
-    RTPS_DllAPI PartitionQosPolicy() :Parameter_t(PID_PARTITION, 0), QosPolicy(false){};
-    virtual RTPS_DllAPI ~PartitionQosPolicy(){};
+public:
+    RTPS_DllAPI PartitionQosPolicy()
+        : Parameter_t(PID_PARTITION, 0),
+          QosPolicy(false),
+          names{}
+    {}
+
+    virtual RTPS_DllAPI ~PartitionQosPolicy(){}
+
+    bool operator==(const PartitionQosPolicy& b) const
+    {
+        return (this->names == b.names) &&
+               Parameter_t::operator==(b) &&
+               QosPolicy::operator==(b);
+    }
+
     /**
      * Appends QoS to the specified CDR message.
      * @param msg Message to append the QoS Policy to.
@@ -383,24 +564,23 @@ class  PartitionQosPolicy : private Parameter_t, public QosPolicy
      * Appends a name to the list of partition names.
      * @param name Name to append.
      */
-    RTPS_DllAPI inline void push_back(const char* name){ names.push_back(std::string(name)); hasChanged=true; };
+    RTPS_DllAPI inline void push_back(const char* name){ names.push_back(std::string(name)); hasChanged=true; }
     /**
      * Clears list of partition names
      */
-    RTPS_DllAPI inline void clear(){ names.clear(); };
+    RTPS_DllAPI inline void clear(){ names.clear(); }
     /**
      * Returns partition names.
      * @return Vector of partition name strings.
      */
-    RTPS_DllAPI inline std::vector<std::string> getNames() const { return names; };
+    RTPS_DllAPI inline std::vector<std::string> getNames() const { return names; }
     /**
      * Overrides partition names
      * @param nam Vector of partition name strings.
      */
-    RTPS_DllAPI inline void setNames(std::vector<std::string>& nam){ names = nam; hasChanged=true; };
+    RTPS_DllAPI inline void setNames(std::vector<std::string>& nam){ names = nam; hasChanged=true; }
 
-    private:
-
+private:
     std::vector<std::string> names;
 };
 
@@ -411,9 +591,21 @@ class  PartitionQosPolicy : private Parameter_t, public QosPolicy
 class  TopicDataQosPolicy : private Parameter_t, public QosPolicy
 {
     friend class ParameterList;
-    public:
-    RTPS_DllAPI TopicDataQosPolicy() :Parameter_t(PID_TOPIC_DATA, 0), QosPolicy(false){};
-    virtual RTPS_DllAPI ~TopicDataQosPolicy(){};
+public:
+    RTPS_DllAPI TopicDataQosPolicy()
+        : Parameter_t(PID_TOPIC_DATA, 0),
+          QosPolicy(false)
+    {}
+
+    virtual RTPS_DllAPI ~TopicDataQosPolicy() {}
+
+    bool operator==(const TopicDataQosPolicy& b) const
+    {
+        return (this->value == b.value) &&
+               Parameter_t::operator==(b) &&
+               QosPolicy::operator==(b);
+    }
+
     /**
      * Appends QoS to the specified CDR message.
      * @param msg Message to append the QoS Policy to.
@@ -425,24 +617,23 @@ class  TopicDataQosPolicy : private Parameter_t, public QosPolicy
      * Appends topic data.
      * @param oc Data octet.
      */
-    RTPS_DllAPI inline void push_back(rtps::octet oc){ value.push_back(oc); };
+    RTPS_DllAPI inline void push_back(rtps::octet oc) { value.push_back(oc); }
     /**
      * Clears all topic data.
      */
-    RTPS_DllAPI inline void clear(){ value.clear(); };
+    RTPS_DllAPI inline void clear(){ value.clear(); }
     /**
      * Overrides topic data vector.
      * @param ocv Topic data octet vector.
      */
-    RTPS_DllAPI inline void setValue(std::vector<rtps::octet> ocv){ value = ocv; };
+    RTPS_DllAPI inline void setValue(std::vector<rtps::octet> ocv) { value = ocv; }
     /**
      * Returns topic data
      * @return Vector of data octets.
      */
-    RTPS_DllAPI inline std::vector<rtps::octet> getValue() const { return value; };
+    RTPS_DllAPI inline std::vector<rtps::octet> getValue() const { return value; }
 
-    private:
-
+private:
     std::vector<rtps::octet> value;
 };
 
@@ -452,9 +643,22 @@ class  TopicDataQosPolicy : private Parameter_t, public QosPolicy
 class  GroupDataQosPolicy : private Parameter_t, public QosPolicy
 {
     friend class ParameterList;
-    public:
-    RTPS_DllAPI GroupDataQosPolicy() :Parameter_t(PID_GROUP_DATA, 0), QosPolicy(false){}
-    virtual RTPS_DllAPI ~GroupDataQosPolicy(){};
+public:
+    RTPS_DllAPI GroupDataQosPolicy()
+        : Parameter_t(PID_GROUP_DATA, 0),
+          QosPolicy(false),
+          value{}
+    {}
+
+    virtual RTPS_DllAPI ~GroupDataQosPolicy() {}
+
+    bool operator==(const GroupDataQosPolicy& b) const
+    {
+        return (this->value == b.value) &&
+               Parameter_t::operator==(b) &&
+               QosPolicy::operator==(b);
+    }
+
     /**
      * Appends QoS to the specified CDR message.
      * @param msg Message to append the QoS Policy to.
@@ -466,24 +670,23 @@ class  GroupDataQosPolicy : private Parameter_t, public QosPolicy
      * Appends group data.
      * @param oc Data octet.
      */
-    RTPS_DllAPI inline void push_back(rtps::octet oc){ value.push_back(oc); };
+    RTPS_DllAPI inline void push_back(rtps::octet oc) { value.push_back(oc); }
     /**
      * Clears all group data.
      */
-    RTPS_DllAPI inline void clear(){ value.clear(); };
+    RTPS_DllAPI inline void clear() { value.clear(); }
     /**
      * Overrides group data vector.
      * @param ocv Group data octet vector.
      */
-    RTPS_DllAPI inline void setValue(std::vector<rtps::octet> ocv){ value = ocv; };
+    RTPS_DllAPI inline void setValue(std::vector<rtps::octet> ocv){ value = ocv; }
     /**
      * Returns group data
      * @return Vector of data octets.
      */
-    RTPS_DllAPI inline std::vector<rtps::octet> getValue() const { return value; };
+    RTPS_DllAPI inline std::vector<rtps::octet> getValue() const { return value; }
 
-    private:
-
+private:
     std::vector<rtps::octet> value;
 };
 
@@ -500,19 +703,36 @@ enum HistoryQosPolicyKind:rtps::octet {
  * kind: Default value KEEP_LAST_HISTORY_QOS.
  * depth: Default value 1000.
  */
-class HistoryQosPolicy : private Parameter_t, public QosPolicy {
-    public:
-        HistoryQosPolicyKind kind;
-        int32_t depth;
-        RTPS_DllAPI HistoryQosPolicy():Parameter_t(PID_HISTORY,PARAMETER_KIND_LENGTH+4),QosPolicy(true),
-        kind(KEEP_LAST_HISTORY_QOS),depth(1){};
-        virtual RTPS_DllAPI ~HistoryQosPolicy(){};
-        /**
-         * Appends QoS to the specified CDR message.
-         * @param msg Message to append the QoS Policy to.
-         * @return True if the modified CDRMessage is valid.
-         */
-        bool addToCDRMessage(rtps::CDRMessage_t* msg) override;
+class HistoryQosPolicy : private Parameter_t, public QosPolicy
+{
+public:
+    RTPS_DllAPI HistoryQosPolicy()
+        : Parameter_t(PID_HISTORY,PARAMETER_KIND_LENGTH+4),
+          QosPolicy(true),
+          kind(KEEP_LAST_HISTORY_QOS),
+          depth(1)
+    {}
+
+    virtual RTPS_DllAPI ~HistoryQosPolicy() {}
+
+    bool operator==(const HistoryQosPolicy& b) const
+    {
+        return (this->kind == b.kind) &&
+               (this->depth == b.depth) &&
+               Parameter_t::operator==(b) &&
+               QosPolicy::operator==(b);
+    }
+
+    /**
+     * Appends QoS to the specified CDR message.
+     * @param msg Message to append the QoS Policy to.
+     * @return True if the modified CDRMessage is valid.
+     */
+    bool addToCDRMessage(rtps::CDRMessage_t* msg) override;
+
+public:
+    HistoryQosPolicyKind kind;
+    int32_t depth;
 };
 
 /**
@@ -551,24 +771,46 @@ class ResourceLimitsQosPolicy : private Parameter_t, public QosPolicy {
  * max_instances: Default value -1.
  * max_samples_per_instance: Default value -1.
  */
-class DurabilityServiceQosPolicy : private Parameter_t, public QosPolicy {
-    public:
-        rtps::Duration_t service_cleanup_delay;
-        HistoryQosPolicyKind history_kind;
-        int32_t history_depth;
-        int32_t max_samples;
-        int32_t max_instances;
-        int32_t max_samples_per_instance;
-        RTPS_DllAPI DurabilityServiceQosPolicy():Parameter_t(PID_DURABILITY_SERVICE,PARAMETER_TIME_LENGTH+PARAMETER_KIND_LENGTH+4+4+4+4),QosPolicy(false),
-        history_kind(KEEP_LAST_HISTORY_QOS),
-        history_depth(1),max_samples(-1),max_instances(-1),max_samples_per_instance(-1){};
-        virtual RTPS_DllAPI ~DurabilityServiceQosPolicy(){};
-        /**
-         * Appends QoS to the specified CDR message.
-         * @param msg Message to append the QoS Policy to.
-         * @return True if the modified CDRMessage is valid.
-         */
-        bool addToCDRMessage(rtps::CDRMessage_t* msg) override;
+class DurabilityServiceQosPolicy : private Parameter_t, public QosPolicy
+{
+public:
+    RTPS_DllAPI DurabilityServiceQosPolicy()
+        : Parameter_t(PID_DURABILITY_SERVICE,PARAMETER_TIME_LENGTH+PARAMETER_KIND_LENGTH+4+4+4+4),
+          QosPolicy(false),
+          history_kind(KEEP_LAST_HISTORY_QOS),
+          history_depth(1),
+          max_samples(-1),
+          max_instances(-1),
+          max_samples_per_instance(-1)
+    {}
+
+    virtual RTPS_DllAPI ~DurabilityServiceQosPolicy(){}
+
+    bool operator==(const DurabilityServiceQosPolicy& b) const
+    {
+        return (this->history_kind == b.history_kind) &&
+               (this->history_depth == b.history_depth) &&
+               (this->max_samples == b.max_samples) &&
+               (this->max_instances == b.max_instances) &&
+               (this->max_samples_per_instance == b.max_samples_per_instance) &&
+               Parameter_t::operator==(b) &&
+               QosPolicy::operator==(b);
+    }
+
+    /**
+     * Appends QoS to the specified CDR message.
+     * @param msg Message to append the QoS Policy to.
+     * @return True if the modified CDRMessage is valid.
+     */
+    bool addToCDRMessage(rtps::CDRMessage_t* msg) override;
+
+public:
+    rtps::Duration_t service_cleanup_delay;
+    HistoryQosPolicyKind history_kind;
+    int32_t history_depth;
+    int32_t max_samples;
+    int32_t max_instances;
+    int32_t max_samples_per_instance;
 };
 
 /**
@@ -576,17 +818,33 @@ class DurabilityServiceQosPolicy : private Parameter_t, public QosPolicy {
  * This QosPolicy can be defined and is transmitted to the rest of the network but is not implemented in this version.
  * duration: Default value c_TimeInfinite.
  */
-class LifespanQosPolicy : private Parameter_t, public QosPolicy {
-    public:
-        RTPS_DllAPI LifespanQosPolicy():Parameter_t(PID_LIFESPAN,PARAMETER_TIME_LENGTH),QosPolicy(true),duration(rtps::c_TimeInfinite){};
-        virtual RTPS_DllAPI ~LifespanQosPolicy(){};
-        rtps::Duration_t duration;
-        /**
-         * Appends QoS to the specified CDR message.
-         * @param msg Message to append the QoS Policy to.
-         * @return True if the modified CDRMessage is valid.
-         */
-        bool addToCDRMessage(rtps::CDRMessage_t* msg) override;
+class LifespanQosPolicy : private Parameter_t, public QosPolicy
+{
+public:
+    RTPS_DllAPI LifespanQosPolicy()
+        : Parameter_t(PID_LIFESPAN,PARAMETER_TIME_LENGTH),
+          QosPolicy(true),
+          duration(rtps::c_TimeInfinite)
+    {}
+
+    virtual RTPS_DllAPI ~LifespanQosPolicy() {}
+
+    bool operator==(const LifespanQosPolicy& b) const
+    {
+        return (this->duration == b.duration) &&
+               Parameter_t::operator==(b) &&
+               QosPolicy::operator==(b);
+    }
+
+    /**
+     * Appends QoS to the specified CDR message.
+     * @param msg Message to append the QoS Policy to.
+     * @return True if the modified CDRMessage is valid.
+     */
+    bool addToCDRMessage(rtps::CDRMessage_t* msg) override;
+
+public:
+    rtps::Duration_t duration;
 };
 
 /**
@@ -594,16 +852,31 @@ class LifespanQosPolicy : private Parameter_t, public QosPolicy {
  * value: Default value 0.
  */
 class OwnershipStrengthQosPolicy : private Parameter_t, public QosPolicy {
-    public:
-        uint32_t value;
-        RTPS_DllAPI OwnershipStrengthQosPolicy():Parameter_t(PID_OWNERSHIP_STRENGTH,4),QosPolicy(false),value(0){};
-        virtual RTPS_DllAPI ~OwnershipStrengthQosPolicy(){};
-        /**
-         * Appends QoS to the specified CDR message.
-         * @param msg Message to append the QoS Policy to.
-         * @return True if the modified CDRMessage is valid.
-         */
-        bool addToCDRMessage(rtps::CDRMessage_t* msg) override;
+public:
+    RTPS_DllAPI OwnershipStrengthQosPolicy()
+        : Parameter_t(PID_OWNERSHIP_STRENGTH,4),
+          QosPolicy(false),
+          value(0)
+    {}
+
+    virtual RTPS_DllAPI ~OwnershipStrengthQosPolicy() {}
+
+    bool operator==(const OwnershipStrengthQosPolicy& b) const
+    {
+        return (this->value == b.value) &&
+               Parameter_t::operator==(b) &&
+               QosPolicy::operator==(b);
+    }
+
+    /**
+     * Appends QoS to the specified CDR message.
+     * @param msg Message to append the QoS Policy to.
+     * @return True if the modified CDRMessage is valid.
+     */
+    bool addToCDRMessage(rtps::CDRMessage_t* msg) override;
+
+public:
+    uint32_t value;
 };
 
 

--- a/include/fastrtps/qos/ReaderQos.h
+++ b/include/fastrtps/qos/ReaderQos.h
@@ -34,8 +34,28 @@ namespace fastrtps {
  */
 class  ReaderQos{
 public:
-	RTPS_DllAPI ReaderQos(){};
-	RTPS_DllAPI virtual ~ReaderQos(){};
+    RTPS_DllAPI ReaderQos() {}
+    RTPS_DllAPI virtual ~ReaderQos() {}
+
+    bool operator==(const ReaderQos& b) const
+    {
+        return (this->m_durability == b.m_durability) &&
+               (this->m_deadline == b.m_deadline) &&
+               (this->m_latencyBudget == b.m_latencyBudget) &&
+               (this->m_liveliness == b.m_liveliness) &&
+               (this->m_reliability == b.m_reliability) &&
+               (this->m_ownership == b.m_ownership) &&
+               (this->m_destinationOrder == b.m_destinationOrder) &&
+               (this->m_userData == b.m_userData) &&
+               (this->m_timeBasedFilter == b.m_timeBasedFilter) &&
+               (this->m_presentation == b.m_presentation) &&
+               (this->m_partition == b.m_partition) &&
+               (this->m_topicData == b.m_topicData) &&
+               (this->m_groupData == b.m_groupData) &&
+               (this->m_durabilityService == b.m_durabilityService) &&
+               (this->m_lifespan == b.m_lifespan);
+    }
+
 	//!Durability Qos, implemented in the library.
 	DurabilityQosPolicy m_durability;
 	//!Deadline Qos, NOT implemented in the library.

--- a/include/fastrtps/qos/WriterQos.h
+++ b/include/fastrtps/qos/WriterQos.h
@@ -37,6 +37,28 @@ class  WriterQos{
 public:
 	RTPS_DllAPI WriterQos();
 	RTPS_DllAPI virtual ~WriterQos();
+
+    bool operator==(const WriterQos& b) const
+    {
+        return (this->m_durability == b.m_durability) &&
+               (this->m_durabilityService == b.m_durabilityService) &&
+               (this->m_deadline == b.m_deadline) &&
+               (this->m_latencyBudget == b.m_latencyBudget) &&
+               (this->m_liveliness == b.m_liveliness) &&
+               (this->m_reliability == b.m_reliability) &&
+               (this->m_lifespan == b.m_lifespan) &&
+               (this->m_userData == b.m_userData) &&
+               (this->m_timeBasedFilter == b.m_timeBasedFilter) &&
+               (this->m_ownership == b.m_ownership) &&
+               (this->m_ownershipStrength == b.m_ownershipStrength) &&
+               (this->m_destinationOrder == b.m_destinationOrder) &&
+               (this->m_presentation == b.m_presentation) &&
+               (this->m_partition == b.m_partition) &&
+               (this->m_topicData == b.m_topicData) &&
+               (this->m_groupData == b.m_groupData) &&
+               (this->m_publishMode == b.m_publishMode);
+    }
+
 	//!Durability Qos, implemented in the library.
 	DurabilityQosPolicy m_durability;
 	//!Durability Service Qos, NOT implemented in the library.

--- a/include/fastrtps/rtps/attributes/PropertyPolicy.h
+++ b/include/fastrtps/rtps/attributes/PropertyPolicy.h
@@ -54,6 +54,12 @@ class PropertyPolicy
             return *this;
         }
 
+        RTPS_DllAPI bool operator==(const PropertyPolicy& b) const
+        {
+            return (this->properties_ == b.properties_) &&
+                   (this->binary_properties_ == b.binary_properties_);
+        }
+
         RTPS_DllAPI const PropertySeq& properties() const
         {
             return properties_;

--- a/include/fastrtps/rtps/attributes/RTPSParticipantAttributes.h
+++ b/include/fastrtps/rtps/attributes/RTPSParticipantAttributes.h
@@ -62,6 +62,18 @@ class SimpleEDPAttributes
         {
 
         }
+
+        bool operator==(const SimpleEDPAttributes& b) const
+        {
+            return (this->use_PublicationWriterANDSubscriptionReader == b.use_PublicationWriterANDSubscriptionReader) &&
+#if HAVE_SECURITY
+                   (this->enable_builtin_secure_publications_writer_and_subscriptions_reader ==
+                    b.enable_builtin_secure_publications_writer_and_subscriptions_reader) &&
+                   (this->enable_builtin_secure_subscriptions_writer_and_publications_reader ==
+                    b.enable_builtin_secure_subscriptions_writer_and_publications_reader) &&
+#endif
+                   (this->use_PublicationReaderANDSubscriptionWriter == b.use_PublicationReaderANDSubscriptionWriter);
+        }
 };
 
 /**
@@ -127,18 +139,37 @@ class BuiltinAttributes{
             use_WriterLivelinessProtocol = true;
             readerHistoryMemoryPolicy = MemoryManagementPolicy_t::PREALLOCATED_MEMORY_MODE;
             writerHistoryMemoryPolicy = MemoryManagementPolicy_t::PREALLOCATED_MEMORY_MODE;
-        };
-        virtual ~BuiltinAttributes(){};
+        }
+        virtual ~BuiltinAttributes() {}
+
+        bool operator==(const BuiltinAttributes& b) const
+        {
+            return (this->use_SIMPLE_RTPSParticipantDiscoveryProtocol == b.use_SIMPLE_RTPSParticipantDiscoveryProtocol) &&
+                   (this->use_WriterLivelinessProtocol == b.use_WriterLivelinessProtocol) &&
+                   (this->use_SIMPLE_EndpointDiscoveryProtocol == b.use_SIMPLE_EndpointDiscoveryProtocol) &&
+                   (this->use_STATIC_EndpointDiscoveryProtocol == b.use_STATIC_EndpointDiscoveryProtocol) &&
+                   (this->domainId == b.domainId) &&
+                   (this->leaseDuration == b.leaseDuration) &&
+                   (this->leaseDuration_announcementperiod == b.leaseDuration_announcementperiod) &&
+                   (this->m_simpleEDP == b.m_simpleEDP) &&
+                   (this->metatrafficUnicastLocatorList == b.metatrafficUnicastLocatorList) &&
+                   (this->metatrafficMulticastLocatorList == b.metatrafficMulticastLocatorList) &&
+                   (this->initialPeersList == b.initialPeersList) &&
+                   (this->readerHistoryMemoryPolicy == b.readerHistoryMemoryPolicy) &&
+                   (this->writerHistoryMemoryPolicy == b.writerHistoryMemoryPolicy) &&
+                   (this->m_staticEndpointXMLFilename == b.m_staticEndpointXMLFilename);
+        }
+
         /**
          * Get the static endpoint XML filename
          * @return Static endpoint XML filename
          */
-        const char* getStaticEndpointXMLFilename() const { return m_staticEndpointXMLFilename.c_str(); };
+        const char* getStaticEndpointXMLFilename() const { return m_staticEndpointXMLFilename.c_str(); }
         /**
          * Set the static endpoint XML filename
          * @param str Static endpoint XML filename
          */
-        void setStaticEndpointXMLFilename(const char* str){ m_staticEndpointXMLFilename = std::string(str); };
+        void setStaticEndpointXMLFilename(const char* str){ m_staticEndpointXMLFilename = std::string(str); }
     private:
         //! StaticEDP XML filename, only necessary if use_STATIC_EndpointDiscoveryProtocol=true
         std::string m_staticEndpointXMLFilename;
@@ -163,7 +194,23 @@ class RTPSParticipantAttributes
             useBuiltinTransports = true;
         }
 
-        virtual ~RTPSParticipantAttributes(){};
+        virtual ~RTPSParticipantAttributes() {}
+
+        bool operator==(const RTPSParticipantAttributes& b) const
+        {
+            return (this->name == b.name) &&
+                   (this->defaultUnicastLocatorList == b.defaultUnicastLocatorList) &&
+                   (this->defaultMulticastLocatorList == b.defaultMulticastLocatorList) &&
+                   (this->sendSocketBufferSize == b.sendSocketBufferSize) &&
+                   (this->listenSocketBufferSize == b.listenSocketBufferSize) &&
+                   (this->builtin == b.builtin) &&
+                   (this->port == b.port) &&
+                   (this->userData == b.userData) &&
+                   (this->participantID == b.participantID) &&
+                   (this->throughputController == b.throughputController) &&
+                   (this->useBuiltinTransports == b.useBuiltinTransports) &&
+                   (this->properties == b.properties);
+        }
 
         /**
          * Default list of Unicast Locators to be used for any Endpoint defined inside this RTPSParticipant in the case

--- a/include/fastrtps/rtps/attributes/ReaderAttributes.h
+++ b/include/fastrtps/rtps/attributes/ReaderAttributes.h
@@ -34,17 +34,25 @@ namespace rtps{
  */
 class ReaderTimes
 {
-    public:
-        ReaderTimes()
-        {
-            initialAcknackDelay.fraction = 200*1000*1000;
-            heartbeatResponseDelay.fraction = 20*1000*1000;
-        };
-        virtual ~ReaderTimes(){};
-        //!Initial AckNack delay. Default value ~45ms.
-        Duration_t initialAcknackDelay;
-        //!Delay to be applied when a hearbeat message is received, default value ~4.5ms.
-        Duration_t heartbeatResponseDelay;
+public:
+    ReaderTimes()
+    {
+        initialAcknackDelay.fraction = 200*1000*1000;
+        heartbeatResponseDelay.fraction = 20*1000*1000;
+    }
+
+    virtual ~ReaderTimes() {}
+
+    bool operator==(const ReaderTimes& b) const
+    {
+        return (this->initialAcknackDelay == b.initialAcknackDelay)  &&
+               (this->heartbeatResponseDelay == b.heartbeatResponseDelay);
+    }
+
+    //!Initial AckNack delay. Default value ~45ms.
+    Duration_t initialAcknackDelay;
+    //!Delay to be applied when a hearbeat message is received, default value ~4.5ms.
+    Duration_t heartbeatResponseDelay;
 };
 
 /**

--- a/include/fastrtps/rtps/attributes/WriterAttributes.h
+++ b/include/fastrtps/rtps/attributes/WriterAttributes.h
@@ -42,24 +42,32 @@ typedef enum RTPSWriterPublishMode : octet
  */
 class  WriterTimes
 {
-    public:
+public:
+    WriterTimes()
+    {
+        initialHeartbeatDelay.fraction = 200*1000*1000;
+        heartbeatPeriod.seconds = 3;
+        nackResponseDelay.fraction = 20*1000*1000;
+    }
 
-        WriterTimes()
-        {
-            initialHeartbeatDelay.fraction = 200*1000*1000;
-            heartbeatPeriod.seconds = 3;
-            nackResponseDelay.fraction = 20*1000*1000;
-        };
-        virtual ~WriterTimes(){};
+    virtual ~WriterTimes() {}
 
-        //! Initial heartbeat delay. Default value ~45ms.
-        Duration_t initialHeartbeatDelay;
-        //! Periodic HB period, default value 3s.
-        Duration_t heartbeatPeriod;
-        //!Delay to apply to the response of a ACKNACK message, default value ~45ms.
-        Duration_t nackResponseDelay;
-        //!This time allows the RTPSWriter to ignore nack messages too soon after the data as sent, default value 0s.
-        Duration_t nackSupressionDuration;
+    bool operator==(const WriterTimes& b) const
+    {
+        return (this->initialHeartbeatDelay == b.initialHeartbeatDelay) &&
+               (this->heartbeatPeriod == b.heartbeatPeriod) &&
+               (this->nackResponseDelay == b.nackResponseDelay) &&
+               (this->nackSupressionDuration == b.nackSupressionDuration);
+    }
+
+    //! Initial heartbeat delay. Default value ~45ms.
+    Duration_t initialHeartbeatDelay;
+    //! Periodic HB period, default value 3s.
+    Duration_t heartbeatPeriod;
+    //!Delay to apply to the response of a ACKNACK message, default value ~45ms.
+    Duration_t nackResponseDelay;
+    //!This time allows the RTPSWriter to ignore nack messages too soon after the data as sent, default value 0s.
+    Duration_t nackSupressionDuration;
 };
 
 /**

--- a/include/fastrtps/rtps/common/BinaryProperty.h
+++ b/include/fastrtps/rtps/common/BinaryProperty.h
@@ -67,6 +67,12 @@ class BinaryProperty
             return *this;
         }
 
+        bool operator==(const BinaryProperty& b) const
+        {
+            return (this->name_ == b.name_) &&
+                   (this->value_ == b.value_);
+        }
+
         void name(const std::string& name)
         {
             name_ = name;

--- a/include/fastrtps/rtps/common/PortParameters.h
+++ b/include/fastrtps/rtps/common/PortParameters.h
@@ -31,57 +31,67 @@ namespace rtps {
  */
 class PortParameters
 {
-    public:
-        PortParameters()
-        {
-            portBase = 7400;
-            participantIDGain = 2;
-            domainIDGain = 250;
-            offsetd0 = 0;
-            offsetd1 = 10;
-            offsetd2 = 1;
-            offsetd3 = 11;
-        };
+public:
+    PortParameters()
+        : portBase(7400),
+          domainIDGain(250),
+          participantIDGain(2),
+          offsetd0(0),
+          offsetd1(10),
+          offsetd2(1),
+          offsetd3(11)
+    {}
 
-        virtual ~PortParameters(){}
+    virtual ~PortParameters(){}
 
-        /**
-         * Get a multicast port based on the domain ID.
-         *
-         * @param domainId Domain ID.
-         * @return Multicast port
-         */
-        inline uint32_t getMulticastPort(uint32_t domainId) const
-        {
-            return portBase + domainIDGain * domainId + offsetd0;
-        }
+    bool operator==(const PortParameters& b) const
+    {
+        return (this->portBase == b.portBase) &&
+               (this->domainIDGain == b.domainIDGain) &&
+               (this->participantIDGain == b.participantIDGain) &&
+               (this->offsetd0 == b.offsetd0) &&
+               (this->offsetd1 == b.offsetd1) &&
+               (this->offsetd2 == b.offsetd2) &&
+               (this->offsetd3 == b.offsetd3);
+    }
 
-        /**
-         * Get a unicast port baes on the domain ID and the participant ID.
-         *
-         * @param domainId Domain ID.
-         * @param RTPSParticipantID Participant ID.
-         * @return Unicast port
-         */
-        inline uint32_t getUnicastPort(uint32_t domainId, uint32_t RTPSParticipantID) const
-        {
-            return portBase + domainIDGain * domainId + offsetd1 + participantIDGain * RTPSParticipantID;
-        }
+    /**
+     * Get a multicast port based on the domain ID.
+     *
+     * @param domainId Domain ID.
+     * @return Multicast port
+     */
+    inline uint32_t getMulticastPort(uint32_t domainId) const
+    {
+        return portBase+ domainIDGain * domainId+ offsetd0;
+    }
+    /**
+     * Get a unicast port baes on the domain ID and the participant ID.
+     *
+     * @param domainId Domain ID.
+     * @param RTPSParticipantID Participant ID.
+     * @return Unicast port
+     */
+    inline uint32_t getUnicastPort(uint32_t domainId,uint32_t RTPSParticipantID) const
+    {
+        return portBase+ domainIDGain * domainId + offsetd1	+ participantIDGain * RTPSParticipantID;
+    }
 
-        //!PortBase, default value 7400.
-        uint16_t portBase;
-        //!DomainID gain, default value 250.
-        uint16_t domainIDGain;
-        //!ParticipantID gain, default value 2.
-        uint16_t participantIDGain;
-        //!Offset d0, default value 0.
-        uint16_t offsetd0;
-        //!Offset d1, default value 10.
-        uint16_t offsetd1;
-        //!Offset d2, default value 1.
-        uint16_t offsetd2;
-        //!Offset d3, default value 11.
-        uint16_t offsetd3;
+public:
+    //!PortBase, default value 7400.
+    uint16_t portBase;
+    //!DomainID gain, default value 250.
+    uint16_t domainIDGain;
+    //!ParticipantID gain, default value 2.
+    uint16_t participantIDGain;
+    //!Offset d0, default value 0.
+    uint16_t offsetd0;
+    //!Offset d1, default value 10.
+    uint16_t offsetd1;
+    //!Offset d2, default value 1.
+    uint16_t offsetd2;
+    //!Offset d3, default value 11.
+    uint16_t offsetd3;
 };
 
 }

--- a/include/fastrtps/rtps/common/Property.h
+++ b/include/fastrtps/rtps/common/Property.h
@@ -65,6 +65,12 @@ class Property
             return *this;
         }
 
+        bool operator==(const Property& b) const
+        {
+            return (this->name_ == b.name_) &&
+                   (this->value_ == b.value_);
+        }
+
         void name(const std::string& name)
         {
             name_ = name;

--- a/include/fastrtps/rtps/flowcontrol/ThroughputControllerDescriptor.h
+++ b/include/fastrtps/rtps/flowcontrol/ThroughputControllerDescriptor.h
@@ -36,6 +36,12 @@ struct ThroughputControllerDescriptor
 
     RTPS_DllAPI ThroughputControllerDescriptor();
     RTPS_DllAPI ThroughputControllerDescriptor(uint32_t size, uint32_t time);
+
+    bool operator==(const ThroughputControllerDescriptor& b) const
+    {
+        return (this->bytesPerPeriod == b.bytesPerPeriod) &&
+               (this->periodMillisecs == b.periodMillisecs);
+    }
 };
 
 } // namespace rtps

--- a/src/cpp/xmlparser/XMLParser.cpp
+++ b/src/cpp/xmlparser/XMLParser.cpp
@@ -67,6 +67,18 @@ XMLP_ret XMLParser::parseXML(tinyxml2::XMLDocument& xmlDoc, up_base_node_t& root
                         root->addChild(std::move(profiles_node));
                     }
                 }
+                else if (strcmp(tag, PARTICIPANT) == 0)
+                {
+                    ret = parseXMLParticipantProf(node, *root);
+                }
+                else if (strcmp(tag, PUBLISHER) == 0 || strcmp(tag, DATA_WRITER) == 0)
+                {
+                    ret = parseXMLPublisherProf(node, *root);
+                }
+                else if (strcmp(tag, SUBSCRIBER) == 0 || strcmp(tag, DATA_READER) == 0)
+                {
+                    ret = parseXMLSubscriberProf(node, *root);
+                }
                 else if (strcmp(tag, TOPIC) == 0)
                 {
                     ret = parseXMLTopicData(node, *root);
@@ -499,11 +511,11 @@ XMLP_ret XMLParser::parseProfiles(tinyxml2::XMLElement* p_root, BaseNode& profil
             {
                 parseXMLParticipantProf(p_profile, profilesNode);
             }
-            else if (strcmp(tag, PUBLISHER) == 0)
+            else if (strcmp(tag, PUBLISHER) == 0 || strcmp(tag, DATA_WRITER) == 0)
             {
                 parseXMLPublisherProf(p_profile, profilesNode);
             }
-            else if (strcmp(tag, SUBSCRIBER) == 0)
+            else if (strcmp(tag, SUBSCRIBER) == 0 || strcmp(tag, DATA_READER) == 0)
             {
                 parseXMLSubscriberProf(p_profile, profilesNode);
             }
@@ -633,12 +645,6 @@ XMLP_ret XMLParser::fillDataNode(tinyxml2::XMLElement* p_profile, DataNode<Parti
         return XMLP_ret::XML_ERROR;
     }
 
-    if (nullptr == p_profile->Attribute(PROFILE_NAME))
-    {
-        logError(XMLPARSER, "Not found '" << PROFILE_NAME << "' attribute");
-        return XMLP_ret::XML_ERROR;
-    }
-
     addAllAttributes(p_profile, participant_node);
 
     tinyxml2::XMLElement* p_element = p_profile->FirstChildElement(RTPS);
@@ -760,11 +766,6 @@ XMLP_ret XMLParser::fillDataNode(tinyxml2::XMLElement* p_profile, DataNode<Publi
         logError(XMLPARSER, "Bad parameters!");
         return XMLP_ret::XML_ERROR;
     }
-    if (nullptr == p_profile->Attribute(PROFILE_NAME))
-    {
-        logError(XMLPARSER, "Not found '" << PROFILE_NAME << "' attribute");
-        return XMLP_ret::XML_ERROR;
-    }
 
     addAllAttributes(p_profile, publisher_node);
 
@@ -866,12 +867,6 @@ XMLP_ret XMLParser::fillDataNode(tinyxml2::XMLElement* p_profile, DataNode<Subsc
     if (nullptr == p_profile)
     {
         logError(XMLPARSER, "Bad parameters!");
-        return XMLP_ret::XML_ERROR;
-    }
-
-    if (nullptr == p_profile->Attribute(PROFILE_NAME))
-    {
-        logError(XMLPARSER, "Not found '" << PROFILE_NAME << "' attribute");
         return XMLP_ret::XML_ERROR;
     }
 


### PR DESCRIPTION
Micro XRCE-DDS support `data_writer` and `data_reader` entities which correspond with `publisher` and `subscriber` in FastRTPS, so in order to support XML representations for the XRCE entities the XMLParser has been modified.