### PR TITLE
Fix errors with versions of asio previous to 1.12.0

### DIFF
--- a/src/cpp/transport/TCPChannelResource.cpp
+++ b/src/cpp/transport/TCPChannelResource.cpp
@@ -163,7 +163,9 @@ void TCPChannelResource::Disconnect()
         {
             mSocket.cancel();
             mSocket.shutdown(asio::ip::tcp::socket::shutdown_both);
-#if !defined(_WIN32_WINNT) || _WIN32_WINNT >= 0x0603
+
+            // This method was added on the version 1.12.0
+#if ASIO_VERSION >= 101200 && (!defined(_WIN32_WINNT) || _WIN32_WINNT >= 0x0603)
             mSocket.release();
 #endif
         }

--- a/src/cpp/transport/TCPTransportInterface.cpp
+++ b/src/cpp/transport/TCPTransportInterface.cpp
@@ -131,8 +131,9 @@ void TCPTransportInterface::Clean()
         mUnboundChannelResources.clear();
     }
 
-    std::for_each(vDeletedSockets.begin(), vDeletedSockets.end(), [this](auto it){
-        DeleteSocket(it); // Disable all added TCPChannelResources
+    std::for_each(vDeletedSockets.begin(), vDeletedSockets.end(), [this](auto it)
+    {
+        this->DeleteSocket(it); // Disable all added TCPChannelResources
     });
 
     CleanDeletedSockets();


### PR DESCRIPTION
Add an extra check to avoid a compilation error with versions of asio previous of 1.12.0 calling a release method of the sockets.