### PR TITLE
Made participant id start on 1 instead of 0.

### DIFF
--- a/src/cpp/rtps/RTPSDomain.cpp
+++ b/src/cpp/rtps/RTPSDomain.cpp
@@ -41,7 +41,7 @@ namespace fastrtps{
 namespace rtps {
 
 std::mutex RTPSDomain::m_mutex;
-std::atomic<uint32_t> RTPSDomain::m_maxRTPSParticipantID(0);
+std::atomic<uint32_t> RTPSDomain::m_maxRTPSParticipantID(1);
 std::vector<RTPSDomain::t_p_RTPSParticipant> RTPSDomain::m_RTPSParticipants;
 std::set<uint32_t> RTPSDomain::m_RTPSParticipantIDs;
 


### PR DESCRIPTION
Although section 9.3.1.5 of the [RTPS standard](https://www.omg.org/spec/DDSI-RTPS/About-DDSI-RTPS/) does not impose a restriction on the guidPrefix value other than the first two bytes, it seems that other implementations may produce error output when certain part of the guidPrefix is all 0's (see ros2/ros2#621).

So in order to keep them happy, this hotfix ensures that participantId starts from 1 instead of 0.