### PR TITLE
[#4021] Create a TCP Release callback

### DIFF
--- a/include/fastrtps/rtps/network/NetworkFactory.h
+++ b/include/fastrtps/rtps/network/NetworkFactory.h
@@ -134,6 +134,12 @@ class NetworkFactory
          * */
         bool fillDefaultUnicastLocator(Locator_t &locator, const RTPSParticipantAttributes& m_att) const;
 
+        /**
+        * Sets if the transports are going to retry sents on error.
+        * @param active Flag enable/disable the retry feature.
+        */
+        void setSendRetry(bool active);
+
     private:
 
         std::vector<std::unique_ptr<TransportInterface> > mRegisteredTransports;

--- a/include/fastrtps/transport/TCPTransportInterface.h
+++ b/include/fastrtps/transport/TCPTransportInterface.h
@@ -263,6 +263,7 @@ protected:
     std::shared_ptr<std::thread> ioServiceThread;
     RTCPMessageManager* mRTCPMessageManager;
     mutable std::mutex mSocketsMapMutex;
+    bool mSendRetryActive;
 
     std::map<uint16_t, std::vector<TCPAcceptor*>> mSocketAcceptors; // The Key is the "Physical Port"
     std::vector<TCPAcceptor*> mDeletedAcceptors;
@@ -338,6 +339,12 @@ protected:
     void Clean(); // Must be called on childs destructors!
 
     virtual void EndpointToLocator(const asio::ip::tcp::endpoint& endpoint, Locator_t& locator) const = 0;
+
+    /**
+    * Sets if the transports are going to retry sents on error.
+    * @param active Flag enable/disable the retry feature.
+    */
+    virtual void setSendRetry(bool active) override;
 };
 
 } // namespace rtps

--- a/include/fastrtps/transport/TransportInterface.h
+++ b/include/fastrtps/transport/TransportInterface.h
@@ -147,6 +147,12 @@ public:
         LocatorList_t& list) const = 0;
 
     virtual bool fillUnicastLocator(Locator_t &locator, uint32_t well_known_port) const = 0;
+
+    /**
+    * Sets if the transports are going to retry sents on error.
+    * @param active Flag enable/disable the retry feature.
+    */
+    virtual void setSendRetry(bool active) = 0;
 };
 
 } // namespace rtps

--- a/include/fastrtps/transport/UDPTransportInterface.h
+++ b/include/fastrtps/transport/UDPTransportInterface.h
@@ -180,6 +180,13 @@ protected:
     virtual void SetReceiveBufferSize(uint32_t size) = 0;
     virtual void SetSendBufferSize(uint32_t size) = 0;
     virtual void SetSocketOutbountInterface(eProsimaUDPSocket&, const std::string&) = 0;
+
+    /**
+    * Sets if the transports are going to retry sents on error.
+    * @param active Flag enable/disable the retry feature.
+    */
+    virtual void setSendRetry(bool /*active*/) override {};
+
     /*
         struct LocatorCompare {
         bool operator()(const Locator_t& lhs, const Locator_t& rhs) const

--- a/src/cpp/rtps/network/NetworkFactory.cpp
+++ b/src/cpp/rtps/network/NetworkFactory.cpp
@@ -277,6 +277,17 @@ bool NetworkFactory::fillDefaultUnicastLocator(Locator_t &locator, const RTPSPar
     return result;
 }
 
+/**
+* Sets if the transports are going to retry sents on error.
+* */
+void NetworkFactory::setSendRetry(bool active)
+{
+    for (auto& transport : mRegisteredTransports)
+    {
+        transport->setSendRetry(active);
+    }
+}
+
 uint16_t NetworkFactory::calculateWellKnownPort(const RTPSParticipantAttributes& att) const
 {
     return static_cast<uint16_t>(att.port.portBase +

--- a/src/cpp/rtps/participant/RTPSParticipantImpl.cpp
+++ b/src/cpp/rtps/participant/RTPSParticipantImpl.cpp
@@ -242,6 +242,9 @@ const std::vector<RTPSReader*>& RTPSParticipantImpl::getAllReaders() const
 
 RTPSParticipantImpl::~RTPSParticipantImpl()
 {
+    // Disable Retries on Transports
+    m_network_Factory.setSendRetry(false);
+
     // Safely abort threads.
     for(auto& block : m_receiverResourcelist)
     {


### PR DESCRIPTION
 Implement a new way to stop the retry system in TCP transports during the destruction of the participants.