### PR TITLE
Create Environment Variable for default XML file

### DIFF
--- a/include/fastrtps/xmlparser/XMLParserCommon.h
+++ b/include/fastrtps/xmlparser/XMLParserCommon.h
@@ -33,6 +33,7 @@ enum class XMLP_ret
 };
 
 
+extern const char* DEFAULT_FASTRTPS_ENV_VARIABLE;
 extern const char* DEFAULT_FASTRTPS_PROFILES;
 
 extern const char* ROOT;

--- a/include/fastrtps/xmlparser/XMLProfileManager.h
+++ b/include/fastrtps/xmlparser/XMLProfileManager.h
@@ -57,7 +57,7 @@ public:
     * Load the default profiles XML file.
     * @return XMLP_ret::XML_OK on success, XMLP_ret::XML_ERROR in other case.
     */
-    RTPS_DllAPI static XMLP_ret loadDefaultXMLFile();
+    RTPS_DllAPI static void loadDefaultXMLFile();
 
     /**
     * Load a profiles XML file.

--- a/src/cpp/xmlparser/XMLParserCommon.cpp
+++ b/src/cpp/xmlparser/XMLParserCommon.cpp
@@ -18,6 +18,7 @@ namespace eprosima {
 namespace fastrtps {
 namespace xmlparser {
 
+const char* DEFAULT_FASTRTPS_ENV_VARIABLE = "FASTRTPS_DEFAULT_PROFILES_FILE";
 const char* DEFAULT_FASTRTPS_PROFILES = "DEFAULT_FASTRTPS_PROFILES.xml";
 
 const char* ROOT = "dds";

--- a/src/cpp/xmlparser/XMLProfileManager.cpp
+++ b/src/cpp/xmlparser/XMLProfileManager.cpp
@@ -15,6 +15,7 @@
 #include <tinyxml2.h>
 #include <fastrtps/xmlparser/XMLProfileManager.h>
 #include <fastrtps/xmlparser/XMLTree.h>
+#include <cstdlib>
 
 namespace eprosima {
 namespace fastrtps {
@@ -104,6 +105,21 @@ void XMLProfileManager::getDefaultTopicAttributes(TopicAttributes& topic_attribu
 
 XMLP_ret XMLProfileManager::loadDefaultXMLFile()
 {
+#ifdef _WIN32
+	char* file_path = nullptr;
+	size_t size = 0;
+	if (_dupenv_s(&file_path, &size, DEFAULT_FASTRTPS_ENV_VARIABLE) == 0 && file_path != nullptr)
+	{
+		XMLP_ret result = loadXMLFile(file_path);
+		free(file_path);
+		return result;
+	}
+#else
+	if (const char* file_path = std::getenv(DEFAULT_FASTRTPS_ENV_VARIABLE))
+	{
+		return loadXMLFile(file_path);
+	}
+#endif
     return loadXMLFile(DEFAULT_FASTRTPS_PROFILES);
 }
 

--- a/src/cpp/xmlparser/XMLProfileManager.cpp
+++ b/src/cpp/xmlparser/XMLProfileManager.cpp
@@ -105,22 +105,25 @@ void XMLProfileManager::getDefaultTopicAttributes(TopicAttributes& topic_attribu
     topic_attributes = default_topic_attributes;
 }
 
-XMLP_ret XMLProfileManager::loadDefaultXMLFile()
+void XMLProfileManager::loadDefaultXMLFile()
 {
+    // Try to load the default XML file set with an environment variable.
 #ifdef _WIN32
-	char file_path[MAX_PATH];
-	size_t size = MAX_PATH;
-	if (getenv_s(&size, file_path, size, DEFAULT_FASTRTPS_ENV_VARIABLE) == 0 && size > 0)
-	{
-		return loadXMLFile(file_path);
-	}
+    char file_path[MAX_PATH];
+    size_t size = MAX_PATH;
+    if (getenv_s(&size, file_path, size, DEFAULT_FASTRTPS_ENV_VARIABLE) == 0 && size > 0)
+    {
+        loadXMLFile(file_path);
+    }
 #else
-	if (const char* file_path = std::getenv(DEFAULT_FASTRTPS_ENV_VARIABLE))
-	{
-		return loadXMLFile(file_path);
-	}
+    if (const char* file_path = std::getenv(DEFAULT_FASTRTPS_ENV_VARIABLE))
+    {
+        loadXMLFile(file_path);
+    }
 #endif
-    return loadXMLFile(DEFAULT_FASTRTPS_PROFILES);
+
+    // Try to load the default XML file.
+    loadXMLFile(DEFAULT_FASTRTPS_PROFILES);
 }
 
 XMLP_ret XMLProfileManager::loadXMLProfiles(tinyxml2::XMLElement& profiles)

--- a/src/cpp/xmlparser/XMLProfileManager.cpp
+++ b/src/cpp/xmlparser/XMLProfileManager.cpp
@@ -16,7 +16,9 @@
 #include <fastrtps/xmlparser/XMLProfileManager.h>
 #include <fastrtps/xmlparser/XMLTree.h>
 #include <cstdlib>
-
+#ifdef _WIN32
+#include <windows.h>
+#endif
 namespace eprosima {
 namespace fastrtps {
 namespace xmlparser {
@@ -106,13 +108,11 @@ void XMLProfileManager::getDefaultTopicAttributes(TopicAttributes& topic_attribu
 XMLP_ret XMLProfileManager::loadDefaultXMLFile()
 {
 #ifdef _WIN32
-	char* file_path = nullptr;
-	size_t size = 0;
-	if (_dupenv_s(&file_path, &size, DEFAULT_FASTRTPS_ENV_VARIABLE) == 0 && file_path != nullptr)
+	char file_path[MAX_PATH];
+	size_t size = MAX_PATH;
+	if (getenv_s(&size, file_path, size, DEFAULT_FASTRTPS_ENV_VARIABLE) == 0 && size > 0)
 	{
-		XMLP_ret result = loadXMLFile(file_path);
-		free(file_path);
-		return result;
+		return loadXMLFile(file_path);
 	}
 #else
 	if (const char* file_path = std::getenv(DEFAULT_FASTRTPS_ENV_VARIABLE))


### PR DESCRIPTION
[#Refs 3937](https://eprosima.easyredmine.com/issues/3937) Create the management to check if exists an environment variable to load the DEFAULT_FASTRTPS_PROFILES.xml. The name of the environment variable is **FASTRTPS_DEFAULT_PROFILES_FILE**
