### PR TITLE
Fixing semaphore on stateful reader.

### DIFF
--- a/include/fastrtps/rtps/reader/StatefulReader.h
+++ b/include/fastrtps/rtps/reader/StatefulReader.h
@@ -185,7 +185,9 @@ class StatefulReader:public RTPSReader
         /*!
          * @remarks Nn thread-safe.
          */
-        bool findWriterProxy(const GUID_t& writerGUID, WriterProxy** WP);
+        bool findWriterProxy(const GUID_t& writerGUID, WriterProxy** wp);
+
+        void NotifyChanges(WriterProxy* wp);
 
         //!ReaderTimes of the StatefulReader.
         ReaderTimes m_times;


### PR DESCRIPTION
Joining duplicated code on new method and fixing post on reader history semaphore when processing heartbeats