### PR TITLE
Refs #3794. Fix compilation issues using Codeblocks for Windows [3810]

### DIFF
--- a/include/fastrtps/utils/eClock.h
+++ b/include/fastrtps/utils/eClock.h
@@ -22,19 +22,19 @@
 
 #if defined(_WIN32)
 #include <time.h>
-#include <windows.h> 
+#include <windows.h>
 #if defined(_MSC_VER) || defined(_MSC_EXTENSIONS)
   #define DELTA_EPOCH_IN_MICROSECS  11644473600000000Ui64
+
+struct timezone
+{
+    int  tz_minuteswest; /* minutes W of Greenwich */
+    int  tz_dsttime;     /* type of dst correction */
+};
 #else
   #define DELTA_EPOCH_IN_MICROSECS  11644473600000000ULL
 #endif
- 
-struct timezone 
-{
-  int  tz_minuteswest; /* minutes W of Greenwich */
-  int  tz_dsttime;     /* type of dst correction */
-};
- 
+
 
 #else
 #include <sys/time.h>

--- a/src/cpp/CMakeLists.txt
+++ b/src/cpp/CMakeLists.txt
@@ -194,7 +194,7 @@ else()
     set(HAVE_SECURITY 0)
 endif()
 
-if(WIN32)
+if(WIN32 AND (MSVC OR MSVC_IDE))
     list(APPEND ${PROJECT_NAME}_source_files
         ${PROJECT_SOURCE_DIR}/src/cpp/fastrtps.rc
         )


### PR DESCRIPTION
[Refs #3794](https://eprosima.easyredmine.com/issues/3794) Fix some issues trying to compile Fast-RTPS on Windows without Visual Studio