### PR TITLE
Fix cmake thirdparty package not using THIRDPARTY_UPDATE

### DIFF
--- a/cmake/common/eprosima_libraries.cmake
+++ b/cmake/common/eprosima_libraries.cmake
@@ -77,17 +77,21 @@ macro(eprosima_find_thirdparty package thirdparty_name)
     if(NOT (EPROSIMA_INSTALLER AND (MSVC OR MSVC_IDE)))
 
         option(THIRDPARTY_${package} "Activate the use of internal thirdparty ${package}" OFF)
+        option(THIRDPARTY_UPDATE "Activate the auto update of internal thirdparties" ON)
 
         if(THIRDPARTY OR THIRDPARTY_${package})
-            execute_process(
-                COMMAND git submodule update --recursive --init "thirdparty/${thirdparty_name}"
-                WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}
-                RESULT_VARIABLE EXECUTE_RESULT
-                )
+            if(THIRDPARTY_UPDATE OR NOT EXISTS "${PROJECT_SOURCE_DIR}/thirdparty/${thirdparty_name}")
+                message(STATUS "${package} thirdparty is being updated...")
+                execute_process(
+                    COMMAND git submodule update --recursive --init "thirdparty/${thirdparty_name}"
+                    WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}
+                    RESULT_VARIABLE EXECUTE_RESULT
+                    )
 
-            if(EXECUTE_RESULT EQUAL 0)
-            else()
-                message(FATAL_ERROR "Cannot configure Git submodule ${package}")
+                if(EXECUTE_RESULT EQUAL 0)
+                else()
+                    message(FATAL_ERROR "Cannot configure Git submodule ${package}")
+                endif()
             endif()
             set(CMAKE_PREFIX_PATH ${CMAKE_PREFIX_PATH} ${PROJECT_SOURCE_DIR}/thirdparty/${thirdparty_name})
             set(CMAKE_PREFIX_PATH ${CMAKE_PREFIX_PATH} ${PROJECT_SOURCE_DIR}/thirdparty/${thirdparty_name}/${thirdparty_name})


### PR DESCRIPTION
### THIRDPARTY_UPDATE=OFF flag is being ignored by thirdparty packages

#### Steps to reproduce:
* git clone --recursive https://github.com/eProsima/Fast-RTPS.git
* mkdir build
* cd build
* cmake -DTHIRDPARTY=ON -DTHIRDPARTY_UPDATE=OFF ..

#### Expected result:
Configuration should be performed without a problem in a machine with no internet o with git not installed since you already downloaded everything needed with --recursive option.

#### Actual result:
Configuration fails with no internet or no git installed.

#### Proposed solution:
Use flag THIRDPARTY_UPDATE=OFF also in thirdparty not only in eprosima packages.

#### Successful Tests performed:
1) Configuration OK with internet access and git installed 
* git clone
* mkdir build;cd build
* cmake -DTHIRDPARTY=ON ..
2) Configuration OK with --recursive clone and no git 
* git clone --recursive
* [Rename /usr/bib/git to /usr/bin/git_backup] -> Simulates no git. 
* mkdir;cd build
* cmake -DTHIRDPARTY=ON -DTHIRDPARTY_UPDATE=OFF ..
3) Configuration FAILS with no git and simple clone (expected behaviour)
* git clone
* [Rename /usr/bib/git to /usr/bin/git_backup] -> Simulates no git. 
* mkdir build;cd build
* cmake -DTHIRDPARTY=ON -DTHIRDPARTY_UPDATE=OFF ..

#### Notes

If anything in the pull-request is not the standard way of the project please tell me! 