### PR TITLE
Forcing SO_REUSEPORT when defined. [4109]

### DIFF
--- a/src/cpp/transport/UDPv4Transport.cpp
+++ b/src/cpp/transport/UDPv4Transport.cpp
@@ -253,6 +253,10 @@ eProsimaUDPSocket UDPv4Transport::OpenAndBindInputSocket(const std::string& sIp,
     if (is_multicast)
     {
         getSocketPtr(socket)->set_option(ip::udp::socket::reuse_address(true));
+#if defined(SO_REUSEPORT)
+        getSocketPtr(socket)->set_option(asio::detail::socket_option::boolean<
+            ASIO_OS_DEF(SOL_SOCKET), SO_REUSEPORT>(true));
+#endif
     }
 
     getSocketPtr(socket)->bind(GenerateEndpoint(sIp, port));

--- a/src/cpp/transport/UDPv4Transport.cpp
+++ b/src/cpp/transport/UDPv4Transport.cpp
@@ -253,7 +253,7 @@ eProsimaUDPSocket UDPv4Transport::OpenAndBindInputSocket(const std::string& sIp,
     if (is_multicast)
     {
         getSocketPtr(socket)->set_option(ip::udp::socket::reuse_address(true));
-#if defined(SO_REUSEPORT)
+#if defined(__QNX__)
         getSocketPtr(socket)->set_option(asio::detail::socket_option::boolean<
             ASIO_OS_DEF(SOL_SOCKET), SO_REUSEPORT>(true));
 #endif

--- a/src/cpp/transport/UDPv6Transport.cpp
+++ b/src/cpp/transport/UDPv6Transport.cpp
@@ -254,6 +254,10 @@ eProsimaUDPSocket UDPv6Transport::OpenAndBindInputSocket(const std::string& sIp,
     if (is_multicast)
     {
         getSocketPtr(socket)->set_option(ip::udp::socket::reuse_address(true));
+#if defined(SO_REUSEPORT)
+        getSocketPtr(socket)->set_option(asio::detail::socket_option::boolean<
+            ASIO_OS_DEF(SOL_SOCKET), SO_REUSEPORT>(true));
+#endif
     }
 
     getSocketPtr(socket)->bind(GenerateEndpoint(sIp, port));

--- a/src/cpp/transport/UDPv6Transport.cpp
+++ b/src/cpp/transport/UDPv6Transport.cpp
@@ -254,7 +254,7 @@ eProsimaUDPSocket UDPv6Transport::OpenAndBindInputSocket(const std::string& sIp,
     if (is_multicast)
     {
         getSocketPtr(socket)->set_option(ip::udp::socket::reuse_address(true));
-#if defined(SO_REUSEPORT)
+#if defined(__QNX__)
         getSocketPtr(socket)->set_option(asio::detail::socket_option::boolean<
             ASIO_OS_DEF(SOL_SOCKET), SO_REUSEPORT>(true));
 #endif


### PR DESCRIPTION
This should fix #343 and fix #347 by forcing SO_REUSEPORT to be used alongside SO_REUSEADDRESS on all the platforms supporting it (including QNX)