### PR TITLE
Fixing liveliness protection

### DIFF
--- a/include/fastrtps/rtps/builtin/liveliness/WLP.h
+++ b/include/fastrtps/rtps/builtin/liveliness/WLP.h
@@ -24,6 +24,7 @@
 
 #include "../../common/Time_t.h"
 #include "../../common/Locator.h"
+#include "../../common/Guid.h"
 
 namespace eprosima {
 namespace fastrtps{
@@ -43,6 +44,8 @@ class WLivelinessPeriodicAssertion;
 class WLPListener;
 class WriterHistory;
 class ReaderHistory;
+class ReaderProxyData;
+class WriterProxyData;
 
 /**
  * Class WLP that implements the Writer Liveliness Protocol described in the RTPS specification.
@@ -132,6 +135,14 @@ public:
     */
     WriterHistory* getBuiltinWriterHistory();
 	
+#if HAVE_SECURITY
+    bool pairing_remote_reader_with_local_writer_after_security(const GUID_t& local_writer,
+        const ReaderProxyData& remote_reader_data);
+
+    bool pairing_remote_writer_with_local_reader_after_security(const GUID_t& local_reader,
+        const WriterProxyData& remote_writer_data);
+#endif
+
 private:
 	//!Pointer to the local RTPSParticipant.
 	RTPSParticipantImpl* mp_participant;

--- a/src/cpp/rtps/participant/RTPSParticipantImpl.cpp
+++ b/src/cpp/rtps/participant/RTPSParticipantImpl.cpp
@@ -45,6 +45,7 @@
 #include <fastrtps/rtps/builtin/BuiltinProtocols.h>
 #include <fastrtps/rtps/builtin/discovery/participant/PDPSimple.h>
 #include <fastrtps/rtps/builtin/data/ParticipantProxyData.h>
+#include <fastrtps/rtps/builtin/liveliness/WLP.h>
 
 #include <fastrtps/utils/IPFinder.h>
 #include <fastrtps/utils/eClock.h>
@@ -1070,6 +1071,41 @@ bool RTPSParticipantImpl::networkFactoryHasRegisteredTransports() const
 {
     return m_network_Factory.numberOfRegisteredTransports() > 0;
 }
+
+#if HAVE_SECURITY
+bool RTPSParticipantImpl::pairing_remote_reader_with_local_writer_after_security(const GUID_t& local_writer,
+    const ReaderProxyData& remote_reader_data)
+{
+    bool return_value;
+
+    return_value = mp_builtinProtocols->mp_PDP->getEDP()->pairing_remote_reader_with_local_writer_after_security(
+        local_writer, remote_reader_data);
+    if (!return_value && mp_builtinProtocols->mp_WLP != nullptr)
+    {
+        return_value = mp_builtinProtocols->mp_WLP->pairing_remote_reader_with_local_writer_after_security(
+            local_writer, remote_reader_data);
+    }
+
+    return return_value;
+}
+
+bool RTPSParticipantImpl::pairing_remote_writer_with_local_reader_after_security(const GUID_t& local_reader,
+    const WriterProxyData& remote_writer_data)
+{
+    bool return_value;
+
+    return_value = mp_builtinProtocols->mp_PDP->getEDP()->pairing_remote_writer_with_local_reader_after_security(
+        local_reader, remote_writer_data);
+    if (!return_value && mp_builtinProtocols->mp_WLP != nullptr)
+    {
+        return_value = mp_builtinProtocols->mp_WLP->pairing_remote_writer_with_local_reader_after_security(
+            local_reader, remote_writer_data);
+    }
+
+    return return_value;
+}
+
+#endif
 
 PDPSimple* RTPSParticipantImpl::pdpsimple()
 {

--- a/src/cpp/rtps/participant/RTPSParticipantImpl.h
+++ b/src/cpp/rtps/participant/RTPSParticipantImpl.h
@@ -209,11 +209,18 @@ public:
     uint32_t calculateMaxDataSize(uint32_t length);
 
 #if HAVE_SECURITY
-        security::SecurityManager& security_manager() { return m_security_manager; }
+    security::SecurityManager& security_manager() { return m_security_manager; }
 
-        const security::ParticipantSecurityAttributes& security_attributes() { return security_attributes_; }
+    const security::ParticipantSecurityAttributes& security_attributes() { return security_attributes_; }
 
-        bool is_security_initialized() const { return m_security_manager_initialized; }
+    bool is_security_initialized() const { return m_security_manager_initialized; }
+
+    bool pairing_remote_reader_with_local_writer_after_security(const GUID_t& local_writer,
+        const ReaderProxyData& remote_reader_data);
+
+    bool pairing_remote_writer_with_local_reader_after_security(const GUID_t& local_reader,
+        const WriterProxyData& remote_writer_data);
+
 #endif
 
     PDPSimple* pdpsimple();

--- a/src/cpp/rtps/security/SecurityManager.cpp
+++ b/src/cpp/rtps/security/SecurityManager.cpp
@@ -1463,7 +1463,7 @@ void SecurityManager::process_participant_volatile_message_secure(const CacheCha
         }
         else
         {
-            logInfo(SECURITY, "Received Reader Cryptography message but not found local writer " <<
+            logError(SECURITY, "Received Reader Cryptography message but not found local writer " <<
                     message.destination_endpoint_key());
         }
         mutex_.unlock();
@@ -1471,7 +1471,7 @@ void SecurityManager::process_participant_volatile_message_secure(const CacheCha
         // If writer was found and setting of crypto tokens works, then tell core to match writer and reader.
         if(writer_guid != GUID_t::unknown())
         {
-            participant_->pdpsimple()->getEDP()->pairing_remote_reader_with_local_writer_after_security(writer_guid,
+            participant_->pairing_remote_reader_with_local_writer_after_security(writer_guid,
                     reader_data);
         }
     }
@@ -1531,7 +1531,7 @@ void SecurityManager::process_participant_volatile_message_secure(const CacheCha
         }
         else
         {
-            logInfo(SECURITY, "Received Writer Cryptography message but not found local reader " <<
+            logError(SECURITY, "Received Writer Cryptography message but not found local reader " <<
                     message.destination_endpoint_key());
         }
         mutex_.unlock();
@@ -1539,7 +1539,7 @@ void SecurityManager::process_participant_volatile_message_secure(const CacheCha
         // If reader was found and setting of crypto tokens works, then tell core to match reader and writer.
         if(reader_guid != GUID_t::unknown())
         {
-            participant_->pdpsimple()->getEDP()->pairing_remote_writer_with_local_reader_after_security(reader_guid,
+            participant_->pairing_remote_writer_with_local_reader_after_security(reader_guid,
                     writer_data);
         }
     }
@@ -2398,7 +2398,7 @@ bool SecurityManager::discovered_reader(const GUID_t& writer_guid, const GUID_t&
                         local_writer->second.associated_readers.emplace(remote_reader_data.guid(),
                             std::make_tuple(remote_reader_data, remote_reader_handle));
                         lock.unlock();
-                        participant_->pdpsimple()->getEDP()->pairing_remote_reader_with_local_writer_after_security(
+                        participant_->pairing_remote_reader_with_local_writer_after_security(
                             writer_guid, remote_reader_data);
                     }
                     else
@@ -2557,14 +2557,14 @@ bool SecurityManager::discovered_reader(const GUID_t& writer_guid, const GUID_t&
                         // If reader was found and setting of crypto tokens works, then tell core to match reader and writer.
                         if (local_reader_guid != GUID_t::unknown())
                         {
-                            participant_->pdpsimple()->getEDP()->pairing_remote_writer_with_local_reader_after_security(
+                            participant_->pairing_remote_writer_with_local_reader_after_security(
                                     local_reader_guid, writer_data);
                         }
 
                         // If writer was found and setting of crypto tokens works, then tell core to match writer and reader.
                         if (pairing_cause_pending_message)
                         {
-                            participant_->pdpsimple()->getEDP()->pairing_remote_reader_with_local_writer_after_security(
+                            participant_->pairing_remote_reader_with_local_writer_after_security(
                                     writer_guid, remote_reader_data);
                         }
                     }
@@ -2592,7 +2592,7 @@ bool SecurityManager::discovered_reader(const GUID_t& writer_guid, const GUID_t&
     else if(returned_value)
     {
         lock.unlock();
-        participant_->pdpsimple()->getEDP()->pairing_remote_reader_with_local_writer_after_security(
+        participant_->pairing_remote_reader_with_local_writer_after_security(
                 writer_guid, remote_reader_data);
     }
 
@@ -2706,7 +2706,7 @@ bool SecurityManager::discovered_writer(const GUID_t& reader_guid, const GUID_t&
                         local_reader->second.associated_writers.emplace(remote_writer_data.guid(),
                             std::make_tuple(remote_writer_data, remote_writer_handle));
                         lock.unlock();
-                        participant_->pdpsimple()->getEDP()->pairing_remote_writer_with_local_reader_after_security(
+                        participant_->pairing_remote_writer_with_local_reader_after_security(
                             reader_guid, remote_writer_data);
                     }
                     else
@@ -2866,14 +2866,14 @@ bool SecurityManager::discovered_writer(const GUID_t& reader_guid, const GUID_t&
                         // If writer was found and setting of crypto tokens works, then tell core to match writer and reader.
                         if (local_writer_guid != GUID_t::unknown())
                         {
-                            participant_->pdpsimple()->getEDP()->pairing_remote_reader_with_local_writer_after_security(
+                            participant_->pairing_remote_reader_with_local_writer_after_security(
                                     local_writer_guid, reader_data);
                         }
 
                         // If reader was found and setting of crypto tokens works, then tell core to match reader and writer.
                         if (pairing_cause_pending_message)
                         {
-                            participant_->pdpsimple()->getEDP()->pairing_remote_writer_with_local_reader_after_security(
+                            participant_->pairing_remote_writer_with_local_reader_after_security(
                                     reader_guid, remote_writer_data);
                         }
                     }
@@ -2901,7 +2901,7 @@ bool SecurityManager::discovered_writer(const GUID_t& reader_guid, const GUID_t&
     else if(returned_value)
     {
         lock.unlock();
-        participant_->pdpsimple()->getEDP()->pairing_remote_writer_with_local_reader_after_security(
+        participant_->pairing_remote_writer_with_local_reader_after_security(
                 reader_guid, remote_writer_data);
     }
 

--- a/test/mock/rtps/RTPSParticipantImpl/rtps/participant/RTPSParticipantImpl.h
+++ b/test/mock/rtps/RTPSParticipantImpl/rtps/participant/RTPSParticipantImpl.h
@@ -84,6 +84,10 @@ class RTPSParticipantImpl
 
 #if HAVE_SECURITY
         MOCK_CONST_METHOD0(security_attributes, const security::ParticipantSecurityAttributes&());
+		
+        MOCK_METHOD2(pairing_remote_reader_with_local_writer_after_security, bool(const GUID_t&, const ReaderProxyData&));
+
+        MOCK_METHOD2(pairing_remote_writer_with_local_reader_after_security,bool(const GUID_t&, const WriterProxyData& remote_writer_data));
 #endif
 
         MOCK_METHOD1(setGuid, void(GUID_t&));


### PR DESCRIPTION
Avoid error messages when matching builtin WLP endpoints.

```
2018-11-14 09:51:32.262 [SECURITY Error] Cannot find remote reader 9a.dd.34.40.e7.49.e8.ca.d9.2c.27.d|ff.2.0.c7 -> Function encode_writer_submessage
2018-11-14 09:51:32.262 [RTPS_WRITER Error] Cannot encrypt HEARTBEAT submessage for writer a0.4f.5e.5c.56.16.b2.6f.34.7c.29.1|ff.2.0.c2 -> Function add_heartbeat
```
