### PR TITLE
Hotfix: Bringing back individual blackbox tests. [4112]

### DIFF
--- a/test/blackbox/CMakeLists.txt
+++ b/test/blackbox/CMakeLists.txt
@@ -97,10 +97,10 @@ if(NOT ((MSVC OR MSVC_IDE) AND EPROSIMA_INSTALLER) AND fastcdr_FOUND)
         ###############################################################################
         # Unit tests
         ###############################################################################
-        set(BLACKBOXTEST_TEST_SOURCE BlackboxTests.cpp
+        set(BLACKBOXTESTS_TEST_SOURCE BlackboxTests.cpp
             NetworkConf.cpp
             )
-        set(BLACKBOXTESTS_SOURCE ${BLACKBOXTEST_TEST_SOURCE}
+        set(BLACKBOXTESTS_SOURCE ${BLACKBOXTESTS_TEST_SOURCE}
             types/HelloWorld.cpp
             types/HelloWorldType.cpp
             types/String.cpp


### PR DESCRIPTION
This fixes an issue introduced on c9f0616cc435c6c91e5c3f7698415404bab58247 provoking the individual blackbox tests not being correctly added