### PR TITLE
New Allocation test [4259]

### DIFF
--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -40,8 +40,6 @@ if(NOT ((MSVC OR MSVC_IDE)) AND PROFILING_TESTS)
    if(CTEST_MEMORYCHECK_COMMAND)
       add_subdirectory(profiling)
    endif()
-
-   add_subdirectory(profiling/allocations)
 endif()
 
 ###############################################################################

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -40,6 +40,8 @@ if(NOT ((MSVC OR MSVC_IDE)) AND PROFILING_TESTS)
    if(CTEST_MEMORYCHECK_COMMAND)
       add_subdirectory(profiling)
    endif()
+
+   add_subdirectory(profiling/allocations)
 endif()
 
 ###############################################################################

--- a/test/profiling/CMakeLists.txt
+++ b/test/profiling/CMakeLists.txt
@@ -92,3 +92,5 @@ if(NOT ((MSVC OR MSVC_IDE) AND EPROSIMA_INSTALLER))
         endif()
     endif()
 endif()
+
+add_subdirectory(allocations)

--- a/test/profiling/allocations/AllocTestCommon.cpp
+++ b/test/profiling/allocations/AllocTestCommon.cpp
@@ -120,7 +120,7 @@ void undiscovery_finished()
 /**
  * Print memory profiling results.
  */
-void print_results(const std::string& entity, const std::string& config) 
+void print_results(const std::string& file_prefix, const std::string& entity, const std::string& config) 
 {
     std::stringstream output_stream;
     output_stream << "\"Phase 0 Allocations\", \"Phase 0 Deallocations\","
@@ -141,7 +141,7 @@ void print_results(const std::string& entity, const std::string& config)
     }
 
     std::ofstream outFile;
-    outFile.open("alloc_test_" + entity + "_" + config + ".csv");
+    outFile.open(file_prefix + "alloc_test_" + entity + "_" + config + ".csv");
     outFile << output_stream.str();
     outFile.close();
 }

--- a/test/profiling/allocations/AllocTestCommon.cpp
+++ b/test/profiling/allocations/AllocTestCommon.cpp
@@ -19,15 +19,120 @@
 
 #include "AllocTestCommon.h"
 
+#include <atomic>
+#include <iostream>
+
+#include "osrf_testing_tools_cpp/memory_tools/memory_tools.hpp"
+
+using MemoryToolsService = osrf_testing_tools_cpp::memory_tools::MemoryToolsService;
+
+namespace eprosima_profiling
+{
+
 /**
- * Used to run callgrind with --zero-before=callgrind_zero_count. 
+ * Used to run callgrind with --zero-before=*callgrind_zero_count. 
  * See http://valgrind.org/docs/manual/cl-manual.html#cl-manual.options.activity
  */
 void callgrind_zero_count() {}
 
 /**
- * Used to run callgrind with --dump-before=callgrind_dump. 
+ * Used to run callgrind with --dump-before=*callgrind_dump. 
  * See http://valgrind.org/docs/manual/cl-manual.html#cl-manual.options.activity
  */
 void callgrind_dump() {}
+
+static std::atomic_size_t g_allocations[4];
+static std::atomic_size_t g_deallocations[4];
+
+static std::atomic_size_t g_phase(0u);
+static std::atomic<std::atomic_size_t*> g_allocationsPtr(g_allocations);
+static std::atomic<std::atomic_size_t*> g_deallocationsPtr(g_deallocations);
+
+static void allocation_account (MemoryToolsService & service)
+{
+    (*g_allocationsPtr.load())++;
+    service.ignore();
+}
+
+static void deallocation_account (MemoryToolsService & service)
+{
+    (*g_deallocationsPtr.load())++;
+    service.ignore();
+}
+
+static void next_phase ()
+{
+    size_t new_phase = ++g_phase;
+    if(new_phase < 4)
+    {
+        g_allocationsPtr.store(&g_allocations[new_phase]);
+        g_deallocationsPtr.store(&g_deallocations[new_phase]);
+    }
+}
+
+/**
+ * Called when entities have been created. Memory profiling should begin.
+ */
+void entities_created() 
+{
+    // Initialize profiling library
+    osrf_testing_tools_cpp::memory_tools::initialize();
+
+    // Set callbacks
+    osrf_testing_tools_cpp::memory_tools::on_unexpected_malloc(allocation_account);
+    osrf_testing_tools_cpp::memory_tools::on_unexpected_calloc(allocation_account);
+    osrf_testing_tools_cpp::memory_tools::on_unexpected_realloc(allocation_account);
+    osrf_testing_tools_cpp::memory_tools::on_unexpected_free(deallocation_account);
+
+    // Start profiling
+    osrf_testing_tools_cpp::memory_tools::enable_monitoring_in_all_threads();
+    EXPECT_NO_MEMORY_OPERATIONS_BEGIN();
+
+    if(!osrf_testing_tools_cpp::memory_tools::is_working())
+    {
+        std::cerr << "Memory profiler not working!" << std::endl;
+    }
+}
+
+/**
+ * Called after remote entity has been discovered. Data exchange will start.
+ */
+void discovery_finished() { next_phase(); }
+
+/**
+ * Called after first sample has been sent/received.
+ */
+void first_sample_exchanged() { next_phase(); }
+
+/**
+ * Called after all samples have been sent/received. Undiscovery will begin.
+ */
+void all_samples_exchanged() { next_phase(); }
+
+/**
+ * Called after remote entity has been undiscovered. Memory profiling should end.
+ */
+void undiscovery_finished() 
+{ 
+    EXPECT_NO_MEMORY_OPERATIONS_END();
+}
+
+/**
+ * Print memory profiling results.
+ */
+void print_results() 
+{
+    for(size_t i = 0; i < 4; i++)
+    {
+        size_t allocs = g_allocations[i].load();
+        size_t deallocs = g_deallocations[i].load();
+
+        if( (allocs + deallocs) > 0)
+        {
+            std::cerr << "Phase " << i << ": " << allocs << " allocations and " << deallocs << " deallocations" << std::endl;
+        }
+    }
+}
+
+}   // namespace eprosima_profiling
 

--- a/test/profiling/allocations/AllocTestCommon.cpp
+++ b/test/profiling/allocations/AllocTestCommon.cpp
@@ -140,7 +140,7 @@ void print_results(const std::string& file_prefix, const std::string& entity, co
         }
     }
 
-    string output_filename = file_prefix;
+    std::string output_filename = file_prefix;
     if (file_prefix.length() == 0)
     {
         output_filename = "alloc_test_" + entity + "_" + config + ".csv";

--- a/test/profiling/allocations/AllocTestCommon.cpp
+++ b/test/profiling/allocations/AllocTestCommon.cpp
@@ -22,6 +22,7 @@
 #include <atomic>
 #include <iostream>
 #include <fstream>
+#include <sstream>
 #include "osrf_testing_tools_cpp/memory_tools/memory_tools.hpp"
 
 using MemoryToolsService = osrf_testing_tools_cpp::memory_tools::MemoryToolsService;

--- a/test/profiling/allocations/AllocTestCommon.cpp
+++ b/test/profiling/allocations/AllocTestCommon.cpp
@@ -21,7 +21,7 @@
 
 #include <atomic>
 #include <iostream>
-
+#include <fstream>
 #include "osrf_testing_tools_cpp/memory_tools/memory_tools.hpp"
 
 using MemoryToolsService = osrf_testing_tools_cpp::memory_tools::MemoryToolsService;
@@ -120,18 +120,30 @@ void undiscovery_finished()
 /**
  * Print memory profiling results.
  */
-void print_results() 
+void print_results(const std::string& entity, const std::string& config) 
 {
+    std::stringstream output_stream;
+    output_stream << "\"Phase 0 Allocations\", \"Phase 0 Deallocations\","
+    << " \"Phase 1 Allocations\", \"Phase 1 Deallocations\","
+    << " \"Phase 2 Allocations\", \"Phase 2 Deallocations\","
+    << " \"Phase 3 Allocations\", \"Phase 3 Deallocations\"";
+
     for(size_t i = 0; i < 4; i++)
     {
         size_t allocs = g_allocations[i].load();
         size_t deallocs = g_deallocations[i].load();
 
-        if( (allocs + deallocs) > 0)
+        output_stream << allocs << "," << deallocs;
+        if (i < 3)
         {
-            std::cerr << "Phase " << i << ": " << allocs << " allocations and " << deallocs << " deallocations" << std::endl;
+            output_stream << ",";
         }
     }
+
+    std::ofstream outFile;
+    outFile.open("alloc_test_" + entity + "_" + config + ".csv");
+    outFile << output_stream.str();
+    outFile.close();
 }
 
 }   // namespace eprosima_profiling

--- a/test/profiling/allocations/AllocTestCommon.cpp
+++ b/test/profiling/allocations/AllocTestCommon.cpp
@@ -140,8 +140,13 @@ void print_results(const std::string& file_prefix, const std::string& entity, co
         }
     }
 
+    if (file_prefix.length() == 0)
+    {
+        file_prefix = "alloc_test_" + entity + "_" + config + ".csv";
+    }
+
     std::ofstream outFile;
-    outFile.open(file_prefix + "alloc_test_" + entity + "_" + config + ".csv");
+    outFile.open(file_prefix);
     outFile << output_stream.str();
     outFile.close();
 }

--- a/test/profiling/allocations/AllocTestCommon.cpp
+++ b/test/profiling/allocations/AllocTestCommon.cpp
@@ -140,13 +140,14 @@ void print_results(const std::string& file_prefix, const std::string& entity, co
         }
     }
 
+    string output_filename = file_prefix;
     if (file_prefix.length() == 0)
     {
-        file_prefix = "alloc_test_" + entity + "_" + config + ".csv";
+        output_filename = "alloc_test_" + entity + "_" + config + ".csv";
     }
 
     std::ofstream outFile;
-    outFile.open(file_prefix);
+    outFile.open(output_filename);
     outFile << output_stream.str();
     outFile.close();
 }

--- a/test/profiling/allocations/AllocTestCommon.cpp
+++ b/test/profiling/allocations/AllocTestCommon.cpp
@@ -123,11 +123,27 @@ void undiscovery_finished()
  */
 void print_results(const std::string& file_prefix, const std::string& entity, const std::string& config) 
 {
+    std::string output_filename = file_prefix;
+    if (file_prefix.length() == 0)
+    {
+        output_filename = "alloc_test_" + entity + "_" + config + ".csv";
+    }
+
+    std::ofstream outFile;
+    outFile.open(output_filename, std::ofstream::app);
+
+    // Check the file is new
+    long pos = outFile.tellp();
+
     std::stringstream output_stream;
-    output_stream << "\"Phase 0 Allocations\", \"Phase 0 Deallocations\","
-    << " \"Phase 1 Allocations\", \"Phase 1 Deallocations\","
-    << " \"Phase 2 Allocations\", \"Phase 2 Deallocations\","
-    << " \"Phase 3 Allocations\", \"Phase 3 Deallocations\"\n";
+
+    if(pos == 0)
+    {
+        output_stream << "\"Phase 0 Allocations\", \"Phase 0 Deallocations\","
+            << " \"Phase 1 Allocations\", \"Phase 1 Deallocations\","
+            << " \"Phase 2 Allocations\", \"Phase 2 Deallocations\","
+            << " \"Phase 3 Allocations\", \"Phase 3 Deallocations\"\n";
+    }
 
     for(size_t i = 0; i < 4; i++)
     {
@@ -140,15 +156,8 @@ void print_results(const std::string& file_prefix, const std::string& entity, co
             output_stream << ",";
         }
     }
+    output_stream << std::endl;
 
-    std::string output_filename = file_prefix;
-    if (file_prefix.length() == 0)
-    {
-        output_filename = "alloc_test_" + entity + "_" + config + ".csv";
-    }
-
-    std::ofstream outFile;
-    outFile.open(output_filename);
     outFile << output_stream.str();
     outFile.close();
 }

--- a/test/profiling/allocations/AllocTestCommon.cpp
+++ b/test/profiling/allocations/AllocTestCommon.cpp
@@ -126,7 +126,7 @@ void print_results(const std::string& file_prefix, const std::string& entity, co
     output_stream << "\"Phase 0 Allocations\", \"Phase 0 Deallocations\","
     << " \"Phase 1 Allocations\", \"Phase 1 Deallocations\","
     << " \"Phase 2 Allocations\", \"Phase 2 Deallocations\","
-    << " \"Phase 3 Allocations\", \"Phase 3 Deallocations\"";
+    << " \"Phase 3 Allocations\", \"Phase 3 Deallocations\"\n";
 
     for(size_t i = 0; i < 4; i++)
     {

--- a/test/profiling/allocations/AllocTestCommon.h
+++ b/test/profiling/allocations/AllocTestCommon.h
@@ -17,8 +17,11 @@
  *
  */
 
-#ifndef ALLOCTESTCOMMON_H_
-#define ALLOCTESTCOMMON_H_
+#ifndef FASTRTPS_TEST_PROFILING_ALLOCATIONS_ALLOCTESTCOMMON_H_
+#define FASTRTPS_TEST_PROFILING_ALLOCATIONS_ALLOCTESTCOMMON_H_
+
+namespace eprosima_profiling
+{
 
 /**
  * Used to run callgrind with --zero-before=callgrind_zero_count. 
@@ -32,5 +35,37 @@ void callgrind_zero_count();
  */
 void callgrind_dump();
 
-#endif
+/**
+ * Called when entities have been created. Memory profiling should begin.
+ */
+void entities_created();
+
+/**
+ * Called after remote entity has been discovered. Data exchange will start.
+ */
+void discovery_finished();
+
+/**
+ * Called after first sample has been sent/received.
+ */
+void first_sample_exchanged();
+
+/**
+ * Called after all samples have been sent/received. Undiscovery will begin.
+ */
+void all_samples_exchanged();
+
+/**
+ * Called after remote entity has been undiscovered. Memory profiling should end.
+ */
+void undiscovery_finished();
+
+/**
+ * Print memory profiling results.
+ */
+void print_results();
+
+}   // namespace eprosima_profiling
+
+#endif   // FASTRTPS_TEST_PROFILING_ALLOCATIONS_ALLOCTESTCOMMON_H_
 

--- a/test/profiling/allocations/AllocTestCommon.h
+++ b/test/profiling/allocations/AllocTestCommon.h
@@ -65,7 +65,7 @@ void undiscovery_finished();
 /**
  * Print memory profiling results.
  */
-void print_results(const std::string& entity, const std::string& config);
+void print_results(const std::string& file_prefix, const std::string& entity, const std::string& config);
 
 }   // namespace eprosima_profiling
 

--- a/test/profiling/allocations/AllocTestCommon.h
+++ b/test/profiling/allocations/AllocTestCommon.h
@@ -20,6 +20,8 @@
 #ifndef FASTRTPS_TEST_PROFILING_ALLOCATIONS_ALLOCTESTCOMMON_H_
 #define FASTRTPS_TEST_PROFILING_ALLOCATIONS_ALLOCTESTCOMMON_H_
 
+#include <string>
+
 namespace eprosima_profiling
 {
 
@@ -63,7 +65,7 @@ void undiscovery_finished();
 /**
  * Print memory profiling results.
  */
-void print_results();
+void print_results(const std::string& entity, const std::string& config);
 
 }   // namespace eprosima_profiling
 

--- a/test/profiling/allocations/AllocTestPublisher.cpp
+++ b/test/profiling/allocations/AllocTestPublisher.cpp
@@ -55,6 +55,7 @@ bool AllocTestPublisher::init(const char* profile)
     if(mp_publisher == nullptr)
         return false;
 
+    eprosima_profiling::entities_created();
     return true;
 
 }
@@ -80,17 +81,13 @@ void AllocTestPublisher::PubListener::onPublicationMatched(Publisher* /*pub*/,Ma
 
 void AllocTestPublisher::run(uint32_t samples, bool wait_unmatch)
 {
-    // Restart callgrind graph
-    callgrind_zero_count();
-
     std::cout << "Publisher waiting for subscriber..." << std::endl;
     while (m_listener.n_matched <= 0)
     {
         eClock::my_sleep(25);
     }
 
-    // Flush callgrind graph
-    callgrind_dump();
+    eprosima_profiling::discovery_finished();
 
     std::cout << "Publisher matched. Sending samples" << std::endl;
     eClock::my_sleep(500);
@@ -101,22 +98,20 @@ void AllocTestPublisher::run(uint32_t samples, bool wait_unmatch)
             --i;
         else
         {
-            std::cout << "Message with index: "<< m_data.index() << " SENT"<<std::endl;
+            std::cout << "Message with index: "<< m_data.index() << " SENT" << std::endl;
         }
         eClock::my_sleep(500);
 
         if (i == 0)
         {
-            // Flush callgrind graph
-            callgrind_dump();
+            eprosima_profiling::first_sample_exchanged();
 
             std::cout << "First message has been sent" << std::endl;
             eClock::my_sleep(500);
         }
     }
 
-    // Flush callgrind graph
-    callgrind_dump();
+    eprosima_profiling::all_samples_exchanged();
 
     if(wait_unmatch)
     {
@@ -132,8 +127,8 @@ void AllocTestPublisher::run(uint32_t samples, bool wait_unmatch)
         eClock::my_sleep(500);
     }
 
-    // Flush callgrind graph
-    callgrind_dump();
+    eprosima_profiling::undiscovery_finished();
+    eprosima_profiling::print_results();
 }
 
 bool AllocTestPublisher::publish()

--- a/test/profiling/allocations/AllocTestPublisher.cpp
+++ b/test/profiling/allocations/AllocTestPublisher.cpp
@@ -25,6 +25,7 @@
 #include <fastrtps/publisher/Publisher.h>
 #include <fastrtps/Domain.h>
 #include <fastrtps/utils/eClock.h>
+#include <fastrtps/xmlparser/XMLProfileManager.h>
 
 using namespace eprosima::fastrtps;
 using namespace eprosima::fastrtps::rtps;

--- a/test/profiling/allocations/AllocTestPublisher.cpp
+++ b/test/profiling/allocations/AllocTestPublisher.cpp
@@ -94,12 +94,17 @@ void AllocTestPublisher::PubListener::onPublicationMatched(Publisher* /*pub*/,Ma
 
 void AllocTestPublisher::run(uint32_t samples, bool wait_unmatch)
 {
+    // Restart callgrind graph
+    eprosima_profiling::callgrind_zero_count();
+
     std::cout << "Publisher waiting for subscriber..." << std::endl;
     while (m_listener.n_matched <= 0)
     {
         eClock::my_sleep(25);
     }
 
+    // Flush callgrind graph
+    eprosima_profiling::callgrind_dump();
     eprosima_profiling::discovery_finished();
 
     std::cout << "Publisher matched. Sending samples" << std::endl;
@@ -117,6 +122,8 @@ void AllocTestPublisher::run(uint32_t samples, bool wait_unmatch)
 
         if (i == 0)
         {
+            // Flush callgrind graph
+            eprosima_profiling::callgrind_dump();
             eprosima_profiling::first_sample_exchanged();
 
             std::cout << "First message has been sent" << std::endl;
@@ -124,6 +131,8 @@ void AllocTestPublisher::run(uint32_t samples, bool wait_unmatch)
         }
     }
 
+    // Flush callgrind graph
+    eprosima_profiling::callgrind_dump();
     eprosima_profiling::all_samples_exchanged();
 
     if(wait_unmatch)
@@ -140,6 +149,8 @@ void AllocTestPublisher::run(uint32_t samples, bool wait_unmatch)
         eClock::my_sleep(500);
     }
 
+    // Flush callgrind graph
+    eprosima_profiling::callgrind_dump();
     eprosima_profiling::undiscovery_finished();
     eprosima_profiling::print_results(m_outputFile, "publisher", m_profile);
 }

--- a/test/profiling/allocations/AllocTestPublisher.cpp
+++ b/test/profiling/allocations/AllocTestPublisher.cpp
@@ -37,11 +37,12 @@ AllocTestPublisher::AllocTestPublisher()
 
 }
 
-bool AllocTestPublisher::init(const char* profile)
+bool AllocTestPublisher::init(const char* profile, const std::string& outputFile)
 {
     m_data.index(0);
 
     m_profile = profile;
+    m_outputFile = outputFile;
     Domain::loadXMLProfilesFile("test_xml_profiles.xml");
     mp_participant = Domain::createParticipant("test_participant_profile");
     if (mp_participant == nullptr)
@@ -130,7 +131,7 @@ void AllocTestPublisher::run(uint32_t samples, bool wait_unmatch)
     }
 
     eprosima_profiling::undiscovery_finished();
-    eprosima_profiling::print_results("publisher", m_profile);
+    eprosima_profiling::print_results(m_outputFile, "publisher", m_profile);
 }
 
 bool AllocTestPublisher::publish()

--- a/test/profiling/allocations/AllocTestPublisher.cpp
+++ b/test/profiling/allocations/AllocTestPublisher.cpp
@@ -29,8 +29,9 @@
 using namespace eprosima::fastrtps;
 using namespace eprosima::fastrtps::rtps;
 
-AllocTestPublisher::AllocTestPublisher():mp_participant(nullptr),
-mp_publisher(nullptr)
+AllocTestPublisher::AllocTestPublisher()
+: mp_participant(nullptr)
+, mp_publisher(nullptr)
 {
 
 
@@ -40,6 +41,7 @@ bool AllocTestPublisher::init(const char* profile)
 {
     m_data.index(0);
 
+    m_profile = profile;
     Domain::loadXMLProfilesFile("test_xml_profiles.xml");
     mp_participant = Domain::createParticipant("test_participant_profile");
     if (mp_participant == nullptr)
@@ -128,7 +130,7 @@ void AllocTestPublisher::run(uint32_t samples, bool wait_unmatch)
     }
 
     eprosima_profiling::undiscovery_finished();
-    eprosima_profiling::print_results();
+    eprosima_profiling::print_results("publisher", m_profile);
 }
 
 bool AllocTestPublisher::publish()

--- a/test/profiling/allocations/AllocTestPublisher.cpp
+++ b/test/profiling/allocations/AllocTestPublisher.cpp
@@ -78,7 +78,7 @@ void AllocTestPublisher::PubListener::onPublicationMatched(Publisher* /*pub*/,Ma
     }
 }
 
-void AllocTestPublisher::run(uint32_t samples)
+void AllocTestPublisher::run(uint32_t samples, bool wait_unmatch)
 {
     // Restart callgrind graph
     callgrind_zero_count();
@@ -92,8 +92,8 @@ void AllocTestPublisher::run(uint32_t samples)
     // Flush callgrind graph
     callgrind_dump();
 
-    std::cout << "Publisher matched. Press enter to start sending samples" << std::endl;
-    std::cin.ignore();
+    std::cout << "Publisher matched. Sending samples" << std::endl;
+    eClock::my_sleep(500);
 
     for(uint32_t i = 0;i<samples;++i)
     {
@@ -101,7 +101,7 @@ void AllocTestPublisher::run(uint32_t samples)
             --i;
         else
         {
-            std::cout << "Message with index: "<< m_data.index()<< " SENT"<<std::endl;
+            std::cout << "Message with index: "<< m_data.index() << " SENT"<<std::endl;
         }
         eClock::my_sleep(500);
 
@@ -110,16 +110,27 @@ void AllocTestPublisher::run(uint32_t samples)
             // Flush callgrind graph
             callgrind_dump();
 
-            std::cout << "First message has been sent. Press enter to continue sending samples" << std::endl;
-            std::cin.ignore();
+            std::cout << "First message has been sent" << std::endl;
+            eClock::my_sleep(500);
         }
     }
 
     // Flush callgrind graph
     callgrind_dump();
 
-    std::cout << "All messages have been sent. Press enter to stop publisher" << std::endl;
-    std::cin.ignore();
+    if(wait_unmatch)
+    {
+        std::cout << "All messages have been sent. Waiting for subscriber to stop." << std::endl;
+        while (m_listener.n_matched > 0)
+        {
+            eClock::my_sleep(25);
+        }
+    }
+    else
+    {
+        std::cout << "All messages have been sent. Waiting a bit to let subscriber receive samples." << std::endl;
+        eClock::my_sleep(500);
+    }
 
     // Flush callgrind graph
     callgrind_dump();

--- a/test/profiling/allocations/AllocTestPublisher.cpp
+++ b/test/profiling/allocations/AllocTestPublisher.cpp
@@ -37,14 +37,23 @@ AllocTestPublisher::AllocTestPublisher()
 
 }
 
-bool AllocTestPublisher::init(const char* profile, const std::string& outputFile)
+bool AllocTestPublisher::init(const char* profile, int domainId, const std::string& outputFile)
 {
     m_data.index(0);
 
     m_profile = profile;
     m_outputFile = outputFile;
     Domain::loadXMLProfilesFile("test_xml_profiles.xml");
-    mp_participant = Domain::createParticipant("test_participant_profile");
+
+    ParticipantAttributes participant_att;
+    if (eprosima::fastrtps::xmlparser::XMLP_ret::XML_OK ==
+        eprosima::fastrtps::xmlparser::XMLProfileManager::fillParticipantAttributes("test_participant_profile",
+            participant_att))
+    {
+        participant_att.rtps.builtin.domainId = domainId;
+        mp_participant = Domain::createParticipant(participant_att);
+    }
+
     if (mp_participant == nullptr)
         return false;
 

--- a/test/profiling/allocations/AllocTestPublisher.h
+++ b/test/profiling/allocations/AllocTestPublisher.h
@@ -26,6 +26,8 @@
 #include <fastrtps/attributes/PublisherAttributes.h>
 #include <fastrtps/publisher/PublisherListener.h>
 #include <string>
+#include <condition_variable>
+#include <mutex>
 #include "AllocTestType.h"
 
 class AllocTestPublisher {
@@ -51,7 +53,15 @@ private:
         PubListener():n_matched(0){};
         ~PubListener(){};
         void onPublicationMatched(eprosima::fastrtps::Publisher* pub, eprosima::fastrtps::rtps::MatchingInfo& info);
+
+        bool is_matched();
+        void wait_match();
+        void wait_unmatch();
+
+    private:
         int n_matched;
+        std::mutex mtx;
+        std::condition_variable cv;
     }m_listener;
 };
 

--- a/test/profiling/allocations/AllocTestPublisher.h
+++ b/test/profiling/allocations/AllocTestPublisher.h
@@ -33,7 +33,7 @@ public:
     AllocTestPublisher();
     virtual ~AllocTestPublisher();
     //!Initialize
-    bool init(const char* profile);
+    bool init(const char* profile, const std::string& outputFile);
     //!Publish a sample
     bool publish();
     //!Run for number samples
@@ -44,6 +44,7 @@ private:
     eprosima::fastrtps::Participant* mp_participant;
     eprosima::fastrtps::Publisher* mp_publisher;
     std::string m_profile;
+    std::string m_outputFile;
     class PubListener:public eprosima::fastrtps::PublisherListener
     {
     public:

--- a/test/profiling/allocations/AllocTestPublisher.h
+++ b/test/profiling/allocations/AllocTestPublisher.h
@@ -33,7 +33,7 @@ public:
     AllocTestPublisher();
     virtual ~AllocTestPublisher();
     //!Initialize
-    bool init(const char* profile, const std::string& outputFile);
+    bool init(const char* profile, int domainId, const std::string& outputFile);
     //!Publish a sample
     bool publish();
     //!Run for number samples

--- a/test/profiling/allocations/AllocTestPublisher.h
+++ b/test/profiling/allocations/AllocTestPublisher.h
@@ -38,7 +38,7 @@ public:
     //!Publish a sample
     bool publish();
     //!Run for number samples
-    void run(uint32_t number);
+    void run(uint32_t number, bool wait_unmatch = false);
 private:
     AllocTestTypePubSubType m_type;
     AllocTestType m_data;

--- a/test/profiling/allocations/AllocTestPublisher.h
+++ b/test/profiling/allocations/AllocTestPublisher.h
@@ -25,8 +25,7 @@
 #include <fastrtps/fastrtps_fwd.h>
 #include <fastrtps/attributes/PublisherAttributes.h>
 #include <fastrtps/publisher/PublisherListener.h>
-
-
+#include <string>
 #include "AllocTestType.h"
 
 class AllocTestPublisher {
@@ -44,6 +43,7 @@ private:
     AllocTestType m_data;
     eprosima::fastrtps::Participant* mp_participant;
     eprosima::fastrtps::Publisher* mp_publisher;
+    std::string m_profile;
     class PubListener:public eprosima::fastrtps::PublisherListener
     {
     public:

--- a/test/profiling/allocations/AllocTestSubscriber.cpp
+++ b/test/profiling/allocations/AllocTestSubscriber.cpp
@@ -36,6 +36,7 @@ mp_subscriber(nullptr)
 
 bool AllocTestSubscriber::init(const char* profile)
 {
+    m_profile = profile;
     Domain::loadXMLProfilesFile("test_xml_profiles.xml");
     mp_participant = Domain::createParticipant("test_participant_profile");
     if(mp_participant==nullptr)
@@ -135,5 +136,5 @@ void AllocTestSubscriber::run(uint32_t number, bool wait_unmatch)
     }
 
     eprosima_profiling::undiscovery_finished();
-    eprosima_profiling::print_results();
+    eprosima_profiling::print_results("subscriber", m_profile);
 }

--- a/test/profiling/allocations/AllocTestSubscriber.cpp
+++ b/test/profiling/allocations/AllocTestSubscriber.cpp
@@ -34,12 +34,21 @@ mp_subscriber(nullptr)
 {
 }
 
-bool AllocTestSubscriber::init(const char* profile, const std::string& outputFile)
+bool AllocTestSubscriber::init(const char* profile, int domainId, const std::string& outputFile)
 {
     m_profile = profile;
     m_outputFile = outputFile;
     Domain::loadXMLProfilesFile("test_xml_profiles.xml");
-    mp_participant = Domain::createParticipant("test_participant_profile");
+
+    ParticipantAttributes participant_att;
+    if (eprosima::fastrtps::xmlparser::XMLP_ret::XML_OK ==
+        eprosima::fastrtps::xmlparser::XMLProfileManager::fillParticipantAttributes("test_participant_profile",
+            participant_att))
+    {
+        participant_att.rtps.builtin.domainId = domainId;
+        mp_participant = Domain::createParticipant(participant_att);
+    }
+
     if(mp_participant==nullptr)
         return false;
 

--- a/test/profiling/allocations/AllocTestSubscriber.cpp
+++ b/test/profiling/allocations/AllocTestSubscriber.cpp
@@ -25,6 +25,7 @@
 #include <fastrtps/subscriber/Subscriber.h>
 #include <fastrtps/Domain.h>
 #include <fastrtps/utils/eClock.h>
+#include <fastrtps/xmlparser/XMLProfileManager.h>
 
 using namespace eprosima::fastrtps;
 using namespace eprosima::fastrtps::rtps;

--- a/test/profiling/allocations/AllocTestSubscriber.cpp
+++ b/test/profiling/allocations/AllocTestSubscriber.cpp
@@ -34,9 +34,10 @@ mp_subscriber(nullptr)
 {
 }
 
-bool AllocTestSubscriber::init(const char* profile)
+bool AllocTestSubscriber::init(const char* profile, const std::string& outputFile)
 {
     m_profile = profile;
+    m_outputFile = outputFile;
     Domain::loadXMLProfilesFile("test_xml_profiles.xml");
     mp_participant = Domain::createParticipant("test_participant_profile");
     if(mp_participant==nullptr)
@@ -136,5 +137,5 @@ void AllocTestSubscriber::run(uint32_t number, bool wait_unmatch)
     }
 
     eprosima_profiling::undiscovery_finished();
-    eprosima_profiling::print_results("subscriber", m_profile);
+    eprosima_profiling::print_results(m_outputFile, "subscriber", m_profile);
 }

--- a/test/profiling/allocations/AllocTestSubscriber.cpp
+++ b/test/profiling/allocations/AllocTestSubscriber.cpp
@@ -52,7 +52,7 @@ bool AllocTestSubscriber::init(const char* profile)
     if(mp_subscriber == nullptr)
         return false;
 
-    // Breakpoint placed here. First snapshot taken.
+    eprosima_profiling::entities_created();
     return true;
 }
 
@@ -96,17 +96,13 @@ void AllocTestSubscriber::run(bool wait_unmatch)
 
 void AllocTestSubscriber::run(uint32_t number, bool wait_unmatch)
 {
-    // Restart callgrind graph
-    callgrind_zero_count();
-
     std::cout << "Subscriber waiting for publisher..." << std::endl;
     while (m_listener.n_matched <= 0)
     {
         eClock::my_sleep(25);
     }
 
-    // Flush callgrind graph
-    callgrind_dump();
+    eprosima_profiling::discovery_finished();
 
     std::cout << "Subscriber matched. Waiting for first sample..." << std::endl;
     while (this->m_listener.n_samples < 1)
@@ -114,8 +110,7 @@ void AllocTestSubscriber::run(uint32_t number, bool wait_unmatch)
         eClock::my_sleep(25);
     }
 
-    // Flush callgrind graph
-    callgrind_dump();
+    eprosima_profiling::first_sample_exchanged();
 
     std::cout << "First sample received. Waiting for rest of samples..." << std::endl;
     while (this->m_listener.n_samples < number)
@@ -123,8 +118,7 @@ void AllocTestSubscriber::run(uint32_t number, bool wait_unmatch)
         eClock::my_sleep(25);
     }
 
-    // Flush callgrind graph
-    callgrind_dump();
+    eprosima_profiling::all_samples_exchanged();
 
     if (wait_unmatch)
     {
@@ -140,6 +134,6 @@ void AllocTestSubscriber::run(uint32_t number, bool wait_unmatch)
         eClock::my_sleep(500);
     }
 
-    // Flush callgrind graph
-    callgrind_dump();
+    eprosima_profiling::undiscovery_finished();
+    eprosima_profiling::print_results();
 }

--- a/test/profiling/allocations/AllocTestSubscriber.cpp
+++ b/test/profiling/allocations/AllocTestSubscriber.cpp
@@ -89,12 +89,12 @@ void AllocTestSubscriber::SubListener::onNewDataMessage(Subscriber* sub)
 }
 
 
-void AllocTestSubscriber::run()
+void AllocTestSubscriber::run(bool wait_unmatch)
 {
-  run(60);
+  run(60, wait_unmatch);
 }
 
-void AllocTestSubscriber::run(uint32_t number)
+void AllocTestSubscriber::run(uint32_t number, bool wait_unmatch)
 {
     // Restart callgrind graph
     callgrind_zero_count();
@@ -126,8 +126,19 @@ void AllocTestSubscriber::run(uint32_t number)
     // Flush callgrind graph
     callgrind_dump();
 
-    std::cout << "All messages received. Press enter to stop subscriber" << std::endl;
-    std::cin.ignore();
+    if (wait_unmatch)
+    {
+        std::cout << "All messages received. Waiting for publisher to stop." << std::endl;
+        while (m_listener.n_matched > 0)
+        {
+            eClock::my_sleep(25);
+        }
+    }
+    else
+    {
+        std::cout << "All messages received. Waiting a bit to let publisher receive acks." << std::endl;
+        eClock::my_sleep(500);
+    }
 
     // Flush callgrind graph
     callgrind_dump();

--- a/test/profiling/allocations/AllocTestSubscriber.cpp
+++ b/test/profiling/allocations/AllocTestSubscriber.cpp
@@ -108,12 +108,17 @@ void AllocTestSubscriber::run(bool wait_unmatch)
 
 void AllocTestSubscriber::run(uint32_t number, bool wait_unmatch)
 {
+    // Restart callgrind graph
+    eprosima_profiling::callgrind_zero_count();
+
     std::cout << "Subscriber waiting for publisher..." << std::endl;
     while (m_listener.n_matched <= 0)
     {
         eClock::my_sleep(25);
     }
 
+    // Flush callgrind graph
+    eprosima_profiling::callgrind_dump();
     eprosima_profiling::discovery_finished();
 
     std::cout << "Subscriber matched. Waiting for first sample..." << std::endl;
@@ -122,6 +127,8 @@ void AllocTestSubscriber::run(uint32_t number, bool wait_unmatch)
         eClock::my_sleep(25);
     }
 
+    // Flush callgrind graph
+    eprosima_profiling::callgrind_dump();
     eprosima_profiling::first_sample_exchanged();
 
     std::cout << "First sample received. Waiting for rest of samples..." << std::endl;
@@ -130,6 +137,8 @@ void AllocTestSubscriber::run(uint32_t number, bool wait_unmatch)
         eClock::my_sleep(25);
     }
 
+    // Flush callgrind graph
+    eprosima_profiling::callgrind_dump();
     eprosima_profiling::all_samples_exchanged();
 
     if (wait_unmatch)
@@ -146,6 +155,8 @@ void AllocTestSubscriber::run(uint32_t number, bool wait_unmatch)
         eClock::my_sleep(500);
     }
 
+    // Flush callgrind graph
+    eprosima_profiling::callgrind_dump();
     eprosima_profiling::undiscovery_finished();
     eprosima_profiling::print_results(m_outputFile, "subscriber", m_profile);
 }

--- a/test/profiling/allocations/AllocTestSubscriber.h
+++ b/test/profiling/allocations/AllocTestSubscriber.h
@@ -39,9 +39,9 @@ public:
 	//!Initialize the subscriber
 	bool init(const char* profile);
 	//!RUN the subscriber
-	void run();
+	void run(bool wait_unmatch=false);
 	//!Run the subscriber until number samples have been recevied.
-	void run(uint32_t number);
+	void run(uint32_t number, bool wait_unmatch = false);
 private:
 	eprosima::fastrtps::Participant* mp_participant;
 	eprosima::fastrtps::Subscriber* mp_subscriber;

--- a/test/profiling/allocations/AllocTestSubscriber.h
+++ b/test/profiling/allocations/AllocTestSubscriber.h
@@ -26,10 +26,7 @@
 #include <fastrtps/attributes/SubscriberAttributes.h>
 #include <fastrtps/subscriber/SubscriberListener.h>
 #include <fastrtps/subscriber/SampleInfo.h>
-
-
-
-
+#include <string>
 #include "AllocTestType.h"
 
 class AllocTestSubscriber {
@@ -45,6 +42,7 @@ public:
 private:
 	eprosima::fastrtps::Participant* mp_participant;
 	eprosima::fastrtps::Subscriber* mp_subscriber;
+	std::string m_profile;
 public:
 	class SubListener:public eprosima::fastrtps::SubscriberListener
 	{

--- a/test/profiling/allocations/AllocTestSubscriber.h
+++ b/test/profiling/allocations/AllocTestSubscriber.h
@@ -27,6 +27,9 @@
 #include <fastrtps/subscriber/SubscriberListener.h>
 #include <fastrtps/subscriber/SampleInfo.h>
 #include <string>
+#include <atomic>
+#include <condition_variable>
+#include <mutex>
 #include "AllocTestType.h"
 
 class AllocTestSubscriber {
@@ -48,15 +51,24 @@ public:
 	class SubListener:public eprosima::fastrtps::SubscriberListener
 	{
 	public:
-		SubListener():n_matched(0),n_samples(0){};
-		~SubListener(){};
+		SubListener():n_matched(0),n_samples(0){}
+		~SubListener(){}
+
 		void onSubscriptionMatched(eprosima::fastrtps::Subscriber* sub, eprosima::fastrtps::rtps::MatchingInfo& info);
 		void onNewDataMessage(eprosima::fastrtps::Subscriber* sub);
-		AllocTestType m_Hello;
-		eprosima::fastrtps::SampleInfo_t m_info;
-		int n_matched;
-		uint32_t n_samples;
-	}m_listener;
+        
+        void wait_match();
+        void wait_unmatch();
+        void wait_until_total_received_at_least(uint32_t n);
+
+    private:
+        AllocTestType m_Hello;
+        eprosima::fastrtps::SampleInfo_t m_info;
+        int n_matched;
+        uint32_t n_samples;
+        std::mutex mtx;
+        std::condition_variable cv;
+    }m_listener;
 private:
 	AllocTestTypePubSubType m_type;
 };

--- a/test/profiling/allocations/AllocTestSubscriber.h
+++ b/test/profiling/allocations/AllocTestSubscriber.h
@@ -34,7 +34,7 @@ public:
 	AllocTestSubscriber();
 	virtual ~AllocTestSubscriber();
 	//!Initialize the subscriber
-	bool init(const char* profile, const std::string& outputFile);
+	bool init(const char* profile, int domainId, const std::string& outputFile);
 	//!RUN the subscriber
 	void run(bool wait_unmatch=false);
 	//!Run the subscriber until number samples have been recevied.

--- a/test/profiling/allocations/AllocTestSubscriber.h
+++ b/test/profiling/allocations/AllocTestSubscriber.h
@@ -34,7 +34,7 @@ public:
 	AllocTestSubscriber();
 	virtual ~AllocTestSubscriber();
 	//!Initialize the subscriber
-	bool init(const char* profile);
+	bool init(const char* profile, const std::string& outputFile);
 	//!RUN the subscriber
 	void run(bool wait_unmatch=false);
 	//!Run the subscriber until number samples have been recevied.
@@ -43,6 +43,7 @@ private:
 	eprosima::fastrtps::Participant* mp_participant;
 	eprosima::fastrtps::Subscriber* mp_subscriber;
 	std::string m_profile;
+	std::string m_outputFile;
 public:
 	class SubListener:public eprosima::fastrtps::SubscriberListener
 	{

--- a/test/profiling/allocations/AllocTest_main.cpp
+++ b/test/profiling/allocations/AllocTest_main.cpp
@@ -34,6 +34,7 @@ int main(int argc, char** argv)
     int type = 1;
     bool wait_unmatch = false;
     const char* profile = "tl_be";
+    std::string outputFile = "";
     if(argc > 2)
     {
         if(strcmp(argv[1],"publisher")==0)
@@ -44,6 +45,10 @@ int main(int argc, char** argv)
         profile = argv[2];
 
         wait_unmatch = (argc > 3) && (strcmp(argv[3], "true") == 0);
+        if (argc > 4)
+        {
+            outputFile = argv[4];
+        }
     }
     else
     {
@@ -66,7 +71,7 @@ int main(int argc, char** argv)
         case 1:
             {
                 AllocTestPublisher mypub;
-                if(mypub.init(profile))
+                if(mypub.init(profile, outputFile))
                 {
                     mypub.run(60, wait_unmatch);
                 }
@@ -75,7 +80,7 @@ int main(int argc, char** argv)
         case 2:
             {
                 AllocTestSubscriber mysub;
-                if(mysub.init(profile))
+                if(mysub.init(profile, outputFile))
                 {
                     mysub.run(wait_unmatch);
                 }

--- a/test/profiling/allocations/AllocTest_main.cpp
+++ b/test/profiling/allocations/AllocTest_main.cpp
@@ -32,6 +32,7 @@ int main(int argc, char** argv)
 {
     std::cout << "Starting "<< std::endl;
     int type = 1;
+    int domain = 1;
     bool wait_unmatch = false;
     const char* profile = "tl_be";
     std::string outputFile = "";
@@ -47,7 +48,12 @@ int main(int argc, char** argv)
         wait_unmatch = (argc > 3) && (strcmp(argv[3], "true") == 0);
         if (argc > 4)
         {
-            outputFile = argv[4];
+            domain = atoi(argv[4]);
+        }
+
+        if (argc > 5)
+        {
+            outputFile = argv[5];
         }
     }
     else
@@ -71,7 +77,7 @@ int main(int argc, char** argv)
         case 1:
             {
                 AllocTestPublisher mypub;
-                if(mypub.init(profile, outputFile))
+                if(mypub.init(profile, domain, outputFile))
                 {
                     mypub.run(60, wait_unmatch);
                 }
@@ -80,7 +86,7 @@ int main(int argc, char** argv)
         case 2:
             {
                 AllocTestSubscriber mysub;
-                if(mysub.init(profile, outputFile))
+                if(mysub.init(profile, domain, outputFile))
                 {
                     mysub.run(wait_unmatch);
                 }

--- a/test/profiling/allocations/AllocTest_main.cpp
+++ b/test/profiling/allocations/AllocTest_main.cpp
@@ -32,6 +32,7 @@ int main(int argc, char** argv)
 {
     std::cout << "Starting "<< std::endl;
     int type = 1;
+    bool wait_unmatch = false;
     const char* profile = "tl_be";
     if(argc > 2)
     {
@@ -41,6 +42,8 @@ int main(int argc, char** argv)
             type = 2;
 
         profile = argv[2];
+
+        wait_unmatch = (argc > 3) && (strcmp(argv[3], "true") == 0);
     }
     else
     {
@@ -65,7 +68,7 @@ int main(int argc, char** argv)
                 AllocTestPublisher mypub;
                 if(mypub.init(profile))
                 {
-                    mypub.run(60);
+                    mypub.run(60, wait_unmatch);
                 }
                 break;
             }
@@ -74,7 +77,7 @@ int main(int argc, char** argv)
                 AllocTestSubscriber mysub;
                 if(mysub.init(profile))
                 {
-                    mysub.run();
+                    mysub.run(wait_unmatch);
                 }
                 break;
             }

--- a/test/profiling/allocations/CMakeLists.txt
+++ b/test/profiling/allocations/CMakeLists.txt
@@ -1,4 +1,4 @@
-# Copyright 2016 Proyectos y Sistemas de Mantenimiento SL (eProsima).
+# Copyright 2018-2019 Proyectos y Sistemas de Mantenimiento SL (eProsima).
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -12,34 +12,23 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-cmake_minimum_required(VERSION 2.8.12)
+cmake_minimum_required(VERSION 3.5)
 
-if(NOT CMAKE_VERSION VERSION_LESS 3.0)
-    cmake_policy(SET CMP0048 NEW)
+project(fastrtps_allocation_test)
+
+# Default to C++11
+if(NOT CMAKE_CXX_STANDARD)
+  set(CMAKE_CXX_STANDARD 11)
 endif()
 
-project(AllocationTest)
+if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
+  add_compile_options(-Wall -Wextra -Wpedantic -Werror)
+endif()
 
 # Find requirements
-if(NOT fastcdr_FOUND)
-    find_package(fastcdr REQUIRED)
-endif()
-
-if(NOT fastrtps_FOUND)
-    find_package(fastrtps REQUIRED)
-endif()
-
-# Set C++11
-include(CheckCXXCompilerFlag)
-if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_COMPILER_IS_CLANG OR
-        CMAKE_CXX_COMPILER_ID MATCHES "Clang")
-    check_cxx_compiler_flag(-std=c++11 SUPPORTS_CXX11)
-    if(SUPPORTS_CXX11)
-        add_compile_options(-std=c++11)
-    else()
-        message(FATAL_ERROR "Compiler doesn't support C++11")
-    endif()
-endif()
+find_package(fastcdr REQUIRED)
+find_package(fastrtps REQUIRED)
+find_package(osrf_testing_tools_cpp REQUIRED)
 
 message(STATUS "Configuring AllocationTest...")
 file(GLOB ALLOCTEST_EXAMPLE_SOURCES_CXX "*.cxx")
@@ -53,6 +42,7 @@ file(COPY ${CMAKE_CURRENT_SOURCE_DIR}/test.sh
     )
 
 add_executable(AllocationTest ${ALLOCTEST_EXAMPLE_SOURCES_CXX} ${ALLOCTEST_EXAMPLE_SOURCES_CPP})
-target_link_libraries(AllocationTest fastrtps fastcdr)
+target_link_libraries(AllocationTest fastrtps fastcdr osrf_testing_tools_cpp::memory_tools)
 install(TARGETS AllocationTest
     RUNTIME DESTINATION test/profiling/allocations/${BIN_INSTALL_DIR})
+

--- a/test/profiling/allocations/CMakeLists.txt
+++ b/test/profiling/allocations/CMakeLists.txt
@@ -26,8 +26,6 @@ if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
 endif()
 
 # Find requirements
-find_package(fastcdr REQUIRED)
-find_package(fastrtps REQUIRED)
 find_package(osrf_testing_tools_cpp REQUIRED)
 
 message(STATUS "Configuring AllocationTest...")

--- a/test/profiling/allocations/README.md
+++ b/test/profiling/allocations/README.md
@@ -1,0 +1,42 @@
+## Requisites
+
+This test uses [OSRF testing tools](https://github.com/osrf/osrf_testing_tools_cpp) memory_tools package.
+OSRF testing tools should be installed before building this test.
+
+## Usage
+
+Note: This test needs the xml file stored in the sources directory.
+You need to copy this file to the folder where you will execute the test executable.
+The CMakeList.txt file also copies this file to the folder used to build the test.
+
+To launch this test open two different consoles:
+
+First launch the entity being profiled (publisher or subscriber) with
+```
+LD_PRELOAD=/usr/local/lib/libmemory_tools_interpose.so:/usr/local/lib/libmemory_tools.so ./AllocationTest <entity> <profile> true
+```
+
+Then launch its counterpart with
+```
+./AllocationTest <entity> <profile>
+```
+
+### Arguments
+
+```
+./AllocationTest <entity> [profile] [wait_unmatch]
+```
+
+First argument is mandatory and should have the value `publisher` or `subscriber` indicating the kind of entity to
+profile.
+
+Second argument is optional, defaults to `tl_be` and indicates the kind of qos to load from the XML file.
+
+|         ||
+|---------|-----------------------------|
+| `tl_be` | transient-local best-effort |
+| `tl_re` | transient-local reliable    |
+| `vo_be` | volatile best-effort        |
+| `vo_re` | volatile reliable           |
+
+Third argument is optional, defaults to false, and indicates whether the test should wait for unmatching or not.

--- a/test/profiling/allocations/README.md
+++ b/test/profiling/allocations/README.md
@@ -40,3 +40,22 @@ Second argument is optional, defaults to `tl_be` and indicates the kind of qos t
 | `vo_re` | volatile reliable           |
 
 Third argument is optional, defaults to false, and indicates whether the test should wait for unmatching or not.
+
+### Result
+
+This test generates a CSV file containing the number of allocations and deallocations in each phase.
+The name of the CSV file follows next rule:
+
+```
+alloc_test_<entity>_<profile>.csv
+```
+
+## Generating plot
+
+This test comes with a python script which shows in a plot the allocations registered in a CSV file.
+
+```
+python3 allocation_plot.py <csv file> [0,1,2,3]
+```
+
+The last argument is the phases you want to see in the plot.

--- a/test/profiling/allocations/README.txt
+++ b/test/profiling/allocations/README.txt
@@ -1,6 +1,0 @@
-To launch this test open two different consoles:
-
-In the first one launch: AllocationTest publisher (or AllocationTest.exe publisher on windows).
-In the second one: AllocationTest subscriber.
-
-Note: This test needs the xml file stored in the sources directory. You need to copy this folder where you will execute the test executable. The CMakeList.txt file also copies this file to the folder used to build the test.

--- a/test/profiling/allocations/allocation_plot.py
+++ b/test/profiling/allocations/allocation_plot.py
@@ -1,0 +1,49 @@
+import matplotlib.pyplot as plt
+from matplotlib import style
+import numpy as np
+import pandas as pd
+import sys
+
+if len(sys.argv) < 2:
+    print("Bad usage.")
+    print("    allocation_plot.py <csv_file> [0,1,2,3]")
+    exit(-1)
+
+if len(sys.argv) > 2:
+    bp0 = sys.argv[2].find('0') != -1
+    bp1 = sys.argv[2].find('1') != -1
+    bp2 = sys.argv[2].find('2') != -1
+    bp3 = sys.argv[2].find('3') != -1
+else:
+    bp0 = True
+    bp1 = True
+    bp2 = True
+    bp3 = True
+
+headers = ["Phase 0 Allocations", "Phase 0 Deallocations", "Phase 1 Allocations", "Phase 1 Deallocations",
+        "Phase 2 Allocations", "Phase 2 Deallocations", "Phase 3 Allocations", "Phase 3 Deallocations"]
+
+df = pd.read_csv(sys.argv[1], delimiter=",", names=headers)
+p0a = [float(value) for value in df["Phase 0 Allocations"].values[1::]]
+p1a = [float(value) for value in df["Phase 1 Allocations"].values[1::]]
+p2a = [float(value) for value in df["Phase 2 Allocations"].values[1::]]
+p3a = [float(value) for value in df["Phase 3 Allocations"].values[1::]]
+
+axis = np.arange(1, len(p0a)+1)
+
+style.use('ggplot')
+
+if bp0:
+    plt.plot(axis, p0a, label='Ph0')
+if bp1:
+    plt.plot(axis, p1a, label='Ph1')
+if bp2:
+    plt.plot(axis, p2a, label='Ph2')
+if bp3:
+    plt.plot(axis, p3a, label='Ph3')
+plt.xlabel("Execution")
+plt.ylabel("Allocations")
+plt.title("Allocations in phases")
+plt.xticks(axis, axis)
+plt.legend()
+plt.show()

--- a/test/profiling/allocations/test.sh
+++ b/test/profiling/allocations/test.sh
@@ -33,7 +33,7 @@ IFS=$old
 #   --dump-before          to force dump when callgrind_dump() is called
 #   --zero-before          to reset the counters when callgrind_zero_count() is called
 #   --callgrind-out-file   to include the arguments on the name of the generated files
-valgrind --tool=callgrind --dump-before=callgrind_dump* --zero-before=callgrind_zero_count* --callgrind-out-file=callgrind.out.$str ./AllocationTest $*
+valgrind --tool=callgrind --dump-before=*callgrind_dump* --zero-before=*callgrind_zero_count* --callgrind-out-file=callgrind.out.$str ./AllocationTest $*
 
 # Remove the base dump file, as we only want the explicitly created dumps
 rm callgrind.out.$str


### PR DESCRIPTION
Created a new profiling test to analyze the number of allocations made on each different steps of the execution(Discovery, Communication, Undiscovery).

The main goal is to have the CI system to keep a historical record of the amount of (de)allocations happening after the creation of all entities. This would allow triggering an alarm when an increment is detected.