### PR TITLE
Fix deadlock on TCP

### DIFF
--- a/src/cpp/transport/TCPTransportInterface.cpp
+++ b/src/cpp/transport/TCPTransportInterface.cpp
@@ -761,7 +761,11 @@ bool TCPTransportInterface::Receive(TCPChannelResource *pChannelResource, octet*
 
                 if (bytes_received != TCPHeader::getSize())
                 {
-                    logError(RTCP_MSG_IN, "Bad TCP header size: " << bytes_received << "(expected: : " << TCPHeader::getSize() << ")");
+                    if (bytes_received > 0)
+                    {
+                        logError(RTCP_MSG_IN, "Bad TCP header size: " << bytes_received << "(expected: : " << TCPHeader::getSize() << ")" << ec);
+                    }
+                    CloseTCPSocket(pChannelResource);
                     success = false;
                 }
                 else


### PR DESCRIPTION
This PR fixes an error introduced by #285. When the socket is closed, the receive call returns 0 (i.e. 0 bytes were read) and the thread keeps looping because the channel has not been closed.