### PR TITLE
Sending [n, n-1] heartbeat when history is empty

### DIFF
--- a/include/fastrtps/rtps/writer/StatefulWriter.h
+++ b/include/fastrtps/rtps/writer/StatefulWriter.h
@@ -184,8 +184,7 @@ namespace eprosima
                  * @brief Sends a heartbeat to a remote reader.
                  * @remarks This function is non thread-safe.
                  */
-                void send_heartbeat_to_nts(ReaderProxy& remoteReaderProxy, bool final = false,
-                        bool send_empty_history_info = false);
+                void send_heartbeat_to_nts(ReaderProxy& remoteReaderProxy, bool final = false);
 
                 void process_acknack(const GUID_t reader_guid, uint32_t ack_count,
                         const SequenceNumberSet_t& sn_set, bool final_flag);
@@ -193,7 +192,7 @@ namespace eprosima
                 private:
 
                 void send_heartbeat_nts_(const std::vector<GUID_t>& remote_readers, const LocatorList_t& locators,
-                        RTPSMessageGroup& message_group, bool final = false, bool send_empty_history_info = false);
+                        RTPSMessageGroup& message_group, bool final = false);
 
                 void check_acked_status();
 

--- a/src/cpp/rtps/messages/MessageReceiver.cpp
+++ b/src/cpp/rtps/messages/MessageReceiver.cpp
@@ -806,7 +806,7 @@ bool MessageReceiver::proc_Submsg_Heartbeat(CDRMessage_t* msg,SubmessageHeader_t
     SequenceNumber_t firstSN, lastSN;
     CDRMessage::readSequenceNumber(msg,&firstSN);
     CDRMessage::readSequenceNumber(msg,&lastSN);
-    if(lastSN < firstSN && lastSN != SequenceNumber_t(0, 0))
+    if(lastSN < firstSN && lastSN != firstSN-1)
     {
         logWarning(RTPS_MSG_IN, IDSTRING"Invalid Heartbeat received (" << firstSN << ") - (" <<
                 lastSN << "), ignoring");


### PR DESCRIPTION
This should fix #177 by sending [n, n-1] heartbeats when writer history is empty.