### PR TITLE
Update the cmake files of FastRTPS tests

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -245,23 +245,7 @@ add_subdirectory(src/cpp)
 ###############################################################################
 # Testing options
 ###############################################################################
-option(PERFORMANCE_TESTS "Activate the building and execution of performance tests" OFF)
-option(PROFILING_TESTS "Activate the building and execution of profiling tests" OFF)
-option(EPROSIMA_BUILD_TESTS "Activate the building and execution unit tests and integral tests" OFF)
-
-if(EPROSIMA_BUILD AND NOT EPROSIMA_INSTALLER AND NOT EPROSIMA_INSTALLER_MINION)
-    set(EPROSIMA_BUILD_TESTS ON)
-endif()
-
-###############################################################################
-# Testing
-###############################################################################
-if(EPROSIMA_BUILD_TESTS AND IS_TOP_LEVEL AND NOT EPROSIMA_INSTALLER)
-    file(TO_CMAKE_PATH "${PROJECT_SOURCE_DIR}/valgrind.supp" MEMORYCHECK_SUPPRESSIONS_FILE)
-    enable_testing()
-    include(CTest)
-    add_subdirectory(test)
-endif()
+add_subdirectory(test)
 
 ###############################################################################
 # Examples

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -12,17 +12,42 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-add_subdirectory(blackbox)
-add_subdirectory(communication)
-if(NOT ((MSVC OR MSVC_IDE)))
+option(PERFORMANCE_TESTS "Activate the building and execution of performance tests" OFF)
+option(PROFILING_TESTS "Activate the building and execution of profiling tests" OFF)
+option(EPROSIMA_BUILD_TESTS "Activate the building and execution unit tests and integral tests" OFF)
+
+if(EPROSIMA_BUILD AND NOT EPROSIMA_INSTALLER AND NOT EPROSIMA_INSTALLER_MINION)
+    set(EPROSIMA_BUILD_TESTS ON)
+endif()
+
+###############################################################################
+# Testing
+###############################################################################
+if(EPROSIMA_BUILD_TESTS AND IS_TOP_LEVEL AND NOT EPROSIMA_INSTALLER)
+    file(TO_CMAKE_PATH "${PROJECT_SOURCE_DIR}/valgrind.supp" MEMORYCHECK_SUPPRESSIONS_FILE)
+    enable_testing()
+    include(CTest)
+
+	add_subdirectory(blackbox)
+	add_subdirectory(communication)
+
+	add_subdirectory(unittest)
+endif()
+
+###############################################################################
+# Profiling tests using valgrind
+###############################################################################
+if(NOT ((MSVC OR MSVC_IDE)) AND PROFILING_TESTS)
    find_program(CTEST_MEMORYCHECK_COMMAND NAMES valgrind)
    if(CTEST_MEMORYCHECK_COMMAND)
       add_subdirectory(profiling)
    endif()
 endif()
-add_subdirectory(unittest)
 
 ###############################################################################
 # Performance tests
 ###############################################################################
-add_subdirectory(performance)
+if(PERFORMANCE_TESTS)
+	add_subdirectory(performance)
+endif()
+

--- a/test/performance/CMakeLists.txt
+++ b/test/performance/CMakeLists.txt
@@ -13,387 +13,385 @@
 # limitations under the License.
 
 if(NOT ((MSVC OR MSVC_IDE) AND EPROSIMA_INSTALLER) AND fastcdr_FOUND)
-    if(PERFORMANCE_TESTS)
-        find_package(Threads REQUIRED)
+    find_package(Threads REQUIRED)
 
-        if(WIN32)
-            if("${CMAKE_SYSTEM_NAME}" STREQUAL "WindowsStore")
-                add_definitions(-D_WIN32_WINNT=0x0603)
+    if(WIN32)
+        if("${CMAKE_SYSTEM_NAME}" STREQUAL "WindowsStore")
+            add_definitions(-D_WIN32_WINNT=0x0603)
+        else()
+            add_definitions(-D_WIN32_WINNT=0x0601)
+        endif()
+    endif()
+
+    add_definitions(
+      -DBOOST_ASIO_STANDALONE
+      -DASIO_STANDALONE
+    )
+
+    include_directories(${ASIO_INCLUDE_DIR})
+
+    ###############################################################################
+    # Binaries
+    ###############################################################################
+    set(LATENCYTEST_SOURCE LatencyTestPublisher.cpp
+        LatencyTestSubscriber.cpp
+        LatencyTestTypes.cpp
+        main_LatencyTest.cpp
+        )
+    add_executable(LatencyTest ${LATENCYTEST_SOURCE})
+    target_link_libraries(LatencyTest fastrtps ${CMAKE_THREAD_LIBS_INIT} ${CMAKE_DL_LIBS})
+
+    set(THROUGHPUTTEST_SOURCE ThroughputPublisher.cpp
+        ThroughputSubscriber.cpp
+        ThroughputTypes.cpp
+        main_ThroughputTest.cpp
+        )
+    add_executable(ThroughputTest ${THROUGHPUTTEST_SOURCE})
+    target_include_directories(ThroughputTest PRIVATE)
+    target_link_libraries(ThroughputTest fastrtps ${CMAKE_THREAD_LIBS_INIT} ${CMAKE_DL_LIBS})
+
+    if(WIN32)
+        if (EXISTS $ENV{GSTREAMER_1_0_ROOT_X86_64})
+            if (EXISTS "$ENV{GSTREAMER_1_0_ROOT_X86_64}/include/gstreamer-1.0/gst/gstversion.h")
+                file (READ "$ENV{GSTREAMER_1_0_ROOT_X86_64}/include/gstreamer-1.0/gst/gstversion.h" GSTREAMER_VERSION_CONTENTS)
+                STRING(REGEX MATCH "#define +GST_VERSION_MAJOR +\\(([0-9]+)\\)" _dummy "${GSTREAMER_VERSION_CONTENTS}")
+                SET(GSTREAMER_VERSION_MAJOR "${CMAKE_MATCH_1}")
+
+                STRING(REGEX MATCH "#define +GST_VERSION_MINOR +\\(([0-9]+)\\)" _dummy "${GSTREAMER_VERSION_CONTENTS}")
+                SET(GSTREAMER_VERSION_MINOR "${CMAKE_MATCH_1}")
+
+                STRING(REGEX MATCH "#define +GST_VERSION_MICRO +\\(([0-9]+)\\)" _dummy "${GSTREAMER_VERSION_CONTENTS}")
+                SET(GSTREAMER_VERSION_MICRO "${CMAKE_MATCH_1}")
+
+                SET(GSTREAMER_VERSION "${GSTREAMER_VERSION_MAJOR}.${GSTREAMER_VERSION_MINOR}.${GSTREAMER_VERSION_MICRO}")
+            endif ()
+        endif ()
+
+        if (GSTREAMER_VERSION)
+            if ("${GSTREAMER_VERSION}" VERSION_LESS "1.4")
+                message(STATUS "Windows: GStreamer version less than the minimum required. ${GSTREAMER_VERSION}")
             else()
-                add_definitions(-D_WIN32_WINNT=0x0601)
-            endif()
+                SET(GST_FOUND TRUE)
+                message(STATUS "Windows: GStreamer FOUND. Version: ${GSTREAMER_VERSION}")
+            endif ()
+        endif()
+    else()
+        find_package(PkgConfig)
+        pkg_check_modules(GST REQUIRED gstreamer-1.0>=1.4)
+        # gstreamer-sdp-1.0>=1.4
+        # gstreamer-video-1.0>=1.4
+        # gstreamer-app-1.0>=1.4)
+    endif()
+
+    if(GST_FOUND)
+        set(VIDEOTEST_SOURCE
+            VideoTestPublisher.cpp
+            VideoTestSubscriber.cpp
+            VideoTestTypes.cpp
+            main_VideoTest.cpp
+            )
+        add_executable(VideoTest ${VIDEOTEST_SOURCE})
+
+        target_compile_options(VideoTest PUBLIC ${GST_CFLAGS})
+
+        if(NOT WIN32)
+            target_include_directories(VideoTest PUBLIC
+                ${GST_INCLUDE_DIRS}
+                )
+        else()
+            target_include_directories(VideoTest PUBLIC
+                $ENV{GSTREAMER_1_0_ROOT_X86_64}/include
+                $ENV{GSTREAMER_1_0_ROOT_X86_64}/include/glib-2.0
+                $ENV{GSTREAMER_1_0_ROOT_X86_64}/include/gstreamer-1.0
+                $ENV{GSTREAMER_1_0_ROOT_X86_64}/lib/glib-2.0/include)
         endif()
 
-        add_definitions(
-          -DBOOST_ASIO_STANDALONE
-          -DASIO_STANDALONE
-        )
+        if (WIN32)
+            target_link_libraries(VideoTest fastrtps
+                ${CMAKE_THREAD_LIBS_INIT}
+                ${CMAKE_DL_LIBS}
+                ${GST_LIBRARIES}
+                $ENV{GSTREAMER_1_0_ROOT_X86_64}/lib/gstapp-1.0.lib
+                $ENV{GSTREAMER_1_0_ROOT_X86_64}/lib/gstbase-1.0.lib
+                $ENV{GSTREAMER_1_0_ROOT_X86_64}/lib/gstreamer-1.0.lib
+                $ENV{GSTREAMER_1_0_ROOT_X86_64}/lib/gobject-2.0.lib
+                $ENV{GSTREAMER_1_0_ROOT_X86_64}/lib/glib-2.0.lib)
+        else()
+            target_link_libraries(VideoTest fastrtps
+                ${CMAKE_THREAD_LIBS_INIT}
+                ${CMAKE_DL_LIBS}
+                ${GST_LIBRARIES}
+                gstapp-1.0
+                )
+        endif()
+    else()
+        message(STATUS "GStreamer libraries not found")
+    endif()
 
-        include_directories(${ASIO_INCLUDE_DIR})
+    find_package(PythonInterp 3 REQUIRED)
 
+    if(PYTHONINTERP_FOUND)
         ###############################################################################
-        # Binaries
+        # LatencyTest
         ###############################################################################
-        set(LATENCYTEST_SOURCE LatencyTestPublisher.cpp
-            LatencyTestSubscriber.cpp
-            LatencyTestTypes.cpp
-            main_LatencyTest.cpp
-            )
-        add_executable(LatencyTest ${LATENCYTEST_SOURCE})
-        target_link_libraries(LatencyTest fastrtps ${CMAKE_THREAD_LIBS_INIT} ${CMAKE_DL_LIBS})
+        add_test(NAME LatencyTest
+            COMMAND ${PYTHON_EXECUTABLE} ${CMAKE_CURRENT_SOURCE_DIR}/latency_tests.py)
 
-        set(THROUGHPUTTEST_SOURCE ThroughputPublisher.cpp
-            ThroughputSubscriber.cpp
-            ThroughputTypes.cpp
-            main_ThroughputTest.cpp
-            )
-        add_executable(ThroughputTest ${THROUGHPUTTEST_SOURCE})
-        target_include_directories(ThroughputTest PRIVATE)
-        target_link_libraries(ThroughputTest fastrtps ${CMAKE_THREAD_LIBS_INIT} ${CMAKE_DL_LIBS})
+        # Set test with label NoMemoryCheck
+        set_property(TEST LatencyTest PROPERTY LABELS "NoMemoryCheck")
 
         if(WIN32)
-            if (EXISTS $ENV{GSTREAMER_1_0_ROOT_X86_64})
-                if (EXISTS "$ENV{GSTREAMER_1_0_ROOT_X86_64}/include/gstreamer-1.0/gst/gstversion.h")
-                    file (READ "$ENV{GSTREAMER_1_0_ROOT_X86_64}/include/gstreamer-1.0/gst/gstversion.h" GSTREAMER_VERSION_CONTENTS)
-                    STRING(REGEX MATCH "#define +GST_VERSION_MAJOR +\\(([0-9]+)\\)" _dummy "${GSTREAMER_VERSION_CONTENTS}")
-                    SET(GSTREAMER_VERSION_MAJOR "${CMAKE_MATCH_1}")
+            set_property(TEST LatencyTest PROPERTY ENVIRONMENT
+                "PATH=$<TARGET_FILE_DIR:${PROJECT_NAME}>\\;$ENV{PATH}")
+        endif()
+        set_property(TEST LatencyTest APPEND PROPERTY ENVIRONMENT
+            "LATENCY_TEST_BIN=$<TARGET_FILE:LatencyTest>")
+        if(SECURITY)
+            set_property(TEST LatencyTest APPEND PROPERTY ENVIRONMENT
+                "CERTS_PATH=${PROJECT_SOURCE_DIR}/test/certs")
+        endif()
 
-                    STRING(REGEX MATCH "#define +GST_VERSION_MINOR +\\(([0-9]+)\\)" _dummy "${GSTREAMER_VERSION_CONTENTS}")
-                    SET(GSTREAMER_VERSION_MINOR "${CMAKE_MATCH_1}")
+        ###############################################################################
+        # ThroughputTest16
+        ###############################################################################
+        add_test(NAME ThroughputTest16
+            COMMAND ${PYTHON_EXECUTABLE} ${CMAKE_CURRENT_SOURCE_DIR}/throughput_tests.py 16)
 
-                    STRING(REGEX MATCH "#define +GST_VERSION_MICRO +\\(([0-9]+)\\)" _dummy "${GSTREAMER_VERSION_CONTENTS}")
-                    SET(GSTREAMER_VERSION_MICRO "${CMAKE_MATCH_1}")
+        # Set test with label NoMemoryCheck
+        set_property(TEST ThroughputTest16 PROPERTY LABELS "NoMemoryCheck")
 
-                    SET(GSTREAMER_VERSION "${GSTREAMER_VERSION_MAJOR}.${GSTREAMER_VERSION_MINOR}.${GSTREAMER_VERSION_MICRO}")
-                endif ()
-            endif ()
+        if(WIN32)
+            set_property(TEST ThroughputTest16 PROPERTY ENVIRONMENT
+                "PATH=$<TARGET_FILE_DIR:${PROJECT_NAME}>\\;$ENV{PATH}")
+        endif()
+        set_property(TEST ThroughputTest16 APPEND PROPERTY ENVIRONMENT
+            "THROUGHPUT_TEST_BIN=$<TARGET_FILE:ThroughputTest>")
+        set_property(TEST ThroughputTest16 APPEND PROPERTY ENVIRONMENT
+            "CMAKE_CURRENT_SOURCE_DIR=${CMAKE_CURRENT_SOURCE_DIR}")
+        if(SECURITY)
+            set_property(TEST ThroughputTest16 APPEND PROPERTY ENVIRONMENT
+                "CERTS_PATH=${PROJECT_SOURCE_DIR}/test/certs")
+        endif()
 
-            if (GSTREAMER_VERSION)
-                if ("${GSTREAMER_VERSION}" VERSION_LESS "1.4")
-                    message(STATUS "Windows: GStreamer version less than the minimum required. ${GSTREAMER_VERSION}")
-                else()
-                    SET(GST_FOUND TRUE)
-                    message(STATUS "Windows: GStreamer FOUND. Version: ${GSTREAMER_VERSION}")
-                endif ()
-            endif()
-        else()
-            find_package(PkgConfig)
-            pkg_check_modules(GST REQUIRED gstreamer-1.0>=1.4)
-            # gstreamer-sdp-1.0>=1.4
-            # gstreamer-video-1.0>=1.4
-            # gstreamer-app-1.0>=1.4)
+        ###############################################################################
+        # ThroughputTest32
+        ###############################################################################
+        add_test(NAME ThroughputTest32
+            COMMAND ${PYTHON_EXECUTABLE} ${CMAKE_CURRENT_SOURCE_DIR}/throughput_tests.py 32)
+
+        # Set test with label NoMemoryCheck
+        set_property(TEST ThroughputTest32 PROPERTY LABELS "NoMemoryCheck")
+
+        if(WIN32)
+            set_property(TEST ThroughputTest32 PROPERTY ENVIRONMENT
+                "PATH=$<TARGET_FILE_DIR:${PROJECT_NAME}>\\;$ENV{PATH}")
+        endif()
+        set_property(TEST ThroughputTest32 APPEND PROPERTY ENVIRONMENT
+            "THROUGHPUT_TEST_BIN=$<TARGET_FILE:ThroughputTest>")
+        set_property(TEST ThroughputTest32 APPEND PROPERTY ENVIRONMENT
+            "CMAKE_CURRENT_SOURCE_DIR=${CMAKE_CURRENT_SOURCE_DIR}")
+        if(SECURITY)
+            set_property(TEST ThroughputTest32 APPEND PROPERTY ENVIRONMENT
+                "CERTS_PATH=${PROJECT_SOURCE_DIR}/test/certs")
+        endif()
+
+        ###############################################################################
+        # ThroughputTest64
+        ###############################################################################
+        add_test(NAME ThroughputTest64
+            COMMAND ${PYTHON_EXECUTABLE} ${CMAKE_CURRENT_SOURCE_DIR}/throughput_tests.py 64)
+
+        # Set test with label NoMemoryCheck
+        set_property(TEST ThroughputTest64 PROPERTY LABELS "NoMemoryCheck")
+
+        if(WIN32)
+            set_property(TEST ThroughputTest64 PROPERTY ENVIRONMENT
+                "PATH=$<TARGET_FILE_DIR:${PROJECT_NAME}>\\;$ENV{PATH}")
+        endif()
+        set_property(TEST ThroughputTest64 APPEND PROPERTY ENVIRONMENT
+            "THROUGHPUT_TEST_BIN=$<TARGET_FILE:ThroughputTest>")
+        set_property(TEST ThroughputTest64 APPEND PROPERTY ENVIRONMENT
+            "CMAKE_CURRENT_SOURCE_DIR=${CMAKE_CURRENT_SOURCE_DIR}")
+        if(SECURITY)
+            set_property(TEST ThroughputTest64 APPEND PROPERTY ENVIRONMENT
+                "CERTS_PATH=${PROJECT_SOURCE_DIR}/test/certs")
+        endif()
+
+        ###############################################################################
+        # ThroughputTest128
+        ###############################################################################
+        add_test(NAME ThroughputTest128
+            COMMAND ${PYTHON_EXECUTABLE} ${CMAKE_CURRENT_SOURCE_DIR}/throughput_tests.py 128)
+
+        # Set test with label NoMemoryCheck
+        set_property(TEST ThroughputTest128 PROPERTY LABELS "NoMemoryCheck")
+
+        if(WIN32)
+            set_property(TEST ThroughputTest128 PROPERTY ENVIRONMENT
+                "PATH=$<TARGET_FILE_DIR:${PROJECT_NAME}>\\;$ENV{PATH}")
+        endif()
+        set_property(TEST ThroughputTest128 APPEND PROPERTY ENVIRONMENT
+            "THROUGHPUT_TEST_BIN=$<TARGET_FILE:ThroughputTest>")
+        set_property(TEST ThroughputTest128 APPEND PROPERTY ENVIRONMENT
+            "CMAKE_CURRENT_SOURCE_DIR=${CMAKE_CURRENT_SOURCE_DIR}")
+        if(SECURITY)
+            set_property(TEST ThroughputTest128 APPEND PROPERTY ENVIRONMENT
+                "CERTS_PATH=${PROJECT_SOURCE_DIR}/test/certs")
+        endif()
+
+        ###############################################################################
+        # ThroughputTest256
+        ###############################################################################
+        add_test(NAME ThroughputTest256
+            COMMAND ${PYTHON_EXECUTABLE} ${CMAKE_CURRENT_SOURCE_DIR}/throughput_tests.py 256)
+
+        # Set test with label NoMemoryCheck
+        set_property(TEST ThroughputTest256 PROPERTY LABELS "NoMemoryCheck")
+
+        if(WIN32)
+            set_property(TEST ThroughputTest256 PROPERTY ENVIRONMENT
+                "PATH=$<TARGET_FILE_DIR:${PROJECT_NAME}>\\;$ENV{PATH}")
+        endif()
+        set_property(TEST ThroughputTest256 APPEND PROPERTY ENVIRONMENT
+            "THROUGHPUT_TEST_BIN=$<TARGET_FILE:ThroughputTest>")
+        set_property(TEST ThroughputTest256 APPEND PROPERTY ENVIRONMENT
+            "CMAKE_CURRENT_SOURCE_DIR=${CMAKE_CURRENT_SOURCE_DIR}")
+        if(SECURITY)
+            set_property(TEST ThroughputTest256 APPEND PROPERTY ENVIRONMENT
+                "CERTS_PATH=${PROJECT_SOURCE_DIR}/test/certs")
+        endif()
+
+        ###############################################################################
+        # ThroughputTest512
+        ###############################################################################
+        add_test(NAME ThroughputTest512
+            COMMAND ${PYTHON_EXECUTABLE} ${CMAKE_CURRENT_SOURCE_DIR}/throughput_tests.py 512)
+
+        # Set test with label NoMemoryCheck
+        set_property(TEST ThroughputTest512 PROPERTY LABELS "NoMemoryCheck")
+
+        if(WIN32)
+            set_property(TEST ThroughputTest512 PROPERTY ENVIRONMENT
+                "PATH=$<TARGET_FILE_DIR:${PROJECT_NAME}>\\;$ENV{PATH}")
+        endif()
+        set_property(TEST ThroughputTest512 APPEND PROPERTY ENVIRONMENT
+            "THROUGHPUT_TEST_BIN=$<TARGET_FILE:ThroughputTest>")
+        set_property(TEST ThroughputTest512 APPEND PROPERTY ENVIRONMENT
+            "CMAKE_CURRENT_SOURCE_DIR=${CMAKE_CURRENT_SOURCE_DIR}")
+        if(SECURITY)
+            set_property(TEST ThroughputTest512 APPEND PROPERTY ENVIRONMENT
+                "CERTS_PATH=${PROJECT_SOURCE_DIR}/test/certs")
+        endif()
+
+        ###############################################################################
+        # ThroughputTest1024
+        ###############################################################################
+        add_test(NAME ThroughputTest1024
+            COMMAND ${PYTHON_EXECUTABLE} ${CMAKE_CURRENT_SOURCE_DIR}/throughput_tests.py 1024)
+
+        # Set test with label NoMemoryCheck
+        set_property(TEST ThroughputTest1024 PROPERTY LABELS "NoMemoryCheck")
+
+        if(WIN32)
+            set_property(TEST ThroughputTest1024 PROPERTY ENVIRONMENT
+                "PATH=$<TARGET_FILE_DIR:${PROJECT_NAME}>\\;$ENV{PATH}")
+        endif()
+        set_property(TEST ThroughputTest1024 APPEND PROPERTY ENVIRONMENT
+            "THROUGHPUT_TEST_BIN=$<TARGET_FILE:ThroughputTest>")
+        set_property(TEST ThroughputTest1024 APPEND PROPERTY ENVIRONMENT
+            "CMAKE_CURRENT_SOURCE_DIR=${CMAKE_CURRENT_SOURCE_DIR}")
+        if(SECURITY)
+            set_property(TEST ThroughputTest1024 APPEND PROPERTY ENVIRONMENT
+                "CERTS_PATH=${PROJECT_SOURCE_DIR}/test/certs")
+        endif()
+
+        ###############################################################################
+        # ThroughputTest2048
+        ###############################################################################
+        add_test(NAME ThroughputTest2048
+            COMMAND ${PYTHON_EXECUTABLE} ${CMAKE_CURRENT_SOURCE_DIR}/throughput_tests.py 2048)
+
+        # Set test with label NoMemoryCheck
+        set_property(TEST ThroughputTest2048 PROPERTY LABELS "NoMemoryCheck")
+
+        if(WIN32)
+            set_property(TEST ThroughputTest2048 PROPERTY ENVIRONMENT
+                "PATH=$<TARGET_FILE_DIR:${PROJECT_NAME}>\\;$ENV{PATH}")
+        endif()
+        set_property(TEST ThroughputTest2048 APPEND PROPERTY ENVIRONMENT
+            "THROUGHPUT_TEST_BIN=$<TARGET_FILE:ThroughputTest>")
+        set_property(TEST ThroughputTest2048 APPEND PROPERTY ENVIRONMENT
+            "CMAKE_CURRENT_SOURCE_DIR=${CMAKE_CURRENT_SOURCE_DIR}")
+        if(SECURITY)
+            set_property(TEST ThroughputTest2048 APPEND PROPERTY ENVIRONMENT
+                "CERTS_PATH=${PROJECT_SOURCE_DIR}/test/certs")
+        endif()
+
+        ###############################################################################
+        # ThroughputTest4096
+        ###############################################################################
+        add_test(NAME ThroughputTest4096
+            COMMAND ${PYTHON_EXECUTABLE} ${CMAKE_CURRENT_SOURCE_DIR}/throughput_tests.py 4096)
+
+        # Set test with label NoMemoryCheck
+        set_property(TEST ThroughputTest4096 PROPERTY LABELS "NoMemoryCheck")
+
+        if(WIN32)
+            set_property(TEST ThroughputTest4096 PROPERTY ENVIRONMENT
+                "PATH=$<TARGET_FILE_DIR:${PROJECT_NAME}>\\;$ENV{PATH}")
+        endif()
+        set_property(TEST ThroughputTest4096 APPEND PROPERTY ENVIRONMENT
+            "THROUGHPUT_TEST_BIN=$<TARGET_FILE:ThroughputTest>")
+        set_property(TEST ThroughputTest4096 APPEND PROPERTY ENVIRONMENT
+            "CMAKE_CURRENT_SOURCE_DIR=${CMAKE_CURRENT_SOURCE_DIR}")
+        if(SECURITY)
+            set_property(TEST ThroughputTest4096 APPEND PROPERTY ENVIRONMENT
+                "CERTS_PATH=${PROJECT_SOURCE_DIR}/test/certs")
+        endif()
+
+        ###############################################################################
+        # ThroughputTest8192
+        ###############################################################################
+        add_test(NAME ThroughputTest8192
+            COMMAND ${PYTHON_EXECUTABLE} ${CMAKE_CURRENT_SOURCE_DIR}/throughput_tests.py 8192)
+
+        # Set test with label NoMemoryCheck
+        set_property(TEST ThroughputTest8192 PROPERTY LABELS "NoMemoryCheck")
+
+        if(WIN32)
+            set_property(TEST ThroughputTest8192 PROPERTY ENVIRONMENT
+                "PATH=$<TARGET_FILE_DIR:${PROJECT_NAME}>\\;$ENV{PATH}")
+        endif()
+        set_property(TEST ThroughputTest8192 APPEND PROPERTY ENVIRONMENT
+            "THROUGHPUT_TEST_BIN=$<TARGET_FILE:ThroughputTest>")
+        set_property(TEST ThroughputTest8192 APPEND PROPERTY ENVIRONMENT
+            "CMAKE_CURRENT_SOURCE_DIR=${CMAKE_CURRENT_SOURCE_DIR}")
+        if(SECURITY)
+            set_property(TEST ThroughputTest8192 APPEND PROPERTY ENVIRONMENT
+                "CERTS_PATH=${PROJECT_SOURCE_DIR}/test/certs")
         endif()
 
         if(GST_FOUND)
-            set(VIDEOTEST_SOURCE
-                VideoTestPublisher.cpp
-                VideoTestSubscriber.cpp
-                VideoTestTypes.cpp
-                main_VideoTest.cpp
-                )
-            add_executable(VideoTest ${VIDEOTEST_SOURCE})
-
-            target_compile_options(VideoTest PUBLIC ${GST_CFLAGS})
-
-            if(NOT WIN32)
-                target_include_directories(VideoTest PUBLIC
-                    ${GST_INCLUDE_DIRS}
-                    )
-            else()
-                target_include_directories(VideoTest PUBLIC
-                    $ENV{GSTREAMER_1_0_ROOT_X86_64}/include
-                    $ENV{GSTREAMER_1_0_ROOT_X86_64}/include/glib-2.0
-                    $ENV{GSTREAMER_1_0_ROOT_X86_64}/include/gstreamer-1.0
-                    $ENV{GSTREAMER_1_0_ROOT_X86_64}/lib/glib-2.0/include)
-            endif()
-
-            if (WIN32)
-                target_link_libraries(VideoTest fastrtps
-                    ${CMAKE_THREAD_LIBS_INIT}
-                    ${CMAKE_DL_LIBS}
-                    ${GST_LIBRARIES}
-                    $ENV{GSTREAMER_1_0_ROOT_X86_64}/lib/gstapp-1.0.lib
-                    $ENV{GSTREAMER_1_0_ROOT_X86_64}/lib/gstbase-1.0.lib
-                    $ENV{GSTREAMER_1_0_ROOT_X86_64}/lib/gstreamer-1.0.lib
-                    $ENV{GSTREAMER_1_0_ROOT_X86_64}/lib/gobject-2.0.lib
-                    $ENV{GSTREAMER_1_0_ROOT_X86_64}/lib/glib-2.0.lib)
-            else()
-                target_link_libraries(VideoTest fastrtps
-                    ${CMAKE_THREAD_LIBS_INIT}
-                    ${CMAKE_DL_LIBS}
-                    ${GST_LIBRARIES}
-                    gstapp-1.0
-                    )
-            endif()
-        else()
-            message(STATUS "GStreamer libraries not found")
-        endif()
-
-        find_package(PythonInterp 3 REQUIRED)
-
-        if(PYTHONINTERP_FOUND)
             ###############################################################################
-            # LatencyTest
+            # VideoTest
             ###############################################################################
-            add_test(NAME LatencyTest
-                COMMAND ${PYTHON_EXECUTABLE} ${CMAKE_CURRENT_SOURCE_DIR}/latency_tests.py)
+            add_test(NAME VideoTest
+                COMMAND ${PYTHON_EXECUTABLE} ${CMAKE_CURRENT_SOURCE_DIR}/video_tests.py)
 
             # Set test with label NoMemoryCheck
-            set_property(TEST LatencyTest PROPERTY LABELS "NoMemoryCheck")
+            set_property(TEST VideoTest PROPERTY LABELS "NoMemoryCheck")
 
             if(WIN32)
-                set_property(TEST LatencyTest PROPERTY ENVIRONMENT
+                set_property(TEST VideoTest PROPERTY ENVIRONMENT
                     "PATH=$<TARGET_FILE_DIR:${PROJECT_NAME}>\\;$ENV{PATH}")
             endif()
-            set_property(TEST LatencyTest APPEND PROPERTY ENVIRONMENT
-                "LATENCY_TEST_BIN=$<TARGET_FILE:LatencyTest>")
+            set_property(TEST VideoTest APPEND PROPERTY ENVIRONMENT
+                "VIDEO_TEST_BIN=$<TARGET_FILE:VideoTest>")
             if(SECURITY)
-                set_property(TEST LatencyTest APPEND PROPERTY ENVIRONMENT
-                    "CERTS_PATH=${PROJECT_SOURCE_DIR}/test/certs")
-            endif()
-
-            ###############################################################################
-            # ThroughputTest16
-            ###############################################################################
-            add_test(NAME ThroughputTest16
-                COMMAND ${PYTHON_EXECUTABLE} ${CMAKE_CURRENT_SOURCE_DIR}/throughput_tests.py 16)
-
-            # Set test with label NoMemoryCheck
-            set_property(TEST ThroughputTest16 PROPERTY LABELS "NoMemoryCheck")
-
-            if(WIN32)
-                set_property(TEST ThroughputTest16 PROPERTY ENVIRONMENT
-                    "PATH=$<TARGET_FILE_DIR:${PROJECT_NAME}>\\;$ENV{PATH}")
-            endif()
-            set_property(TEST ThroughputTest16 APPEND PROPERTY ENVIRONMENT
-                "THROUGHPUT_TEST_BIN=$<TARGET_FILE:ThroughputTest>")
-            set_property(TEST ThroughputTest16 APPEND PROPERTY ENVIRONMENT
-                "CMAKE_CURRENT_SOURCE_DIR=${CMAKE_CURRENT_SOURCE_DIR}")
-            if(SECURITY)
-                set_property(TEST ThroughputTest16 APPEND PROPERTY ENVIRONMENT
-                    "CERTS_PATH=${PROJECT_SOURCE_DIR}/test/certs")
-            endif()
-
-            ###############################################################################
-            # ThroughputTest32
-            ###############################################################################
-            add_test(NAME ThroughputTest32
-                COMMAND ${PYTHON_EXECUTABLE} ${CMAKE_CURRENT_SOURCE_DIR}/throughput_tests.py 32)
-
-            # Set test with label NoMemoryCheck
-            set_property(TEST ThroughputTest32 PROPERTY LABELS "NoMemoryCheck")
-
-            if(WIN32)
-                set_property(TEST ThroughputTest32 PROPERTY ENVIRONMENT
-                    "PATH=$<TARGET_FILE_DIR:${PROJECT_NAME}>\\;$ENV{PATH}")
-            endif()
-            set_property(TEST ThroughputTest32 APPEND PROPERTY ENVIRONMENT
-                "THROUGHPUT_TEST_BIN=$<TARGET_FILE:ThroughputTest>")
-            set_property(TEST ThroughputTest32 APPEND PROPERTY ENVIRONMENT
-                "CMAKE_CURRENT_SOURCE_DIR=${CMAKE_CURRENT_SOURCE_DIR}")
-            if(SECURITY)
-                set_property(TEST ThroughputTest32 APPEND PROPERTY ENVIRONMENT
-                    "CERTS_PATH=${PROJECT_SOURCE_DIR}/test/certs")
-            endif()
-
-            ###############################################################################
-            # ThroughputTest64
-            ###############################################################################
-            add_test(NAME ThroughputTest64
-                COMMAND ${PYTHON_EXECUTABLE} ${CMAKE_CURRENT_SOURCE_DIR}/throughput_tests.py 64)
-
-            # Set test with label NoMemoryCheck
-            set_property(TEST ThroughputTest64 PROPERTY LABELS "NoMemoryCheck")
-
-            if(WIN32)
-                set_property(TEST ThroughputTest64 PROPERTY ENVIRONMENT
-                    "PATH=$<TARGET_FILE_DIR:${PROJECT_NAME}>\\;$ENV{PATH}")
-            endif()
-            set_property(TEST ThroughputTest64 APPEND PROPERTY ENVIRONMENT
-                "THROUGHPUT_TEST_BIN=$<TARGET_FILE:ThroughputTest>")
-            set_property(TEST ThroughputTest64 APPEND PROPERTY ENVIRONMENT
-                "CMAKE_CURRENT_SOURCE_DIR=${CMAKE_CURRENT_SOURCE_DIR}")
-            if(SECURITY)
-                set_property(TEST ThroughputTest64 APPEND PROPERTY ENVIRONMENT
-                    "CERTS_PATH=${PROJECT_SOURCE_DIR}/test/certs")
-            endif()
-
-            ###############################################################################
-            # ThroughputTest128
-            ###############################################################################
-            add_test(NAME ThroughputTest128
-                COMMAND ${PYTHON_EXECUTABLE} ${CMAKE_CURRENT_SOURCE_DIR}/throughput_tests.py 128)
-
-            # Set test with label NoMemoryCheck
-            set_property(TEST ThroughputTest128 PROPERTY LABELS "NoMemoryCheck")
-
-            if(WIN32)
-                set_property(TEST ThroughputTest128 PROPERTY ENVIRONMENT
-                    "PATH=$<TARGET_FILE_DIR:${PROJECT_NAME}>\\;$ENV{PATH}")
-            endif()
-            set_property(TEST ThroughputTest128 APPEND PROPERTY ENVIRONMENT
-                "THROUGHPUT_TEST_BIN=$<TARGET_FILE:ThroughputTest>")
-            set_property(TEST ThroughputTest128 APPEND PROPERTY ENVIRONMENT
-                "CMAKE_CURRENT_SOURCE_DIR=${CMAKE_CURRENT_SOURCE_DIR}")
-            if(SECURITY)
-                set_property(TEST ThroughputTest128 APPEND PROPERTY ENVIRONMENT
-                    "CERTS_PATH=${PROJECT_SOURCE_DIR}/test/certs")
-            endif()
-
-            ###############################################################################
-            # ThroughputTest256
-            ###############################################################################
-            add_test(NAME ThroughputTest256
-                COMMAND ${PYTHON_EXECUTABLE} ${CMAKE_CURRENT_SOURCE_DIR}/throughput_tests.py 256)
-
-            # Set test with label NoMemoryCheck
-            set_property(TEST ThroughputTest256 PROPERTY LABELS "NoMemoryCheck")
-
-            if(WIN32)
-                set_property(TEST ThroughputTest256 PROPERTY ENVIRONMENT
-                    "PATH=$<TARGET_FILE_DIR:${PROJECT_NAME}>\\;$ENV{PATH}")
-            endif()
-            set_property(TEST ThroughputTest256 APPEND PROPERTY ENVIRONMENT
-                "THROUGHPUT_TEST_BIN=$<TARGET_FILE:ThroughputTest>")
-            set_property(TEST ThroughputTest256 APPEND PROPERTY ENVIRONMENT
-                "CMAKE_CURRENT_SOURCE_DIR=${CMAKE_CURRENT_SOURCE_DIR}")
-            if(SECURITY)
-                set_property(TEST ThroughputTest256 APPEND PROPERTY ENVIRONMENT
-                    "CERTS_PATH=${PROJECT_SOURCE_DIR}/test/certs")
-            endif()
-
-            ###############################################################################
-            # ThroughputTest512
-            ###############################################################################
-            add_test(NAME ThroughputTest512
-                COMMAND ${PYTHON_EXECUTABLE} ${CMAKE_CURRENT_SOURCE_DIR}/throughput_tests.py 512)
-
-            # Set test with label NoMemoryCheck
-            set_property(TEST ThroughputTest512 PROPERTY LABELS "NoMemoryCheck")
-
-            if(WIN32)
-                set_property(TEST ThroughputTest512 PROPERTY ENVIRONMENT
-                    "PATH=$<TARGET_FILE_DIR:${PROJECT_NAME}>\\;$ENV{PATH}")
-            endif()
-            set_property(TEST ThroughputTest512 APPEND PROPERTY ENVIRONMENT
-                "THROUGHPUT_TEST_BIN=$<TARGET_FILE:ThroughputTest>")
-            set_property(TEST ThroughputTest512 APPEND PROPERTY ENVIRONMENT
-                "CMAKE_CURRENT_SOURCE_DIR=${CMAKE_CURRENT_SOURCE_DIR}")
-            if(SECURITY)
-                set_property(TEST ThroughputTest512 APPEND PROPERTY ENVIRONMENT
-                    "CERTS_PATH=${PROJECT_SOURCE_DIR}/test/certs")
-            endif()
-
-            ###############################################################################
-            # ThroughputTest1024
-            ###############################################################################
-            add_test(NAME ThroughputTest1024
-                COMMAND ${PYTHON_EXECUTABLE} ${CMAKE_CURRENT_SOURCE_DIR}/throughput_tests.py 1024)
-
-            # Set test with label NoMemoryCheck
-            set_property(TEST ThroughputTest1024 PROPERTY LABELS "NoMemoryCheck")
-
-            if(WIN32)
-                set_property(TEST ThroughputTest1024 PROPERTY ENVIRONMENT
-                    "PATH=$<TARGET_FILE_DIR:${PROJECT_NAME}>\\;$ENV{PATH}")
-            endif()
-            set_property(TEST ThroughputTest1024 APPEND PROPERTY ENVIRONMENT
-                "THROUGHPUT_TEST_BIN=$<TARGET_FILE:ThroughputTest>")
-            set_property(TEST ThroughputTest1024 APPEND PROPERTY ENVIRONMENT
-                "CMAKE_CURRENT_SOURCE_DIR=${CMAKE_CURRENT_SOURCE_DIR}")
-            if(SECURITY)
-                set_property(TEST ThroughputTest1024 APPEND PROPERTY ENVIRONMENT
-                    "CERTS_PATH=${PROJECT_SOURCE_DIR}/test/certs")
-            endif()
-
-            ###############################################################################
-            # ThroughputTest2048
-            ###############################################################################
-            add_test(NAME ThroughputTest2048
-                COMMAND ${PYTHON_EXECUTABLE} ${CMAKE_CURRENT_SOURCE_DIR}/throughput_tests.py 2048)
-
-            # Set test with label NoMemoryCheck
-            set_property(TEST ThroughputTest2048 PROPERTY LABELS "NoMemoryCheck")
-
-            if(WIN32)
-                set_property(TEST ThroughputTest2048 PROPERTY ENVIRONMENT
-                    "PATH=$<TARGET_FILE_DIR:${PROJECT_NAME}>\\;$ENV{PATH}")
-            endif()
-            set_property(TEST ThroughputTest2048 APPEND PROPERTY ENVIRONMENT
-                "THROUGHPUT_TEST_BIN=$<TARGET_FILE:ThroughputTest>")
-            set_property(TEST ThroughputTest2048 APPEND PROPERTY ENVIRONMENT
-                "CMAKE_CURRENT_SOURCE_DIR=${CMAKE_CURRENT_SOURCE_DIR}")
-            if(SECURITY)
-                set_property(TEST ThroughputTest2048 APPEND PROPERTY ENVIRONMENT
-                    "CERTS_PATH=${PROJECT_SOURCE_DIR}/test/certs")
-            endif()
-
-            ###############################################################################
-            # ThroughputTest4096
-            ###############################################################################
-            add_test(NAME ThroughputTest4096
-                COMMAND ${PYTHON_EXECUTABLE} ${CMAKE_CURRENT_SOURCE_DIR}/throughput_tests.py 4096)
-
-            # Set test with label NoMemoryCheck
-            set_property(TEST ThroughputTest4096 PROPERTY LABELS "NoMemoryCheck")
-
-            if(WIN32)
-                set_property(TEST ThroughputTest4096 PROPERTY ENVIRONMENT
-                    "PATH=$<TARGET_FILE_DIR:${PROJECT_NAME}>\\;$ENV{PATH}")
-            endif()
-            set_property(TEST ThroughputTest4096 APPEND PROPERTY ENVIRONMENT
-                "THROUGHPUT_TEST_BIN=$<TARGET_FILE:ThroughputTest>")
-            set_property(TEST ThroughputTest4096 APPEND PROPERTY ENVIRONMENT
-                "CMAKE_CURRENT_SOURCE_DIR=${CMAKE_CURRENT_SOURCE_DIR}")
-            if(SECURITY)
-                set_property(TEST ThroughputTest4096 APPEND PROPERTY ENVIRONMENT
-                    "CERTS_PATH=${PROJECT_SOURCE_DIR}/test/certs")
-            endif()
-
-            ###############################################################################
-            # ThroughputTest8192
-            ###############################################################################
-            add_test(NAME ThroughputTest8192
-                COMMAND ${PYTHON_EXECUTABLE} ${CMAKE_CURRENT_SOURCE_DIR}/throughput_tests.py 8192)
-
-            # Set test with label NoMemoryCheck
-            set_property(TEST ThroughputTest8192 PROPERTY LABELS "NoMemoryCheck")
-
-            if(WIN32)
-                set_property(TEST ThroughputTest8192 PROPERTY ENVIRONMENT
-                    "PATH=$<TARGET_FILE_DIR:${PROJECT_NAME}>\\;$ENV{PATH}")
-            endif()
-            set_property(TEST ThroughputTest8192 APPEND PROPERTY ENVIRONMENT
-                "THROUGHPUT_TEST_BIN=$<TARGET_FILE:ThroughputTest>")
-            set_property(TEST ThroughputTest8192 APPEND PROPERTY ENVIRONMENT
-                "CMAKE_CURRENT_SOURCE_DIR=${CMAKE_CURRENT_SOURCE_DIR}")
-            if(SECURITY)
-                set_property(TEST ThroughputTest8192 APPEND PROPERTY ENVIRONMENT
-                    "CERTS_PATH=${PROJECT_SOURCE_DIR}/test/certs")
-            endif()
-
-            if(GST_FOUND)
-                ###############################################################################
-                # VideoTest
-                ###############################################################################
-                add_test(NAME VideoTest
-                    COMMAND ${PYTHON_EXECUTABLE} ${CMAKE_CURRENT_SOURCE_DIR}/video_tests.py)
-
-                # Set test with label NoMemoryCheck
-                set_property(TEST VideoTest PROPERTY LABELS "NoMemoryCheck")
-
-                if(WIN32)
-                    set_property(TEST VideoTest PROPERTY ENVIRONMENT
-                        "PATH=$<TARGET_FILE_DIR:${PROJECT_NAME}>\\;$ENV{PATH}")
-                endif()
                 set_property(TEST VideoTest APPEND PROPERTY ENVIRONMENT
-                    "VIDEO_TEST_BIN=$<TARGET_FILE:VideoTest>")
-                if(SECURITY)
-                    set_property(TEST VideoTest APPEND PROPERTY ENVIRONMENT
-                        "CERTS_PATH=${PROJECT_SOURCE_DIR}/test/certs")
-                endif()
+                    "CERTS_PATH=${PROJECT_SOURCE_DIR}/test/certs")
             endif()
-
         endif()
+
     endif()
 endif()

--- a/test/profiling/CMakeLists.txt
+++ b/test/profiling/CMakeLists.txt
@@ -13,85 +13,83 @@
 # limitations under the License.
 
 if(NOT ((MSVC OR MSVC_IDE) AND EPROSIMA_INSTALLER))
-    if(PROFILING_TESTS)
-        find_package(Threads REQUIRED)
+    find_package(Threads REQUIRED)
+
+    if(WIN32)
+        target_compile_definitions(${PROJECT_NAME} PRIVATE
+            $<$<AND:$<BOOL:${WIN32}>,$<STREQUAL:"${CMAKE_SYSTEM_NAME}","WindowsStore">>:_WIN32_WINNT=0x0603>
+            $<$<AND:$<BOOL:${WIN32}>,$<NOT:$<STREQUAL:"${CMAKE_SYSTEM_NAME}","WindowsStore">>>:_WIN32_WINNT=0x0601>
+            )
+    endif()
+
+    add_definitions(
+        -DBOOST_ASIO_STANDALONE
+        -DASIO_STANDALONE
+        )
+
+    include_directories(${ASIO_INCLUDE_DIR})
+
+    ###############################################################################
+    # Binaries
+    ###############################################################################
+    set(MEMORYTEST_SOURCE MemoryTestPublisher.cpp
+        MemoryTestSubscriber.cpp
+        MemoryTestTypes.cpp
+        main_MemoryTest.cpp
+        )
+    add_executable(MemoryTest ${MEMORYTEST_SOURCE})
+    target_link_libraries(MemoryTest fastrtps ${CMAKE_THREAD_LIBS_INIT} ${CMAKE_DL_LIBS})
+
+    configure_file("cycles_tests.py" "cycles_tests.py")
+    configure_file("memory_tests.py" "memory_tests.py")
+    configure_file("memory_analysis.py" "memory_analysis.py")
+
+    find_package(PythonInterp 3 REQUIRED)
+
+    if(PYTHONINTERP_FOUND)
+        ###############################################################################
+        # MemoryTest
+        ###############################################################################
+        add_test(NAME MemoryTest
+            COMMAND ${PYTHON_EXECUTABLE} memory_tests.py)
+
+        # Set test with label NoMemoryCheck
+        set_property(TEST MemoryTest PROPERTY LABELS "NoMemoryCheck")
 
         if(WIN32)
-            target_compile_definitions(${PROJECT_NAME} PRIVATE
-                $<$<AND:$<BOOL:${WIN32}>,$<STREQUAL:"${CMAKE_SYSTEM_NAME}","WindowsStore">>:_WIN32_WINNT=0x0603>
-                $<$<AND:$<BOOL:${WIN32}>,$<NOT:$<STREQUAL:"${CMAKE_SYSTEM_NAME}","WindowsStore">>>:_WIN32_WINNT=0x0601>
-                )
+            set_property(TEST MemoryTest PROPERTY ENVIRONMENT
+                "PATH=$<TARGET_FILE_DIR:${PROJECT_NAME}>\\;$ENV{PATH}")
+        endif()
+        set_property(TEST MemoryTest APPEND PROPERTY ENVIRONMENT
+            "PROFILING_BINS=$<TARGET_FILE:MemoryTest>")
+        set_property(TEST MemoryTest APPEND PROPERTY ENVIRONMENT
+            "VALGRIND_BIN=${CTEST_MEMORYCHECK_COMMAND}")
+        if(SECURITY)
+            set_property(TEST MemoryTest APPEND PROPERTY ENVIRONMENT
+                "CERTS_PATH=${PROJECT_SOURCE_DIR}/test/certs")
         endif()
 
-        add_definitions(
-            -DBOOST_ASIO_STANDALONE
-            -DASIO_STANDALONE
-            )
-
-        include_directories(${ASIO_INCLUDE_DIR})
-
         ###############################################################################
-        # Binaries
+        # CyclesTest
         ###############################################################################
-        set(MEMORYTEST_SOURCE MemoryTestPublisher.cpp
-            MemoryTestSubscriber.cpp
-            MemoryTestTypes.cpp
-            main_MemoryTest.cpp
-            )
-        add_executable(MemoryTest ${MEMORYTEST_SOURCE})
-        target_link_libraries(MemoryTest fastrtps ${CMAKE_THREAD_LIBS_INIT} ${CMAKE_DL_LIBS})
+        add_test(NAME CyclesTest
+            COMMAND ${PYTHON_EXECUTABLE} cycles_tests.py)
 
-        configure_file("cycles_tests.py" "cycles_tests.py")
-        configure_file("memory_tests.py" "memory_tests.py")
-        configure_file("memory_analysis.py" "memory_analysis.py")
+        # Set test with label NoMemoryCheck
+        set_property(TEST CyclesTest PROPERTY LABELS "NoMemoryCheck")
 
-        find_package(PythonInterp 3 REQUIRED)
-
-        if(PYTHONINTERP_FOUND)
-            ###############################################################################
-            # MemoryTest
-            ###############################################################################
-            add_test(NAME MemoryTest
-                COMMAND ${PYTHON_EXECUTABLE} memory_tests.py)
-
-            # Set test with label NoMemoryCheck
-            set_property(TEST MemoryTest PROPERTY LABELS "NoMemoryCheck")
-
-            if(WIN32)
-                set_property(TEST MemoryTest PROPERTY ENVIRONMENT
-                    "PATH=$<TARGET_FILE_DIR:${PROJECT_NAME}>\\;$ENV{PATH}")
-            endif()
-            set_property(TEST MemoryTest APPEND PROPERTY ENVIRONMENT
-                "PROFILING_BINS=$<TARGET_FILE:MemoryTest>")
-            set_property(TEST MemoryTest APPEND PROPERTY ENVIRONMENT
-                "VALGRIND_BIN=${CTEST_MEMORYCHECK_COMMAND}")
-            if(SECURITY)
-                set_property(TEST MemoryTest APPEND PROPERTY ENVIRONMENT
-                    "CERTS_PATH=${PROJECT_SOURCE_DIR}/test/certs")
-            endif()
-
-            ###############################################################################
-            # CyclesTest
-            ###############################################################################
-            add_test(NAME CyclesTest
-                COMMAND ${PYTHON_EXECUTABLE} cycles_tests.py)
-
-            # Set test with label NoMemoryCheck
-            set_property(TEST CyclesTest PROPERTY LABELS "NoMemoryCheck")
-
-            if(WIN32)
-                set_property(TEST CyclesTest PROPERTY ENVIRONMENT
-                    "PATH=$<TARGET_FILE_DIR:${PROJECT_NAME}>\\;$ENV{PATH}")
-            endif()
-            set_property(TEST CyclesTest APPEND PROPERTY ENVIRONMENT
-                "PROFILING_BINS=$<TARGET_FILE:MemoryTest>")
-            set_property(TEST CyclesTest APPEND PROPERTY ENVIRONMENT
-                "VALGRIND_BIN=valgrind")
-            if(SECURITY)
-                set_property(TEST CyclesTest APPEND PROPERTY ENVIRONMENT
-                    "CERTS_PATH=${PROJECT_SOURCE_DIR}/test/certs")
-            endif()
-
+        if(WIN32)
+            set_property(TEST CyclesTest PROPERTY ENVIRONMENT
+                "PATH=$<TARGET_FILE_DIR:${PROJECT_NAME}>\\;$ENV{PATH}")
         endif()
+        set_property(TEST CyclesTest APPEND PROPERTY ENVIRONMENT
+            "PROFILING_BINS=$<TARGET_FILE:MemoryTest>")
+        set_property(TEST CyclesTest APPEND PROPERTY ENVIRONMENT
+            "VALGRIND_BIN=valgrind")
+        if(SECURITY)
+            set_property(TEST CyclesTest APPEND PROPERTY ENVIRONMENT
+                "CERTS_PATH=${PROJECT_SOURCE_DIR}/test/certs")
+        endif()
+
     endif()
 endif()


### PR DESCRIPTION
Update the cmake files of FastRTPS tests to allow a way to build only the performance tests without the rest of tests