### PR TITLE
Fixing security_info

### DIFF
--- a/src/cpp/rtps/builtin/data/ReaderProxyData.cpp
+++ b/src/cpp/rtps/builtin/data/ReaderProxyData.cpp
@@ -258,6 +258,7 @@ ParameterList_t ReaderProxyData::toParameterList()
         }
     }
 #if HAVE_SECURITY
+    if ((this->security_attributes_ != 0UL) || (this->plugin_security_attributes_ != 0UL))
     {
         ParameterEndpointSecurityInfo_t*p = new ParameterEndpointSecurityInfo_t();
         p->security_attributes = security_attributes_;

--- a/src/cpp/rtps/builtin/data/WriterProxyData.cpp
+++ b/src/cpp/rtps/builtin/data/WriterProxyData.cpp
@@ -268,6 +268,7 @@ ParameterList_t WriterProxyData::toParameterList()
         }
     }
 #if HAVE_SECURITY
+    if ((this->security_attributes_ != 0UL) || (this->plugin_security_attributes_ != 0UL))
     {
         ParameterEndpointSecurityInfo_t*p = new ParameterEndpointSecurityInfo_t();
         p->security_attributes = security_attributes_;

--- a/src/cpp/rtps/builtin/discovery/endpoint/EDP.cpp
+++ b/src/cpp/rtps/builtin/discovery/endpoint/EDP.cpp
@@ -76,8 +76,16 @@ bool EDP::newLocalReaderProxyData(RTPSReader* reader, const TopicAttributes& att
     rpd.m_qos = rqos;
     rpd.userDefinedId(reader->getAttributes().getUserDefinedID());
 #if HAVE_SECURITY
-    rpd.security_attributes_ = reader->getAttributes().security_attributes().mask();
-    rpd.plugin_security_attributes_ = reader->getAttributes().security_attributes().plugin_endpoint_attributes;
+    if (mp_RTPSParticipant->is_secure())
+    {
+        rpd.security_attributes_ = reader->getAttributes().security_attributes().mask();
+        rpd.plugin_security_attributes_ = reader->getAttributes().security_attributes().plugin_endpoint_attributes;
+    }
+    else
+    {
+        rpd.security_attributes_ = 0UL;
+        rpd.plugin_security_attributes_ = 0UL;
+    }
 #endif
     reader->m_acceptMessagesFromUnkownWriters = false;
 
@@ -158,8 +166,16 @@ bool EDP::newLocalWriterProxyData(RTPSWriter* writer, const TopicAttributes& att
     wpd.userDefinedId(writer->getAttributes().getUserDefinedID());
     wpd.persistence_guid(writer->getAttributes().persistence_guid);
 #if HAVE_SECURITY
-    wpd.security_attributes_ = writer->getAttributes().security_attributes().mask();
-    wpd.plugin_security_attributes_ = writer->getAttributes().security_attributes().plugin_endpoint_attributes;
+    if (mp_RTPSParticipant->is_secure())
+    {
+        wpd.security_attributes_ = writer->getAttributes().security_attributes().mask();
+        wpd.plugin_security_attributes_ = writer->getAttributes().security_attributes().plugin_endpoint_attributes;
+    }
+    else
+    {
+        wpd.security_attributes_ = 0UL;
+        wpd.plugin_security_attributes_ = 0UL;
+    }
 #endif
 
     if (att.getTopicDiscoveryKind() != NO_CHECK)
@@ -236,8 +252,16 @@ bool EDP::updatedLocalReader(RTPSReader* reader, const TopicAttributes& att, con
     rdata.m_qos.setQos(rqos, true);
     rdata.userDefinedId(reader->getAttributes().getUserDefinedID());
 #if HAVE_SECURITY
-    rdata.security_attributes_ = reader->getAttributes().security_attributes().mask();
-    rdata.plugin_security_attributes_ = reader->getAttributes().security_attributes().plugin_endpoint_attributes;
+    if (mp_RTPSParticipant->is_secure())
+    {
+        rdata.security_attributes_ = reader->getAttributes().security_attributes().mask();
+        rdata.plugin_security_attributes_ = reader->getAttributes().security_attributes().plugin_endpoint_attributes;
+    }
+    else
+    {
+        rdata.security_attributes_ = 0UL;
+        rdata.plugin_security_attributes_ = 0UL;
+    }
 #endif
 
     if(this->mp_PDP->addReaderProxyData(&rdata, pdata))
@@ -270,8 +294,16 @@ bool EDP::updatedLocalWriter(RTPSWriter* writer, const TopicAttributes& att, con
     wdata.userDefinedId(writer->getAttributes().getUserDefinedID());
     wdata.persistence_guid(writer->getAttributes().persistence_guid);
 #if HAVE_SECURITY
-    wdata.security_attributes_ = writer->getAttributes().security_attributes().mask();
-    wdata.plugin_security_attributes_ = writer->getAttributes().security_attributes().plugin_endpoint_attributes;
+    if (mp_RTPSParticipant->is_secure())
+    {
+        wdata.security_attributes_ = writer->getAttributes().security_attributes().mask();
+        wdata.plugin_security_attributes_ = writer->getAttributes().security_attributes().plugin_endpoint_attributes;
+    }
+    else
+    {
+        wdata.security_attributes_ = 0UL;
+        wdata.plugin_security_attributes_ = 0UL;
+    }
 #endif
 
     if(this->mp_PDP->addWriterProxyData(&wdata, pdata))

--- a/src/cpp/rtps/builtin/discovery/participant/PDPSimple.cpp
+++ b/src/cpp/rtps/builtin/discovery/participant/PDPSimple.cpp
@@ -198,9 +198,17 @@ void PDPSimple::initializeParticipantProxyData(ParticipantProxyData* participant
         mp_RTPSParticipant->security_manager().return_permissions_token(permissions_token);
     }
 
-    auto sec_attrs = mp_RTPSParticipant->security_attributes();
-    participant_data->security_attributes_ = sec_attrs.mask();
-    participant_data->plugin_security_attributes_ = sec_attrs.plugin_participant_attributes;
+    if (mp_RTPSParticipant->is_secure())
+    {
+        const security::ParticipantSecurityAttributes & sec_attrs = mp_RTPSParticipant->security_attributes();
+        participant_data->security_attributes_ = sec_attrs.mask();
+        participant_data->plugin_security_attributes_ = sec_attrs.plugin_participant_attributes;
+    }
+    else
+    {
+        participant_data->security_attributes_ = 0UL;
+        participant_data->plugin_security_attributes_ = 0UL;
+    }
 #endif
 }
 

--- a/src/cpp/rtps/participant/RTPSParticipantImpl.cpp
+++ b/src/cpp/rtps/participant/RTPSParticipantImpl.cpp
@@ -218,7 +218,7 @@ RTPSParticipantImpl::RTPSParticipantImpl(const RTPSParticipantAttributes& PParam
 #if HAVE_SECURITY
     // Start security
     // TODO(Ricardo) Get returned value in future.
-    m_security_manager_initialized = m_security_manager.init(security_attributes_, PParam.properties);
+    m_security_manager_initialized = m_security_manager.init(security_attributes_, PParam.properties, m_is_security_active);
 #endif
 
     //START BUILTIN PROTOCOLS

--- a/src/cpp/rtps/participant/RTPSParticipantImpl.h
+++ b/src/cpp/rtps/participant/RTPSParticipantImpl.h
@@ -215,6 +215,8 @@ public:
 
     bool is_security_initialized() const { return m_security_manager_initialized; }
 
+    bool is_secure() const { return m_is_security_active; }
+
     bool pairing_remote_reader_with_local_writer_after_security(const GUID_t& local_writer,
         const ReaderProxyData& remote_reader_data);
 
@@ -265,6 +267,8 @@ private:
         security::SecurityManager m_security_manager;
         // Security manager initialization result
         bool m_security_manager_initialized;
+        // Security activation flag
+        bool m_is_security_active;
 #endif
 
     //! Encapsulates all associated resources on a Receiving element.

--- a/src/cpp/rtps/security/SecurityManager.cpp
+++ b/src/cpp/rtps/security/SecurityManager.cpp
@@ -98,8 +98,10 @@ SecurityManager::~SecurityManager()
     destroy();
 }
 
-bool SecurityManager::init(ParticipantSecurityAttributes& attributes, const PropertyPolicy& participant_properties)
+bool SecurityManager::init(ParticipantSecurityAttributes& attributes, const PropertyPolicy& participant_properties, bool& security_activated)
 {
+    security_activated = false;
+
     SecurityException exception;
     domain_id_ = participant_->getRTPSParticipantAttributes().builtin.domainId;
 
@@ -248,6 +250,7 @@ bool SecurityManager::init(ParticipantSecurityAttributes& attributes, const Prop
                 if(create_entities())
                 {
                     logInfo(SECURITY, "Initialized security manager for participant " << participant_->getGuid());
+                    security_activated = true;
                     return true;
                 }
             }

--- a/src/cpp/rtps/security/SecurityManager.h
+++ b/src/cpp/rtps/security/SecurityManager.h
@@ -66,7 +66,8 @@ class SecurityManager
 
         ~SecurityManager();
 
-        bool init(ParticipantSecurityAttributes& attributes, const PropertyPolicy& participant_properties);
+        bool init(ParticipantSecurityAttributes& attributes, const PropertyPolicy& participant_properties, 
+            bool& security_activated);
 
         void destroy();
 

--- a/test/unittest/rtps/security/SecurityInitializationTests.cpp
+++ b/test/unittest/rtps/security/SecurityInitializationTests.cpp
@@ -25,7 +25,7 @@ TEST_F(SecurityTest, initialization_auth_nullptr)
     DefaultValue<const RTPSParticipantAttributes&>::Set(pattr);
     DefaultValue<const GUID_t&>::Set(guid);
 
-    ASSERT_TRUE(manager_.init(security_attributes_, participant_properties_));
+    ASSERT_TRUE(manager_.init(security_attributes_, participant_properties_, security_activated_));
 }
 
 TEST_F(SecurityTest, initialization_auth_failed)
@@ -36,7 +36,7 @@ TEST_F(SecurityTest, initialization_auth_failed)
     EXPECT_CALL(*auth_plugin_, validate_local_identity(_,_,_,_,_,_)).Times(1).
         WillOnce(Return(ValidationResult_t::VALIDATION_FAILED));
 
-    ASSERT_FALSE(manager_.init(security_attributes_, participant_properties_));
+    ASSERT_FALSE(manager_.init(security_attributes_, participant_properties_, security_activated_));
 }
 
 TEST_F(SecurityTest, initialization_register_local_participant_error)
@@ -50,7 +50,7 @@ TEST_F(SecurityTest, initialization_register_local_participant_error)
     EXPECT_CALL(crypto_plugin_->cryptokeyfactory_, register_local_participant(Ref(local_identity_handle_),_,_,_,_)).Times(1).
         WillOnce(Return(nullptr));
 
-    ASSERT_FALSE(manager_.init(security_attributes_, participant_properties_));
+    ASSERT_FALSE(manager_.init(security_attributes_, participant_properties_, security_activated_));
 }
 
 TEST_F(SecurityTest, initialization_fail_participant_stateless_message_writer)
@@ -69,7 +69,7 @@ TEST_F(SecurityTest, initialization_fail_participant_stateless_message_writer)
     EXPECT_CALL(participant_, createWriter_mock(_,_,_,_,_,_)).Times(1).
         WillOnce(Return(false));
 
-    ASSERT_FALSE(manager_.init(security_attributes_, participant_properties_));
+    ASSERT_FALSE(manager_.init(security_attributes_, participant_properties_, security_activated_));
 }
 
 TEST_F(SecurityTest, initialization_fail_participant_stateless_message_reader)
@@ -91,7 +91,7 @@ TEST_F(SecurityTest, initialization_fail_participant_stateless_message_reader)
     EXPECT_CALL(participant_, createReader_mock(_,_,_,_,_,_,_)).Times(1).
         WillOnce(Return(false));
 
-    ASSERT_FALSE(manager_.init(security_attributes_, participant_properties_));
+    ASSERT_FALSE(manager_.init(security_attributes_, participant_properties_, security_activated_));
 }
 
 TEST_F(SecurityTest, initialization_fail_participant_volatile_message_writer)
@@ -115,7 +115,7 @@ TEST_F(SecurityTest, initialization_fail_participant_volatile_message_writer)
     EXPECT_CALL(participant_, createReader_mock(_,_,_,_,_,_,_)).Times(1).
         WillOnce(DoAll(SetArgPointee<0>(stateless_reader), Return(true)));
 
-    ASSERT_FALSE(manager_.init(security_attributes_, participant_properties_));
+    ASSERT_FALSE(manager_.init(security_attributes_, participant_properties_, security_activated_));
 }
 
 TEST_F(SecurityTest, initialization_fail_participant_volatile_message_reader)
@@ -141,7 +141,7 @@ TEST_F(SecurityTest, initialization_fail_participant_volatile_message_reader)
         WillOnce(DoAll(SetArgPointee<0>(stateless_reader), Return(true))).
         WillOnce(Return(false));
 
-    ASSERT_FALSE(manager_.init(security_attributes_, participant_properties_));
+    ASSERT_FALSE(manager_.init(security_attributes_, participant_properties_, security_activated_));
 }
 
 TEST_F(SecurityTest, initialization_auth_retry)
@@ -171,7 +171,7 @@ TEST_F(SecurityTest, initialization_auth_retry)
     EXPECT_CALL(*auth_plugin_, return_identity_handle(&local_identity_handle_,_)).Times(1).
         WillOnce(Return(true));
 
-    ASSERT_TRUE(manager_.init(security_attributes_, participant_properties_));
+    ASSERT_TRUE(manager_.init(security_attributes_, participant_properties_, security_activated_));
 }
 
 

--- a/test/unittest/rtps/security/SecurityTests.hpp
+++ b/test/unittest/rtps/security/SecurityTests.hpp
@@ -131,7 +131,7 @@ class SecurityTest : public ::testing::Test
                 WillOnce(DoAll(SetArgPointee<0>(stateless_reader_), Return(true))).
                 WillOnce(DoAll(SetArgPointee<0>(volatile_reader_), Return(true)));
 
-            ASSERT_TRUE(manager_.init(security_attributes_, participant_properties_));
+            ASSERT_TRUE(manager_.init(security_attributes_, participant_properties_, security_activated_));
         }
 
         void initialization_auth_ok()
@@ -152,7 +152,7 @@ class SecurityTest : public ::testing::Test
             EXPECT_CALL(participant_, createReader_mock(_,_,_,_,_,_,_)).Times(1).
                 WillOnce(DoAll(SetArgPointee<0>(stateless_reader_), Return(true)));
 
-            ASSERT_TRUE(manager_.init(security_attributes_, participant_properties_));
+            ASSERT_TRUE(manager_.init(security_attributes_, participant_properties_, security_activated_));
         }
 
         void request_process_ok(CacheChange_t** request_message_change = nullptr)
@@ -356,6 +356,7 @@ class SecurityTest : public ::testing::Test
         ParticipantProxyData participant_data_;
         ParticipantSecurityAttributes security_attributes_;
         PropertyPolicy participant_properties_;
+        bool security_activated_;
 
 
         // Default Values


### PR DESCRIPTION
This fixes an issue in which a non-secure participant was sending security information on discovery when building with security.