### PR TITLE
TCP bugfixing

### DIFF
--- a/include/fastrtps/rtps/common/Types.h
+++ b/include/fastrtps/rtps/common/Types.h
@@ -113,8 +113,12 @@ struct RTPS_DllAPI ProtocolVersion_t
     octet m_major;
     octet m_minor;
     ProtocolVersion_t():
-        m_major(2),
-        m_minor(1)
+#if HAVE_SECURITY
+        // As imposed by DDSSEC11-93
+        ProtocolVersion_t(2,3)
+#else
+        ProtocolVersion_t(2,2)
+#endif
     {
 
     };
@@ -137,17 +141,22 @@ struct RTPS_DllAPI ProtocolVersion_t
     }
 };
 
+/**
+ * Prints a ProtocolVersion
+ * @param output Output Stream
+ * @param pv ProtocolVersion
+ * @return OStream.
+ */
+inline std::ostream& operator<<(std::ostream& output, const ProtocolVersion_t& pv){
+    return output << static_cast<int>(pv.m_major) << "." << static_cast<int>(pv.m_minor);
+}
+
 const ProtocolVersion_t c_ProtocolVersion_2_0(2,0);
 const ProtocolVersion_t c_ProtocolVersion_2_1(2,1);
 const ProtocolVersion_t c_ProtocolVersion_2_2(2,2);
 const ProtocolVersion_t c_ProtocolVersion_2_3(2,3);
 
-#if HAVE_SECURITY
-// As imposed by DDSSEC11-93
-const ProtocolVersion_t c_ProtocolVersion(2,3);
-#else
-const ProtocolVersion_t c_ProtocolVersion(2,2);
-#endif
+const ProtocolVersion_t c_ProtocolVersion;
 
 //!@brief Structure VendorId_t, specifying the vendor Id of the implementation.
 class VendorId_t

--- a/include/fastrtps/transport/tcp/RTCPMessageManager.h
+++ b/include/fastrtps/transport/tcp/RTCPMessageManager.h
@@ -32,6 +32,8 @@ namespace rtps {
 class TCPChannelResource;
 class TCPTransportInterface;
 
+const ProtocolVersion_t c_rtcpProtocolVersion = {1, 0};
+
 /**
  * Class RTCPMessageManager, process the received TCP messages.
  * @ingroup MANAGEMENT_MODULE
@@ -72,34 +74,34 @@ public:
     /** @name Process RTCP Message Methods.
     * These methods create RTPS messages for different types
     */
-    bool processBindConnectionRequest(TCPChannelResource *pChannelResource, const ConnectionRequest_t &request,
+    ResponseCode processBindConnectionRequest(TCPChannelResource *pChannelResource, const ConnectionRequest_t &request,
         const TCPTransactionId &transactionId, Locator_t &localLocator);
 
-    virtual bool processOpenLogicalPortRequest(TCPChannelResource *pChannelResource,
+    virtual ResponseCode processOpenLogicalPortRequest(TCPChannelResource *pChannelResource,
         const OpenLogicalPortRequest_t &request, const TCPTransactionId &transactionId);
 
     void processCheckLogicalPortsRequest(TCPChannelResource *pChannelResource,
         const CheckLogicalPortsRequest_t &request, const TCPTransactionId &transactionId);
 
-    bool processKeepAliveRequest(TCPChannelResource *pChannelResource, const KeepAliveRequest_t &request,
+    ResponseCode processKeepAliveRequest(TCPChannelResource *pChannelResource, const KeepAliveRequest_t &request,
         const TCPTransactionId &transactionId);
 
     void processLogicalPortIsClosedRequest(TCPChannelResource *pChannelResource,
         const LogicalPortIsClosedRequest_t &request, const TCPTransactionId &transactionId);
 
-    bool processBindConnectionResponse(TCPChannelResource *pChannelResource, const BindConnectionResponse_t &response,
-        const TCPTransactionId &transactionId);
+    ResponseCode processBindConnectionResponse(TCPChannelResource *pChannelResource,
+        const BindConnectionResponse_t &response, const TCPTransactionId &transactionId);
 
-    bool processCheckLogicalPortsResponse(TCPChannelResource *pChannelResource,
+    ResponseCode processCheckLogicalPortsResponse(TCPChannelResource *pChannelResource,
         const CheckLogicalPortsResponse_t &response, const TCPTransactionId &transactionId);
 
-    bool processOpenLogicalPortResponse(TCPChannelResource *pChannelResource, ResponseCode respCode,
+    ResponseCode processOpenLogicalPortResponse(TCPChannelResource *pChannelResource, ResponseCode respCode,
         const TCPTransactionId &transactionId, Locator_t &remoteLocator);
 
-    bool processKeepAliveResponse(TCPChannelResource *pChannelResource, ResponseCode respCode,
+    ResponseCode processKeepAliveResponse(TCPChannelResource *pChannelResource, ResponseCode respCode,
         const TCPTransactionId &transactionId);
 
-    bool processRTCPMessage(TCPChannelResource *ChannelResource, octet* receiveBuffer, size_t receivedSize);
+    ResponseCode processRTCPMessage(TCPChannelResource *ChannelResource, octet* receiveBuffer, size_t receivedSize);
 
     static uint32_t& addToCRC(uint32_t &crc, octet data);
 
@@ -152,6 +154,8 @@ protected:
 
     void fillHeaders(TCPCPMKind kind, const TCPTransactionId &transactionId, TCPControlMsgHeader &retCtrlHeader,
         TCPHeader &header, const SerializedPayload_t *payload = nullptr, const ResponseCode *respCode = nullptr);
+
+    bool isCompatibleProtocol(const ProtocolVersion_t &protocol) const;
 };
 } /* namespace rtps */
 } /* namespace fastrtps */

--- a/include/fastrtps/transport/tcp/test_RTCPMessageManager.h
+++ b/include/fastrtps/transport/tcp/test_RTCPMessageManager.h
@@ -44,7 +44,7 @@ public:
     void SetInvalidTransactionPercentage(uint8_t value) { mInvalidTransactionPercentage = value; }
     void SetLogicalPortsBlocked(std::vector<uint16_t> list) { mLogicalPortsBlocked = list; }
 
-    virtual bool processOpenLogicalPortRequest(TCPChannelResource *pChannelResource,
+    virtual ResponseCode processOpenLogicalPortRequest(TCPChannelResource *pChannelResource,
         const OpenLogicalPortRequest_t &request, const TCPTransactionId &transactionId) override;
 
 protected:

--- a/include/fastrtps/utils/System.h
+++ b/include/fastrtps/utils/System.h
@@ -1,0 +1,40 @@
+// Copyright 2018 Proyectos y Sistemas de Mantenimiento SL (eProsima).
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+/**
+ * @file System.h
+ *
+ */
+
+#ifndef _EPROSIMA_SYSTEM_UTILS_H
+#define _EPROSIMA_SYSTEM_UTILS_H
+#include "../fastrtps_dll.h"
+
+namespace eprosima {
+namespace fastrtps {
+/**
+ * Class System, to provide helper functions to access system information.
+ * @ingroup UTILITIES_MODULE
+ */
+class System
+{
+    public:
+        //! Returns current process identifier.
+        RTPS_DllAPI static int GetPID();
+};
+
+}
+} /* namespace eprosima */
+
+#endif /* _EPROSIMA_SYSTEM_UTILS_H */

--- a/src/cpp/CMakeLists.txt
+++ b/src/cpp/CMakeLists.txt
@@ -24,6 +24,7 @@ set(${PROJECT_NAME}_source_files
     utils/md5.cpp
     utils/StringMatching.cpp
     utils/IPLocator.cpp
+    utils/System.cpp
     rtps/resources/ResourceEvent.cpp
     rtps/resources/TimedEvent.cpp
     rtps/resources/TimedEventImpl.cpp

--- a/src/cpp/rtps/RTPSDomain.cpp
+++ b/src/cpp/rtps/RTPSDomain.cpp
@@ -30,6 +30,7 @@
 
 #include <fastrtps/utils/IPFinder.h>
 #include <fastrtps/utils/eClock.h>
+#include <fastrtps/utils/System.h>
 
 #include <fastrtps/rtps/writer/RTPSWriter.h>
 #include <fastrtps/rtps/reader/RTPSReader.h>
@@ -95,14 +96,7 @@ RTPSParticipant* RTPSDomain::createParticipant(RTPSParticipantAttributes& PParam
     }
 
     PParam.participantID = ID;
-    int pid;
-#if defined(__cplusplus_winrt)
-    pid = (int)GetCurrentProcessId();
-#elif defined(_WIN32)
-    pid = (int)_getpid();
-#else
-    pid = (int)getpid();
-#endif
+    int pid = System::GetPID();
     GuidPrefix_t guidP;
     LocatorList_t loc;
     IPFinder::getIP4Address(&loc);
@@ -252,6 +246,3 @@ bool RTPSDomain::removeRTPSReader(RTPSReader* reader)
 } /* namespace  rtps */
 } /* namespace  fastrtps */
 } /* namespace eprosima */
-
-
-

--- a/src/cpp/transport/tcp/test_RTCPMessageManager.cpp
+++ b/src/cpp/transport/tcp/test_RTCPMessageManager.cpp
@@ -48,7 +48,7 @@ TCPTransactionId test_RTCPMessageManager::getTransactionId()
     return TCPTransactionId();
 }
 
-bool test_RTCPMessageManager::processOpenLogicalPortRequest(TCPChannelResource *pChannelResource,
+ResponseCode test_RTCPMessageManager::processOpenLogicalPortRequest(TCPChannelResource *pChannelResource,
     const OpenLogicalPortRequest_t &request, const TCPTransactionId &transactionId)
 {
     if (std::find(mLogicalPortsBlocked.begin(), mLogicalPortsBlocked.end(), request.logicalPort()) !=
@@ -72,7 +72,7 @@ bool test_RTCPMessageManager::processOpenLogicalPortRequest(TCPChannelResource *
             sendData(pChannelResource, OPEN_LOGICAL_PORT_RESPONSE, transactionId, nullptr, RETCODE_OK);
         }
     }
-    return true;
+    return RETCODE_OK;
 }
 
 } /* namespace rtps */

--- a/src/cpp/utils/System.cpp
+++ b/src/cpp/utils/System.cpp
@@ -1,0 +1,24 @@
+#include <fastrtps/utils/System.h>
+
+#if defined(_WIN32)
+#include <process.h>
+#else
+#include <unistd.h>
+#endif
+
+namespace eprosima {
+namespace fastrtps {
+
+int System::GetPID()
+{
+#if defined(__cplusplus_winrt)
+    return (int)GetCurrentProcessId();
+#elif defined(_WIN32)
+    return (int)_getpid();
+#else
+    return (int)getpid();
+#endif
+}
+
+}
+}

--- a/test/unittest/transport/CMakeLists.txt
+++ b/test/unittest/transport/CMakeLists.txt
@@ -85,6 +85,7 @@ if(NOT ((MSVC OR MSVC_IDE) AND EPROSIMA_INSTALLER))
             ${PROJECT_SOURCE_DIR}/src/cpp/rtps/resources/TimedEvent.cpp
             ${PROJECT_SOURCE_DIR}/src/cpp/rtps/resources/TimedEventImpl.cpp
             ${PROJECT_SOURCE_DIR}/src/cpp/utils/md5.cpp
+            ${PROJECT_SOURCE_DIR}/src/cpp/utils/System.cpp
         )
 
         set(TCPV6TESTS_SOURCE
@@ -111,6 +112,7 @@ if(NOT ((MSVC OR MSVC_IDE) AND EPROSIMA_INSTALLER))
             ${PROJECT_SOURCE_DIR}/src/cpp/rtps/resources/TimedEvent.cpp
             ${PROJECT_SOURCE_DIR}/src/cpp/rtps/resources/TimedEventImpl.cpp
             ${PROJECT_SOURCE_DIR}/src/cpp/utils/md5.cpp
+            ${PROJECT_SOURCE_DIR}/src/cpp/utils/System.cpp
         )
 
         set(TEST_UDPV4TESTS_SOURCE
@@ -139,7 +141,7 @@ if(NOT ((MSVC OR MSVC_IDE) AND EPROSIMA_INSTALLER))
         add_executable(UDPv4Tests ${UDPV4TESTS_SOURCE})
         target_compile_definitions(UDPv4Tests PRIVATE FASTRTPS_NO_LIB)
         target_include_directories(UDPv4Tests PRIVATE
-            ${GTEST_INCLUDE_DIRS} ${GMOCK_INCLUDE_DIRS}            
+            ${GTEST_INCLUDE_DIRS} ${GMOCK_INCLUDE_DIRS}
             ${PROJECT_SOURCE_DIR}/test/mock/rtps/MessageReceiver
             ${PROJECT_SOURCE_DIR}/test/mock/rtps/ReceiverResource
             ${PROJECT_SOURCE_DIR}/include ${PROJECT_BINARY_DIR}/include)


### PR DESCRIPTION
- Fixed issue when server rejects a bind connection request due to protocol version causing the client to retry forever.
- Fixed protocol version used.
- Improved Fast-RTPS current protocol version management.
- Added possibility to expand both client and server behaviour on errors in RTCP while negotiation.
- Added "virtual physical port" on tcp clients instead of always report 0. This fixes several clients on the same machine issue.
- Added System.h file to utils folder as helper when retrieving system information.