### PR TITLE
Moved submessage IDs from defines to enum.

### DIFF
--- a/include/fastrtps/rtps/messages/RTPS_messages.h
+++ b/include/fastrtps/rtps/messages/RTPS_messages.h
@@ -29,19 +29,22 @@ namespace fastrtps{
 namespace rtps{
 
 // //!@brief Enumeration of the different Submessages types
-#define PAD 0x01
-#define ACKNACK 0x06
-#define HEARTBEAT 0x07
-#define GAP 0x08
-#define INFO_TS 0x09
-#define INFO_SRC 0x0c
-#define INFO_REPLY_IP4 0x0d
-#define INFO_DST 0x0e
-#define INFO_REPLY 0x0f
-#define NACK_FRAG 0x12
-#define HEARTBEAT_FRAG 0x13
-#define DATA 0x15
-#define DATA_FRAG 0x16
+enum SubmessageId : uint8_t
+{
+    PAD             = 0x01,
+    ACKNACK         = 0x06,
+    HEARTBEAT       = 0x07,
+    GAP             = 0x08,
+    INFO_TS         = 0x09,
+    INFO_SRC        = 0x0c,
+    INFO_REPLY_IP4  = 0x0d,
+    INFO_DST        = 0x0e,
+    INFO_REPLY      = 0x0f,
+    NACK_FRAG       = 0x12,
+    HEARTBEAT_FRAG  = 0x13,
+    DATA            = 0x15,
+    DATA_FRAG       = 0x16
+};
 
 //!@brief Structure Header_t, RTPS Message Header Structure.
 //!@ingroup COMMON_MODULE


### PR DESCRIPTION
This pull request move submessage IDs from defines to enum in order to avoid collision with the submessage IDs used in Micro XRCE-DDS Agent, and other potential collisions.  