### PR TITLE
Fixed TCP max msg size and TCPv4 Tests.

### DIFF
--- a/include/fastrtps/transport/TCPTransportInterface.h
+++ b/include/fastrtps/transport/TCPTransportInterface.h
@@ -250,7 +250,7 @@ private:
     {
         public:
 
-            bool in_use;
+            bool in_use = false;
 
             std::condition_variable cv;
     };

--- a/include/fastrtps/transport/TCPTransportInterface.h
+++ b/include/fastrtps/transport/TCPTransportInterface.h
@@ -265,9 +265,11 @@ protected:
     mutable std::mutex mSocketsMapMutex;
 
     std::map<uint16_t, std::vector<TCPAcceptor*>> mSocketAcceptors; // The Key is the "Physical Port"
+    std::vector<TCPAcceptor*> mDeletedAcceptors;
     std::map<Locator_t, TCPChannelResource*> mChannelResources; // The key is the "Physical locator"
     std::vector<TCPChannelResource*> mUnboundChannelResources; // Needed to avoid memory leaks if client doesn't bound
-    std::map<uint16_t, std::pair<TransportReceiverInterface*, ReceiverInUseCV*>> mReceiverResources; // The key is the logical port
+    // The key is the logical port
+    std::map<uint16_t, std::pair<TransportReceiverInterface*, ReceiverInUseCV*>> mReceiverResources;
 
     std::vector<TCPChannelResource*> mDeletedSocketsPool;
     std::recursive_mutex mDeletedSocketsPoolMutex;

--- a/test/unittest/transport/TCPv4Tests.cpp
+++ b/test/unittest/transport/TCPv4Tests.cpp
@@ -139,18 +139,18 @@ TEST_F(TCPv4Tests, send_and_receive_between_ports)
     std::regex filter("RTCP(?!_SEQ)");
     Log::SetCategoryFilter(filter);
     TCPv4TransportDescriptor recvDescriptor;
-    recvDescriptor.maxMessageSize = 5;
-    recvDescriptor.sendBufferSize = 5;
-    recvDescriptor.receiveBufferSize = 5;
+    //recvDescriptor.maxMessageSize = 5;
+    //recvDescriptor.sendBufferSize = 5;
+    //recvDescriptor.receiveBufferSize = 5;
     recvDescriptor.add_listener_port(g_default_port);
     recvDescriptor.wait_for_tcp_negotiation = true;
     TCPv4Transport receiveTransportUnderTest(recvDescriptor);
     receiveTransportUnderTest.init();
 
     TCPv4TransportDescriptor sendDescriptor;
-    sendDescriptor.maxMessageSize = 5;
-    sendDescriptor.sendBufferSize = 5;
-    sendDescriptor.receiveBufferSize = 5;
+    //sendDescriptor.maxMessageSize = 5;
+    //sendDescriptor.sendBufferSize = 5;
+    //sendDescriptor.receiveBufferSize = 5;
     sendDescriptor.wait_for_tcp_negotiation = true;
     TCPv4Transport sendTransportUnderTest(sendDescriptor);
     sendTransportUnderTest.init();
@@ -327,9 +327,9 @@ TEST_F(TCPv4Tests, send_and_receive_between_allowed_interfaces_ports)
             Log::SetCategoryFilter(filter);
             TCPv4TransportDescriptor recvDescriptor;
             recvDescriptor.interfaceWhiteList.emplace_back(IPLocator::toIPv4string(locator));
-            recvDescriptor.maxMessageSize = 5;
-            recvDescriptor.sendBufferSize = 5;
-            recvDescriptor.receiveBufferSize = 5;
+            //recvDescriptor.maxMessageSize = 5;
+            //recvDescriptor.sendBufferSize = 5;
+            //recvDescriptor.receiveBufferSize = 5;
             recvDescriptor.add_listener_port(g_default_port);
             recvDescriptor.wait_for_tcp_negotiation = true;
             TCPv4Transport receiveTransportUnderTest(recvDescriptor);
@@ -337,9 +337,9 @@ TEST_F(TCPv4Tests, send_and_receive_between_allowed_interfaces_ports)
 
             TCPv4TransportDescriptor sendDescriptor;
             sendDescriptor.interfaceWhiteList.emplace_back(IPLocator::toIPv4string(locator));
-            sendDescriptor.maxMessageSize = 5;
-            sendDescriptor.sendBufferSize = 5;
-            sendDescriptor.receiveBufferSize = 5;
+            //sendDescriptor.maxMessageSize = 5;
+            //sendDescriptor.sendBufferSize = 5;
+            //sendDescriptor.receiveBufferSize = 5;
             sendDescriptor.wait_for_tcp_negotiation = true;
             TCPv4Transport sendTransportUnderTest(sendDescriptor);
             sendTransportUnderTest.init();
@@ -404,9 +404,9 @@ TEST_F(TCPv4Tests, send_and_receive_between_allowed_localhost_interfaces_ports)
     Log::SetCategoryFilter(filter);
     TCPv4TransportDescriptor recvDescriptor;
     recvDescriptor.interfaceWhiteList.emplace_back("127.0.0.1");
-    recvDescriptor.maxMessageSize = 5;
-    recvDescriptor.sendBufferSize = 5;
-    recvDescriptor.receiveBufferSize = 5;
+    //recvDescriptor.maxMessageSize = 5;
+    //recvDescriptor.sendBufferSize = 5;
+    //recvDescriptor.receiveBufferSize = 5;
     recvDescriptor.add_listener_port(g_default_port);
     recvDescriptor.wait_for_tcp_negotiation = true;
     TCPv4Transport receiveTransportUnderTest(recvDescriptor);
@@ -414,9 +414,9 @@ TEST_F(TCPv4Tests, send_and_receive_between_allowed_localhost_interfaces_ports)
 
     TCPv4TransportDescriptor sendDescriptor;
     sendDescriptor.interfaceWhiteList.emplace_back("127.0.0.1");
-    sendDescriptor.maxMessageSize = 5;
-    sendDescriptor.sendBufferSize = 5;
-    sendDescriptor.receiveBufferSize = 5;
+    //sendDescriptor.maxMessageSize = 5;
+    //sendDescriptor.sendBufferSize = 5;
+    //sendDescriptor.receiveBufferSize = 5;
     sendDescriptor.wait_for_tcp_negotiation = true;
     TCPv4Transport sendTransportUnderTest(sendDescriptor);
     sendTransportUnderTest.init();
@@ -493,9 +493,9 @@ TEST_F(TCPv4Tests, send_and_receive_between_blocked_interfaces_ports)
             Log::SetCategoryFilter(filter);
             TCPv4TransportDescriptor recvDescriptor;
             recvDescriptor.interfaceWhiteList.emplace_back(IPLocator::toIPv4string(locator));
-            recvDescriptor.maxMessageSize = 5;
-            recvDescriptor.sendBufferSize = 5;
-            recvDescriptor.receiveBufferSize = 5;
+            //recvDescriptor.maxMessageSize = 5;
+            //recvDescriptor.sendBufferSize = 5;
+            //recvDescriptor.receiveBufferSize = 5;
             recvDescriptor.add_listener_port(g_default_port);
             recvDescriptor.wait_for_tcp_negotiation = true;
             TCPv4Transport receiveTransportUnderTest(recvDescriptor);
@@ -503,9 +503,9 @@ TEST_F(TCPv4Tests, send_and_receive_between_blocked_interfaces_ports)
 
             TCPv4TransportDescriptor sendDescriptor;
             sendDescriptor.interfaceWhiteList.emplace_back(IPLocator::toIPv4string(locator));
-            sendDescriptor.maxMessageSize = 5;
-            sendDescriptor.sendBufferSize = 5;
-            sendDescriptor.receiveBufferSize = 5;
+            //sendDescriptor.maxMessageSize = 5;
+            //sendDescriptor.sendBufferSize = 5;
+            //sendDescriptor.receiveBufferSize = 5;
             sendDescriptor.wait_for_tcp_negotiation = true;
             TCPv4Transport sendTransportUnderTest(sendDescriptor);
             sendTransportUnderTest.init();
@@ -597,9 +597,9 @@ TEST_F(TCPv4Tests, shrink_locator_lists)
 
 void TCPv4Tests::HELPER_SetDescriptorDefaults()
 {
-    descriptor.maxMessageSize = 5;
-    descriptor.sendBufferSize = 5;
-    descriptor.receiveBufferSize = 5;
+    //descriptor.maxMessageSize = 5;
+    //descriptor.sendBufferSize = 5;
+    //descriptor.receiveBufferSize = 5;
     descriptor.add_listener_port(g_default_port);
 }
 

--- a/test/unittest/transport/TCPv4Tests.cpp
+++ b/test/unittest/transport/TCPv4Tests.cpp
@@ -139,18 +139,12 @@ TEST_F(TCPv4Tests, send_and_receive_between_ports)
     std::regex filter("RTCP(?!_SEQ)");
     Log::SetCategoryFilter(filter);
     TCPv4TransportDescriptor recvDescriptor;
-    //recvDescriptor.maxMessageSize = 5;
-    //recvDescriptor.sendBufferSize = 5;
-    //recvDescriptor.receiveBufferSize = 5;
     recvDescriptor.add_listener_port(g_default_port);
     recvDescriptor.wait_for_tcp_negotiation = true;
     TCPv4Transport receiveTransportUnderTest(recvDescriptor);
     receiveTransportUnderTest.init();
 
     TCPv4TransportDescriptor sendDescriptor;
-    //sendDescriptor.maxMessageSize = 5;
-    //sendDescriptor.sendBufferSize = 5;
-    //sendDescriptor.receiveBufferSize = 5;
     sendDescriptor.wait_for_tcp_negotiation = true;
     TCPv4Transport sendTransportUnderTest(sendDescriptor);
     sendTransportUnderTest.init();
@@ -327,9 +321,6 @@ TEST_F(TCPv4Tests, send_and_receive_between_allowed_interfaces_ports)
             Log::SetCategoryFilter(filter);
             TCPv4TransportDescriptor recvDescriptor;
             recvDescriptor.interfaceWhiteList.emplace_back(IPLocator::toIPv4string(locator));
-            //recvDescriptor.maxMessageSize = 5;
-            //recvDescriptor.sendBufferSize = 5;
-            //recvDescriptor.receiveBufferSize = 5;
             recvDescriptor.add_listener_port(g_default_port);
             recvDescriptor.wait_for_tcp_negotiation = true;
             TCPv4Transport receiveTransportUnderTest(recvDescriptor);
@@ -337,9 +328,6 @@ TEST_F(TCPv4Tests, send_and_receive_between_allowed_interfaces_ports)
 
             TCPv4TransportDescriptor sendDescriptor;
             sendDescriptor.interfaceWhiteList.emplace_back(IPLocator::toIPv4string(locator));
-            //sendDescriptor.maxMessageSize = 5;
-            //sendDescriptor.sendBufferSize = 5;
-            //sendDescriptor.receiveBufferSize = 5;
             sendDescriptor.wait_for_tcp_negotiation = true;
             TCPv4Transport sendTransportUnderTest(sendDescriptor);
             sendTransportUnderTest.init();
@@ -404,9 +392,6 @@ TEST_F(TCPv4Tests, send_and_receive_between_allowed_localhost_interfaces_ports)
     Log::SetCategoryFilter(filter);
     TCPv4TransportDescriptor recvDescriptor;
     recvDescriptor.interfaceWhiteList.emplace_back("127.0.0.1");
-    //recvDescriptor.maxMessageSize = 5;
-    //recvDescriptor.sendBufferSize = 5;
-    //recvDescriptor.receiveBufferSize = 5;
     recvDescriptor.add_listener_port(g_default_port);
     recvDescriptor.wait_for_tcp_negotiation = true;
     TCPv4Transport receiveTransportUnderTest(recvDescriptor);
@@ -414,9 +399,6 @@ TEST_F(TCPv4Tests, send_and_receive_between_allowed_localhost_interfaces_ports)
 
     TCPv4TransportDescriptor sendDescriptor;
     sendDescriptor.interfaceWhiteList.emplace_back("127.0.0.1");
-    //sendDescriptor.maxMessageSize = 5;
-    //sendDescriptor.sendBufferSize = 5;
-    //sendDescriptor.receiveBufferSize = 5;
     sendDescriptor.wait_for_tcp_negotiation = true;
     TCPv4Transport sendTransportUnderTest(sendDescriptor);
     sendTransportUnderTest.init();
@@ -493,9 +475,6 @@ TEST_F(TCPv4Tests, send_and_receive_between_blocked_interfaces_ports)
             Log::SetCategoryFilter(filter);
             TCPv4TransportDescriptor recvDescriptor;
             recvDescriptor.interfaceWhiteList.emplace_back(IPLocator::toIPv4string(locator));
-            //recvDescriptor.maxMessageSize = 5;
-            //recvDescriptor.sendBufferSize = 5;
-            //recvDescriptor.receiveBufferSize = 5;
             recvDescriptor.add_listener_port(g_default_port);
             recvDescriptor.wait_for_tcp_negotiation = true;
             TCPv4Transport receiveTransportUnderTest(recvDescriptor);
@@ -503,9 +482,6 @@ TEST_F(TCPv4Tests, send_and_receive_between_blocked_interfaces_ports)
 
             TCPv4TransportDescriptor sendDescriptor;
             sendDescriptor.interfaceWhiteList.emplace_back(IPLocator::toIPv4string(locator));
-            //sendDescriptor.maxMessageSize = 5;
-            //sendDescriptor.sendBufferSize = 5;
-            //sendDescriptor.receiveBufferSize = 5;
             sendDescriptor.wait_for_tcp_negotiation = true;
             TCPv4Transport sendTransportUnderTest(sendDescriptor);
             sendTransportUnderTest.init();
@@ -597,9 +573,6 @@ TEST_F(TCPv4Tests, shrink_locator_lists)
 
 void TCPv4Tests::HELPER_SetDescriptorDefaults()
 {
-    //descriptor.maxMessageSize = 5;
-    //descriptor.sendBufferSize = 5;
-    //descriptor.receiveBufferSize = 5;
     descriptor.add_listener_port(g_default_port);
 }
 

--- a/test/unittest/transport/TCPv6Tests.cpp
+++ b/test/unittest/transport/TCPv6Tests.cpp
@@ -259,9 +259,6 @@ TEST_F(TCPv6Tests, send_to_loopback)
 
 void TCPv6Tests::HELPER_SetDescriptorDefaults()
 {
-    //descriptor.maxMessageSize = 5;
-    //descriptor.sendBufferSize = 5;
-    //descriptor.receiveBufferSize = 5;
 }
 
 int main(int argc, char **argv)

--- a/test/unittest/transport/TCPv6Tests.cpp
+++ b/test/unittest/transport/TCPv6Tests.cpp
@@ -259,9 +259,9 @@ TEST_F(TCPv6Tests, send_to_loopback)
 
 void TCPv6Tests::HELPER_SetDescriptorDefaults()
 {
-    descriptor.maxMessageSize = 5;
-    descriptor.sendBufferSize = 5;
-    descriptor.receiveBufferSize = 5;
+    //descriptor.maxMessageSize = 5;
+    //descriptor.sendBufferSize = 5;
+    //descriptor.receiveBufferSize = 5;
 }
 
 int main(int argc, char **argv)


### PR DESCRIPTION
- TCP internal buffers are now configured by maxMessageSize instead of socket sizes.
- If TCP detects a message bigger than its buffer capacity, now drops all the expected bytes that don't fit instead of trying to read a TCP header again.
- TCPv4 tests updated to use default message, and sockets buffer sizes.