### PR TITLE
Return const ref to reduce copies/allocations

### DIFF
--- a/include/fastrtps/rtps/participant/RTPSParticipant.h
+++ b/include/fastrtps/rtps/participant/RTPSParticipant.h
@@ -135,7 +135,11 @@ class RTPS_DllAPI RTPSParticipant
      * Get a copy of the actual state of the RTPSParticipantParameters
      * @return RTPSParticipantAttributes copy of the params.
      */
+    /*
     RTPSParticipantAttributes getRTPSParticipantAttributes() const;
+    */
+
+    const RTPSParticipantAttributes& getRTPSParticipantAttributes() const;
 
     uint32_t getMaxMessageSize() const;
 

--- a/src/cpp/rtps/participant/RTPSParticipant.cpp
+++ b/src/cpp/rtps/participant/RTPSParticipant.cpp
@@ -87,7 +87,7 @@ bool RTPSParticipant::updateReader(RTPSReader* Reader,ReaderQos& rqos)
     return mp_impl->updateLocalReader(Reader, rqos);
 }
 
-std::pair<StatefulReader*,StatefulReader*> RTPSParticipant::getEDPReaders(){	
+std::pair<StatefulReader*,StatefulReader*> RTPSParticipant::getEDPReaders(){
     return mp_impl->getEDPReaders();
 }
 
@@ -95,7 +95,13 @@ std::vector<std::string> RTPSParticipant::getParticipantNames() const {
     return mp_impl->getParticipantNames();
 }
 
+/*
 RTPSParticipantAttributes RTPSParticipant::getRTPSParticipantAttributes() const {
+    return mp_impl->getRTPSParticipantAttributes();
+}
+*/
+
+const RTPSParticipantAttributes& RTPSParticipant::getRTPSParticipantAttributes() const {
     return mp_impl->getRTPSParticipantAttributes();
 }
 


### PR DESCRIPTION
Found when running memory audits on the `rmw` implementations:  there is a place where a copy is being used when a `const ref` should suffice, causing some additional allocations and frees:

```
 malloc  (not expected) 144 -> 0x5603f5f0c050
 malloc  (not expected) 24 -> 0x5603f9bf3d30
 malloc  (not expected) 144 -> 0x5603f8e5f720
 malloc  (not expected) 24 -> 0x5603f8e50180
 malloc  (not expected) 24 -> 0x5603f500ddf0
 malloc  (not expected) 38 -> 0x5603f51b01a0
 malloc  (not expected) 20 -> 0x5603f951bb20
 free    (not expected) 0x5603f951bb20
 free    (not expected) 0x5603f51b01a0
 free    (not expected) 0x5603f500ddf0
 free    (not expected) 0x5603f8e50180
 free    (not expected) 0x5603f8e5f720
 free    (not expected) 0x5603f9bf3d30
 free    (not expected) 0x5603f5f0c050
```

In https://github.com/eProsima/Fast-RTPS/blob/master/src/cpp/publisher/PublisherImpl.cpp#L128, when the `RTPSParticipantAttributes` are retrieved, a copy is returned, rather than a reference or const reference.

As far as I could tell, the copy variant of the method wasn't being used anywhere, so switching to the `const ref` version shouldn't cause issues.  If it is being used, then having multiple variations should be suitable.