### PR TITLE
Account for potential target namespace for tinyxml2 [4107]

### DIFF
--- a/cmake/modules/FindTinyXML2.cmake
+++ b/cmake/modules/FindTinyXML2.cmake
@@ -7,10 +7,12 @@ option(TINYXML2_FROM_SOURCE "Integrate TinyXML2 source code inside Fast RTPS" OF
 find_package(TinyXML2 CONFIG QUIET)
 if(TinyXML2_FOUND AND NOT THIRDPARTY)
     message(STATUS "Found TinyXML2: ${TinyXML2_DIR}")
-    if(NOT TINYXML2_LIBRARY AND TARGET tinyxml2::tinyxml2)
+    if(NOT TINYXML2_LIBRARY)
         # in this case, we're probably using TinyXML2 version 5.0.0 or greater
         # in which case tinyxml2 is an exported target and we should use that
-        set(TINYXML2_LIBRARY tinyxml2)
+        if(TARGET tinyxml2 OR TARGET tinyxml2::tinyxml2)
+          set(TINYXML2_LIBRARY tinyxml2)
+        endif()
     endif()
 else()
     if(THIRDPARTY OR ANDROID)

--- a/cmake/modules/FindTinyXML2.cmake
+++ b/cmake/modules/FindTinyXML2.cmake
@@ -10,7 +10,7 @@ if(TinyXML2_FOUND AND NOT THIRDPARTY)
     if(NOT TINYXML2_LIBRARY AND TARGET tinyxml2::tinyxml2)
         # in this case, we're probably using TinyXML2 version 5.0.0 or greater
         # in which case tinyxml2 is an exported target and we should use that
-        set(TINYXML2_LIBRARY tinyxml2::tinyxml2)
+        set(TINYXML2_LIBRARY tinyxml2)
     endif()
 else()
     if(THIRDPARTY OR ANDROID)

--- a/cmake/modules/FindTinyXML2.cmake
+++ b/cmake/modules/FindTinyXML2.cmake
@@ -10,8 +10,10 @@ if(TinyXML2_FOUND AND NOT THIRDPARTY)
     if(NOT TINYXML2_LIBRARY)
         # in this case, we're probably using TinyXML2 version 5.0.0 or greater
         # in which case tinyxml2 is an exported target and we should use that
-        if(TARGET tinyxml2 OR TARGET tinyxml2::tinyxml2)
+        if(TARGET tinyxml2)
           set(TINYXML2_LIBRARY tinyxml2)
+        elseif(TARGET tinyxml2::tinyxml2)
+          set(TINYXML2_LIBRARY tinyxml2::tinyxml2)
         endif()
     endif()
 else()

--- a/cmake/modules/FindTinyXML2.cmake
+++ b/cmake/modules/FindTinyXML2.cmake
@@ -7,10 +7,10 @@ option(TINYXML2_FROM_SOURCE "Integrate TinyXML2 source code inside Fast RTPS" OF
 find_package(TinyXML2 CONFIG QUIET)
 if(TinyXML2_FOUND AND NOT THIRDPARTY)
     message(STATUS "Found TinyXML2: ${TinyXML2_DIR}")
-    if(NOT TINYXML2_LIBRARY AND TARGET tinyxml2)
+    if(NOT TINYXML2_LIBRARY AND TARGET tinyxml2::tinyxml2)
         # in this case, we're probably using TinyXML2 version 5.0.0 or greater
         # in which case tinyxml2 is an exported target and we should use that
-        set(TINYXML2_LIBRARY tinyxml2)
+        set(TINYXML2_LIBRARY tinyxml2::tinyxml2)
     endif()
 else()
     if(THIRDPARTY OR ANDROID)

--- a/cmake/packaging/Config.cmake.in
+++ b/cmake/packaging/Config.cmake.in
@@ -23,6 +23,7 @@ set_and_check(@PROJECT_NAME@_INCLUDE_DIR "@PACKAGE_INCLUDE_INSTALL_DIR@")
 set_and_check(@PROJECT_NAME@_LIB_DIR "@PACKAGE_LIB_INSTALL_DIR@")
 
 find_package(fastcdr REQUIRED)
+find_package(TinyXML2 REQUIRED)
 @FASTRTPS_PACKAGE_OPT_DEPS@
 
 include(${CMAKE_CURRENT_LIST_DIR}/@PROJECT_NAME@-targets.cmake)

--- a/cmake/packaging/Config.cmake.in
+++ b/cmake/packaging/Config.cmake.in
@@ -23,7 +23,7 @@ set_and_check(@PROJECT_NAME@_INCLUDE_DIR "@PACKAGE_INCLUDE_INSTALL_DIR@")
 set_and_check(@PROJECT_NAME@_LIB_DIR "@PACKAGE_LIB_INSTALL_DIR@")
 
 find_package(fastcdr REQUIRED)
-find_package(TinyXML2 REQUIRED)
+find_package(TinyXML2 QUIET)
 @FASTRTPS_PACKAGE_OPT_DEPS@
 
 include(${CMAKE_CURRENT_LIST_DIR}/@PROJECT_NAME@-targets.cmake)


### PR DESCRIPTION
This change accounts for an added namespace in `tinyxml2`  > v7.0.0 (introduced in leethomason/tinyxml2#645)
