### PR TITLE
Fixed size bitmaps [4320]

### DIFF
--- a/include/fastrtps/rtps/common/CacheChange.h
+++ b/include/fastrtps/rtps/common/CacheChange.h
@@ -318,7 +318,18 @@ namespace eprosima
 
                 FragmentNumberSet_t getUnsentFragments() const
                 {
-                    return unsent_fragments_;
+                    FragmentNumberSet_t rv;
+                    auto min = unsent_fragments_.begin();
+                    if (min != unsent_fragments_.end())
+                    {
+                        rv.base(*min);
+                        for (FragmentNumber_t fn : unsent_fragments_)
+                        {
+                            rv.add(fn);
+                        }
+                    }
+
+                    return rv;
                 }
 
                 void markAllFragmentsAsUnsent()
@@ -335,8 +346,10 @@ namespace eprosima
 
                 void markFragmentsAsUnsent(const FragmentNumberSet_t& unsentFragments)
                 {
-                    for(auto element : unsentFragments.set)
+                    unsentFragments.for_each([this](FragmentNumber_t element)
+                    {
                         unsent_fragments_.insert(element);
+                    });
                 }
 
                 private:

--- a/include/fastrtps/rtps/common/FragmentNumber.h
+++ b/include/fastrtps/rtps/common/FragmentNumber.h
@@ -25,7 +25,6 @@
 #include <set>
 #include <cmath>
 #include <algorithm>
-#include <sstream>
 
 namespace eprosima{
 namespace fastrtps{

--- a/include/fastrtps/rtps/common/FragmentNumber.h
+++ b/include/fastrtps/rtps/common/FragmentNumber.h
@@ -19,169 +19,33 @@
 #ifndef RPTS_ELEM_FRAGNUM_H_
 #define RPTS_ELEM_FRAGNUM_H_
 #include "../../fastrtps_dll.h"
+#include "../../utils/fixed_size_bitmap.hpp"
 #include "Types.h"
 
 #include <set>
 #include <cmath>
 #include <algorithm>
 #include <sstream>
+
 namespace eprosima{
 namespace fastrtps{
 namespace rtps{
 
-typedef uint32_t FragmentNumber_t;
+using FragmentNumber_t = uint32_t;
 
 //!Structure FragmentNumberSet_t, contains a group of fragmentnumbers.
 //!@ingroup COMMON_MODULE
-class FragmentNumberSet_t
+using FragmentNumberSet_t = BitmapRange<FragmentNumber_t>;
+
+inline std::ostream& operator<<(std::ostream& output, const FragmentNumberSet_t& fns)
 {
-    public:
+    output << fns.base() << ":";
+    fns.for_each([&](FragmentNumber_t it)
+    {
+        output << it << "-";
+    });
 
-        //!Base fragment number
-        FragmentNumber_t base;
-
-        /**
-         * Assignment operator
-         * @param set2 FragmentNumberSet_t to copy the data from
-         */
-        FragmentNumberSet_t& operator=(const FragmentNumberSet_t& set2)
-        {
-            base = set2.base;
-            set = set2.set;
-            return *this;
-        }
-
-        FragmentNumberSet_t(): base(0), set() {}
-
-        FragmentNumberSet_t(const std::set<FragmentNumber_t>& set2) : base(0)
-        {
-            set = set2;
-            auto min = set.begin();
-            if (min != set.end())
-                base = *min;
-        }
-
-        /**
-         * Compares object with other FragmentNumberSet_t.
-         * @param other FragmentNumberSet_t to compare
-         * @return True if equal
-         */
-        bool operator==(const FragmentNumberSet_t& other) {
-
-            if (base != other.base)
-                return false;
-            return other.set == set;	
-        }
-
-
-        /**
-         * Add a fragment number to the set
-         * @param in FragmentNumberSet_t to add
-         * @return True on success
-         */
-        bool add(FragmentNumber_t in)
-        {
-            if (in >= base && in <= base + 255)
-                set.insert(in);
-            else
-                return false;
-            return true;
-        }
-
-        /**
-         * Check if the set is empty
-         * @return True if the set is empty
-         */
-        bool isSetEmpty() const
-        {
-            return set.empty();
-        }
-
-        /**
-         * Get the begin of the set
-         * @return Vector iterator pointing to the begin of the set
-         */
-        std::set<FragmentNumber_t>::const_iterator get_begin() const
-        {
-            return set.begin();
-        }
-
-        /**
-         * Get the end of the set
-         * @return Vector iterator pointing to the end of the set
-         */
-        std::set<FragmentNumber_t>::const_iterator get_end() const
-        {
-            return set.end();
-        }
-
-        /**
-         * Get the number of FragmentNumbers in the set
-         * @return Size of the set
-         */
-        size_t get_size()
-        {
-            return set.size();
-        }
-
-        /**
-         * Get a string representation of the set
-         * @return string representation of the set
-         */
-        std::string print()
-        {
-            std::stringstream ss;
-            ss << base << ":";
-            for (auto it = set.begin(); it != set.end(); ++it)
-                ss << *it << "-";
-            return ss.str();
-        }
-
-        FragmentNumberSet_t& operator-=(const FragmentNumberSet_t& rhs)
-        {
-            for ( auto element : rhs.set)
-                set.erase(element);
-            return *this;
-        }
-
-        FragmentNumberSet_t& operator-=(const FragmentNumber_t& fragment_number)
-        {
-            set.erase(fragment_number);
-            return *this;
-        }
-
-        FragmentNumberSet_t& operator+=(const FragmentNumberSet_t& rhs)
-        {
-            for ( auto element : rhs.set )
-                add(element);
-            return *this;
-        }
-
-        std::set<FragmentNumber_t> set;
-};
-
-/**
- * Prints a Fragment Number set
- * @param output Output Stream
- * @param sns SequenceNumber set
- * @return OStream.
- */
-inline std::ostream& operator<<(std::ostream& output, FragmentNumberSet_t& sns){
-    return output << sns.print();
-}
-
-inline FragmentNumberSet_t operator-(FragmentNumberSet_t lhs, const FragmentNumberSet_t& rhs)
-{
-    for ( auto element : rhs.set)
-        lhs.set.erase(element);
-    return lhs;
-}
-
-inline FragmentNumberSet_t operator+(FragmentNumberSet_t lhs, const FragmentNumberSet_t& rhs)
-{
-    for ( auto element : rhs.set)
-        lhs.add(element);
-    return lhs;
+    return output;
 }
 
 }

--- a/include/fastrtps/rtps/common/SequenceNumber.h
+++ b/include/fastrtps/rtps/common/SequenceNumber.h
@@ -19,6 +19,7 @@
 #ifndef RPTS_ELEM_SEQNUM_H_
 #define RPTS_ELEM_SEQNUM_H_
 #include "../../fastrtps_dll.h"
+#include "../../utils/fixed_size_bitmap.hpp"
 #include "Types.h"
 
 #include <vector>
@@ -42,7 +43,7 @@ struct RTPS_DllAPI SequenceNumber_t
     uint32_t low;
 
     //!Default constructor
-    SequenceNumber_t()
+    SequenceNumber_t() noexcept
     {
         high = 0;
         low = 0;
@@ -51,7 +52,7 @@ struct RTPS_DllAPI SequenceNumber_t
     /*!
      * @brief Copy constructor.
      */
-    SequenceNumber_t(const SequenceNumber_t& seq) : high(seq.high), low(seq.low)
+    SequenceNumber_t(const SequenceNumber_t& seq) noexcept : high(seq.high), low(seq.low)
     {
     }
 
@@ -59,7 +60,7 @@ struct RTPS_DllAPI SequenceNumber_t
      * @param hi
      * @param lo
      */
-    SequenceNumber_t(int32_t hi, uint32_t lo): high(hi),low(lo)
+    SequenceNumber_t(int32_t hi, uint32_t lo) noexcept : high(hi),low(lo)
     {
     }
 
@@ -68,7 +69,7 @@ struct RTPS_DllAPI SequenceNumber_t
     /*! Convert the number to 64 bit.
      * @return 64 bit representation of the SequenceNumber
      */
-    uint64_t to64long() const
+    uint64_t to64long() const noexcept
     {
         return (((uint64_t)high) << 32) + low;
     }
@@ -78,7 +79,7 @@ struct RTPS_DllAPI SequenceNumber_t
      * Assignment operator
      * @param seq SequenceNumber_t to copy the data from
      */
-    SequenceNumber_t& operator=(const SequenceNumber_t& seq)
+    SequenceNumber_t& operator= (const SequenceNumber_t& seq) noexcept
     {
         high = seq.high;
         low = seq.low;
@@ -87,7 +88,7 @@ struct RTPS_DllAPI SequenceNumber_t
 
 
     //! Increase SequenceNumber in 1.
-    SequenceNumber_t& operator++()
+    SequenceNumber_t& operator++() noexcept
     {
         if(low == UINT32_MAX)
         { ++high; low = 0; }
@@ -97,7 +98,7 @@ struct RTPS_DllAPI SequenceNumber_t
         return *this;
     }
 
-    SequenceNumber_t operator++(int)
+    SequenceNumber_t operator++(int) noexcept
     {
         SequenceNumber_t result(*this);
         ++(*this);
@@ -108,7 +109,7 @@ struct RTPS_DllAPI SequenceNumber_t
      * Increase SequenceNumber.
      * @param inc Number to add to the SequenceNumber
      */
-    SequenceNumber_t& operator+=(int inc)
+    SequenceNumber_t& operator+=(int inc) noexcept
     {
         uint32_t aux_low = low;
         low += inc;
@@ -122,7 +123,7 @@ struct RTPS_DllAPI SequenceNumber_t
         return *this;
     }
 
-    static SequenceNumber_t unknown()
+    static SequenceNumber_t unknown() noexcept
     {
         return SequenceNumber_t(-1, 0);
     }
@@ -137,7 +138,7 @@ struct RTPS_DllAPI SequenceNumber_t
  * @param sn2 Second SequenceNumber_t to compare
  * @return True if equal
  */
-inline bool operator==(const SequenceNumber_t& sn1, const SequenceNumber_t& sn2)
+inline bool operator==(const SequenceNumber_t& sn1, const SequenceNumber_t& sn2) noexcept
 {
     if(sn1.high != sn2.high || sn1.low != sn2.low)
         return false;
@@ -151,7 +152,7 @@ inline bool operator==(const SequenceNumber_t& sn1, const SequenceNumber_t& sn2)
  * @param sn2 Second SequenceNumber_t to compare
  * @return True if not equal
  */
-inline bool operator!=(const SequenceNumber_t& sn1, const SequenceNumber_t& sn2)
+inline bool operator!=(const SequenceNumber_t& sn1, const SequenceNumber_t& sn2) noexcept
 {
     if(sn1.high == sn2.high && sn1.low == sn2.low)
         return false;
@@ -165,7 +166,7 @@ inline bool operator!=(const SequenceNumber_t& sn1, const SequenceNumber_t& sn2)
  * @param seq2 Second SequenceNumber_t to compare
  * @return True if the first SequenceNumber_t is greater than the second
  */
-inline bool operator>(const SequenceNumber_t& seq1, const SequenceNumber_t& seq2)
+inline bool operator>(const SequenceNumber_t& seq1, const SequenceNumber_t& seq2) noexcept
 {
     if(seq1.high > seq2.high)
         return true;
@@ -185,7 +186,7 @@ inline bool operator>(const SequenceNumber_t& seq1, const SequenceNumber_t& seq2
  * @param seq2 Second SequenceNumber_t to compare
  * @return True if the first SequenceNumber_t is less than the second
  */
-inline bool operator<(const SequenceNumber_t& seq1, const SequenceNumber_t& seq2)
+inline bool operator<(const SequenceNumber_t& seq1, const SequenceNumber_t& seq2) noexcept
 {
     if(seq1.high > seq2.high)
         return false;
@@ -205,7 +206,7 @@ inline bool operator<(const SequenceNumber_t& seq1, const SequenceNumber_t& seq2
  * @param seq2 Second SequenceNumber_t to compare
  * @return True if the first SequenceNumber_t is greater or equal than the second
  */
-inline bool operator>=(const SequenceNumber_t& seq1, const SequenceNumber_t& seq2)
+inline bool operator>=(const SequenceNumber_t& seq1, const SequenceNumber_t& seq2) noexcept
 {
     if(seq1.high > seq2.high)
         return true;
@@ -225,7 +226,7 @@ inline bool operator>=(const SequenceNumber_t& seq1, const SequenceNumber_t& seq
  * @param seq2 Second SequenceNumber_t to compare
  * @return True if the first SequenceNumber_t is less or equal than the second
  */
-inline bool operator<=( const SequenceNumber_t& seq1, const  SequenceNumber_t& seq2)
+inline bool operator<=( const SequenceNumber_t& seq1, const  SequenceNumber_t& seq2) noexcept
 {
     if(seq1.high > seq2.high)
         return false;
@@ -245,7 +246,7 @@ inline bool operator<=( const SequenceNumber_t& seq1, const  SequenceNumber_t& s
  * @param inc SequenceNumber_t to substract
  * @return Result of the substraction
  */
-inline SequenceNumber_t operator-(const SequenceNumber_t& seq, const uint32_t inc)
+inline SequenceNumber_t operator-(const SequenceNumber_t& seq, const uint32_t inc) noexcept
 {
     SequenceNumber_t res(seq.high, seq.low - inc);
 
@@ -264,7 +265,7 @@ inline SequenceNumber_t operator-(const SequenceNumber_t& seq, const uint32_t in
  * @param inc value to add to the base
  * @return Result of the addition
  */
-inline SequenceNumber_t operator+(const SequenceNumber_t& seq, const uint32_t inc)
+inline SequenceNumber_t operator+(const SequenceNumber_t& seq, const uint32_t inc) noexcept
 {
     SequenceNumber_t res(seq.high, seq.low + inc);
 
@@ -283,7 +284,7 @@ inline SequenceNumber_t operator+(const SequenceNumber_t& seq, const uint32_t in
  * @param subtrahend Subtrahend.
  * @return Result of the subtraction
  */
-inline SequenceNumber_t operator-(const SequenceNumber_t& minuend, const SequenceNumber_t& subtrahend)
+inline SequenceNumber_t operator-(const SequenceNumber_t& minuend, const SequenceNumber_t& subtrahend) noexcept
 {
     assert(minuend >= subtrahend);
     SequenceNumber_t res(minuend.high - subtrahend.high, minuend.low - subtrahend.low);
@@ -306,7 +307,7 @@ const SequenceNumber_t c_SequenceNumber_Unknown(-1,0);
  * @param s2 First SequenceNumber_t to compare
  * @return True if s1 is less than s2
  */
-inline bool sort_seqNum(const SequenceNumber_t& s1, const SequenceNumber_t& s2)
+inline bool sort_seqNum(const SequenceNumber_t& s1, const SequenceNumber_t& s2) noexcept
 {
     return(s1 < s2);
 }
@@ -340,7 +341,7 @@ inline std::ostream& operator<<(std::ostream& output, std::vector<SequenceNumber
  */
 struct SequenceNumberHash
 {
-    std::size_t operator()(const SequenceNumber_t& sequence_number) const
+    std::size_t operator()(const SequenceNumber_t& sequence_number) const noexcept
     {
 #ifdef LLONG_MAX
         return static_cast<std::size_t>(sequence_number.to64long());
@@ -350,87 +351,25 @@ struct SequenceNumberHash
     };
 };
 
+struct SequenceNumberDiff
+{
+    uint32_t operator () (const SequenceNumber_t& a, const SequenceNumber_t& b) const noexcept
+    {
+        SequenceNumber_t diff = a - b;
+        return diff.low;
+    }
+};
+
 #endif
 
 //!Structure SequenceNumberSet_t, contains a group of sequencenumbers.
 //!@ingroup COMMON_MODULE
-class SequenceNumberSet_t
+class SequenceNumberSet_t : public BitmapRange<SequenceNumber_t, SequenceNumberDiff, 256>
 {
     public:
-        //!Base sequence number
-        SequenceNumber_t base;
 
-        /**
-         * Assignment operator
-         * @param set2 SequenceNumberSet_t to copy the data from
-         */
-        SequenceNumberSet_t& operator=(const SequenceNumberSet_t& set2)
-        {
-            base = set2.base;
-            set = set2.set;
-            return *this;
-        }
-
-        /**
-         * Add a sequence number to the set
-         * @param in SequenceNumberSet_t to add
-         * @return True on success
-         */
-        bool add(const SequenceNumber_t& in)
-        {
-            SequenceNumber_t max = base + 255;
-            if(in >= base && in < max)
-                set.push_back(in);
-            else
-                return false;
-
-            return true;
-        }
-
-        /**
-         * Get the maximum sequence number in the set
-         * @return maximum sequence number in the set
-         */
-        SequenceNumber_t get_maxSeqNum() const
-        {
-            return *std::max_element(set.begin(),set.end(),sort_seqNum);
-        }
-
-        /**
-         * Check if the set is empty
-         * @return True if the set is empty
-         */
-        bool isSetEmpty() const
-        {
-            return set.empty();
-        }
-
-        /**
-         * Get the begin of the set
-         * @return Vector iterator pointing to the begin of the set
-         */
-        std::vector<SequenceNumber_t>::const_iterator get_begin() const
-        {
-            return set.begin();
-        }
-
-        /**
-         * Get the end of the set
-         * @return Vector iterator pointing to the end of the set
-         */
-        std::vector<SequenceNumber_t>::const_iterator get_end() const
-        {
-            return set.end();
-        }
-
-        /**
-         * Get the number of SequenceNumbers in the set
-         * @return Size of the set
-         */
-        size_t get_size()
-        {
-            return set.size();
-        }
+        SequenceNumberSet_t() : BitmapRange() {}
+        explicit SequenceNumberSet_t(SequenceNumber_t base) : BitmapRange(base) {}
 
         /**
          * Get a string representation of the set
@@ -441,23 +380,21 @@ class SequenceNumberSet_t
             std::stringstream ss;
 
 #ifdef LLONG_MAX
-            ss << base.to64long() << ":";
+            ss << base_.to64long() << ":";
 #else
-            ss << "{high: " << base.high << ", low: " << base.low << "} :";
+            ss << "{high: " << base_.high << ", low: " << base_.low << "} :";
 #endif
-            for(std::vector<SequenceNumber_t>::const_iterator it = set.begin(); it != set.end(); ++it)
+
+            for_each([&](SequenceNumber_t it)
             {
 #ifdef LLONG_MAX
-                ss << it->to64long() << "-";
+                ss << it.to64long() << "-";
 #else
-                ss << "{high: " << it->high << ", low: " << it->low << "} -";
+                ss << "{high: " << it.high << ", low: " << it.low << "} -";
 #endif
-            }
+            });
             return ss.str();
         }
-
-    private:
-        std::vector<SequenceNumber_t> set;
 };
 
 #ifndef DOXYGEN_SHOULD_SKIP_THIS_PUBLIC
@@ -471,18 +408,18 @@ class SequenceNumberSet_t
 inline std::ostream& operator<<(std::ostream& output, const SequenceNumberSet_t& sns)
 {
 #ifdef LLONG_MAX
-    output << sns.base.to64long() << ":";
+    output << sns.base().to64long() << ":";
 #else
-    output << "{high: " << sns.base.high << ", low: " << sns.base.low << "} :";
+    output << "{high: " << sns.base().high << ", low: " << sns.base().low << "} :";
 #endif
-    for (std::vector<SequenceNumber_t>::const_iterator it = sns.get_begin(); it != sns.get_end(); ++it)
+    sns.for_each([&](SequenceNumber_t it)
     {
 #ifdef LLONG_MAX
-        output << it->to64long() << "-";
+        output << it.to64long() << "-";
 #else
-        output << "{high: " << it->high << ", low: " << it->low << "} -";
+        output << "{high: " << it.high << ", low: " << it.low << "} -";
 #endif
-    }
+    });
 
     return output;
 }

--- a/include/fastrtps/rtps/common/SequenceNumber.h
+++ b/include/fastrtps/rtps/common/SequenceNumber.h
@@ -433,19 +433,10 @@ class SequenceNumberSet_t
         }
 
         /**
-         * Get the set of SequenceNumbers 
-         * @return Set of SequenceNumbers
-         */
-        std::vector<SequenceNumber_t> get_set() const
-        {
-            return set;
-        }
-
-        /**
          * Get a string representation of the set
          * @return string representation of the set
          */
-        std::string print()
+        std::string print() const
         {
             std::stringstream ss;
 
@@ -454,7 +445,7 @@ class SequenceNumberSet_t
 #else
             ss << "{high: " << base.high << ", low: " << base.low << "} :";
 #endif
-            for(std::vector<SequenceNumber_t>::iterator it = set.begin(); it != set.end(); ++it)
+            for(std::vector<SequenceNumber_t>::const_iterator it = set.begin(); it != set.end(); ++it)
             {
 #ifdef LLONG_MAX
                 ss << it->to64long() << "-";
@@ -477,9 +468,23 @@ class SequenceNumberSet_t
  * @param sns SequenceNumber set
  * @return OStream.
  */
-inline std::ostream& operator<<(std::ostream& output, SequenceNumberSet_t& sns)
+inline std::ostream& operator<<(std::ostream& output, const SequenceNumberSet_t& sns)
 {
-    return output << sns.print();
+#ifdef LLONG_MAX
+    output << sns.base.to64long() << ":";
+#else
+    output << "{high: " << sns.base.high << ", low: " << sns.base.low << "} :";
+#endif
+    for (std::vector<SequenceNumber_t>::const_iterator it = sns.get_begin(); it != sns.get_end(); ++it)
+    {
+#ifdef LLONG_MAX
+        output << it->to64long() << "-";
+#else
+        output << "{high: " << it->high << ", low: " << it->low << "} -";
+#endif
+    }
+
+    return output;
 }
 
 #endif

--- a/include/fastrtps/rtps/common/SequenceNumber.h
+++ b/include/fastrtps/rtps/common/SequenceNumber.h
@@ -24,7 +24,6 @@
 
 #include <vector>
 #include <algorithm>
-#include <sstream>
 #include <limits.h>
 #include <cassert>
 
@@ -364,38 +363,7 @@ struct SequenceNumberDiff
 
 //!Structure SequenceNumberSet_t, contains a group of sequencenumbers.
 //!@ingroup COMMON_MODULE
-class SequenceNumberSet_t : public BitmapRange<SequenceNumber_t, SequenceNumberDiff, 256>
-{
-    public:
-
-        SequenceNumberSet_t() : BitmapRange() {}
-        explicit SequenceNumberSet_t(SequenceNumber_t base) : BitmapRange(base) {}
-
-        /**
-         * Get a string representation of the set
-         * @return string representation of the set
-         */
-        std::string print() const
-        {
-            std::stringstream ss;
-
-#ifdef LLONG_MAX
-            ss << base_.to64long() << ":";
-#else
-            ss << "{high: " << base_.high << ", low: " << base_.low << "} :";
-#endif
-
-            for_each([&](SequenceNumber_t it)
-            {
-#ifdef LLONG_MAX
-                ss << it.to64long() << "-";
-#else
-                ss << "{high: " << it.high << ", low: " << it.low << "} -";
-#endif
-            });
-            return ss.str();
-        }
-};
+using SequenceNumberSet_t = BitmapRange<SequenceNumber_t, SequenceNumberDiff, 256>;
 
 #ifndef DOXYGEN_SHOULD_SKIP_THIS_PUBLIC
 

--- a/include/fastrtps/rtps/messages/CDRMessage.h
+++ b/include/fastrtps/rtps/messages/CDRMessage.h
@@ -61,7 +61,7 @@ namespace CDRMessage{
 	  inline bool readUInt16(CDRMessage_t* msg,uint16_t* i16);
 	  inline bool readLocator(CDRMessage_t* msg,Locator_t* loc);
 	  inline bool readOctet(CDRMessage_t* msg, octet* o);
-	  inline bool readSequenceNumberSet(CDRMessage_t* msg, SequenceNumberSet_t* snset);
+	  inline SequenceNumberSet_t readSequenceNumberSet(CDRMessage_t* msg);
 	  inline bool readFragmentNumberSet(CDRMessage_t* msg, FragmentNumberSet_t* snset);
 	  inline bool readTimestamp(CDRMessage_t*msg,Time_t* ts);
 	  inline bool readString(CDRMessage_t*msg,std::string* p_str);

--- a/include/fastrtps/rtps/messages/CDRMessage.hpp
+++ b/include/fastrtps/rtps/messages/CDRMessage.hpp
@@ -176,7 +176,7 @@ inline SequenceNumberSet_t CDRMessage::readSequenceNumberSet(CDRMessage_t* msg)
 inline bool CDRMessage::readFragmentNumberSet(CDRMessage_t* msg, FragmentNumberSet_t* fns)
 {
     bool valid = true;
-    FragmentNumber_t base;
+    FragmentNumber_t base = 0ul;
     valid &= CDRMessage::readUInt32(msg, &base);
     fns->base(base);
     uint32_t numBits = 0;

--- a/include/fastrtps/rtps/reader/RTPSReader.h
+++ b/include/fastrtps/rtps/reader/RTPSReader.h
@@ -24,6 +24,7 @@
 
 #include "../Endpoint.h"
 #include "../attributes/ReaderAttributes.h"
+#include "../common/SequenceNumber.h"
 
 #include <map>
 
@@ -39,8 +40,6 @@ namespace eprosima
             class ReaderHistory;
             struct CacheChange_t;
             class WriterProxy;
-            struct SequenceNumber_t;
-            class SequenceNumberSet_t;
             class FragmentedChangePitStop;
 
             /**

--- a/include/fastrtps/rtps/writer/ReaderProxy.h
+++ b/include/fastrtps/rtps/writer/ReaderProxy.h
@@ -80,7 +80,7 @@ namespace eprosima
                  * @param seqNumSet Vector of sequenceNumbers
                  * @return False if any change was set REQUESTED.
                  */
-                bool requested_changes_set(std::vector<SequenceNumber_t>& seqNumSet);
+                bool requested_changes_set(const SequenceNumberSet_t& seqNumSet);
 
                 /*!
                  * @brief Lists all unsent changes. These changes are also relevants and valid.
@@ -147,7 +147,7 @@ namespace eprosima
                  * @param[in] sequence_number Sequence number to be paired with the requested fragments.
                  * @return True if there is at least one requested fragment. False in other case.
                  */
-                bool requested_fragment_set(SequenceNumber_t sequence_number, const FragmentNumberSet_t& frag_set);
+                bool requested_fragment_set(const SequenceNumber_t& sequence_number, const FragmentNumberSet_t& frag_set);
 
                 /*!
                  * @brief Returns the last NACKFRAG count.

--- a/include/fastrtps/rtps/writer/ReaderProxy.h
+++ b/include/fastrtps/rtps/writer/ReaderProxy.h
@@ -101,12 +101,6 @@ namespace eprosima
                 }
 
                 /*!
-                 * @brief Lists all requested changes.
-                 * @return STL vector with the requested change list.
-                 */
-                std::vector<const ChangeForReader_t*> get_requested_changes() const;
-
-                /*!
                  * @brief Sets a change to a particular status (if present in the ReaderProxy)
                  * @param change change to search and set.
                  * @param status Status to apply.

--- a/include/fastrtps/rtps/writer/ReaderProxy.h
+++ b/include/fastrtps/rtps/writer/ReaderProxy.h
@@ -82,13 +82,24 @@ namespace eprosima
                  */
                 bool requested_changes_set(const SequenceNumberSet_t& seqNumSet);
 
-                /*!
-                 * @brief Lists all unsent changes. These changes are also relevants and valid.
-                 * @return STL vector with the unsent change list.
-                 */
-                //TODO(Ricardo) Temporal
-                //std::vector<const ChangeForReader_t*> get_unsent_changes() const;
-                std::vector<ChangeForReader_t*> get_unsent_changes();
+                /**
+                * Applies the given function object to every unsent change.
+                * @param seqNumSet Vector of sequenceNumbers
+                */
+                template <class UnaryFunction>
+                void for_each_unsent_change(UnaryFunction f) const
+                {
+                    std::lock_guard<std::recursive_mutex> guard(*mp_mutex);
+
+                    for (auto &change_for_reader : m_changesForReader)
+                    {
+                        if (change_for_reader.getStatus() == UNSENT)
+                        {
+                            f(&change_for_reader);
+                        }
+                    }
+                }
+
                 /*!
                  * @brief Lists all requested changes.
                  * @return STL vector with the requested change list.

--- a/include/fastrtps/utils/fixed_size_bitmap.hpp
+++ b/include/fastrtps/utils/fixed_size_bitmap.hpp
@@ -1,0 +1,221 @@
+// Copyright 2018 Proyectos y Sistemas de Mantenimiento SL (eProsima).
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+/*!
+* @file fixed_size_string.hpp
+*
+*/
+
+#ifndef FASTRTPS_UTILS_FIXED_SIZE_BITMAP_HPP_
+#define FASTRTPS_UTILS_FIXED_SIZE_BITMAP_HPP_
+
+#include <array>
+#include <string.h>
+
+#if _MSC_VER
+#include <intrin.h>
+#endif
+
+#ifndef DOXYGEN_SHOULD_SKIP_THIS_PUBLIC
+namespace eprosima {
+namespace fastrtps {
+
+template <class T>
+struct DiffFunction
+{
+    constexpr auto operator () (T a, T b) const 
+        -> decltype(a - b) 
+    { 
+        return a - b; 
+    }
+};
+
+/**
+ * Template class to hold a range of items using a custom bitmap.
+ * @tparam T      Type of the elements in the range.
+ *                Should have `>=` operator and `T + uint32_t` returning T. 
+ * @tparam Diff   Functor calculating the difference of two T. 
+ *                The result should be assignable to a uint32_t.
+ * @tparam NBITS  Size in bits of the bitmap.
+ *                Range of items will be [base, base + NBITS - 1].
+ * @ingroup UTILITIES_MODULE
+ */
+template<class T, class Diff = DiffFunction<T>, uint32_t NBITS = 256>
+class BitmapRange
+{
+public:
+    // Alias to improve readability.
+    using bitmap_type = std::array<uint32_t, (NBITS + 31) / 32>;
+
+    /**
+     * Default constructor.
+     * Constructs an empty range with default base.
+     */
+    BitmapRange() noexcept : base_(), bitmap_(), num_bits_(0u) {}
+
+    /**
+     * Base-specific constructor.
+     * Constructs an empty range with specified base.
+     * 
+     * @param base   Specific base value for the created range.
+     */
+    explicit BitmapRange(T base) noexcept : base_(base), bitmap_(), num_bits_(0u) {}
+
+    // We don't need to define copy/move constructors/assignment operators as the default ones would be enough
+
+    /**
+     * Get base of the range.
+     * @return a copy of the range base.
+     */
+    T base() const noexcept { return base_; }
+
+    /**
+     * Set a new base for the range.
+     * This method resets the range and sets a new value for its base.
+     *
+     * @param base   New base value to set.
+     */
+    void base(T base) noexcept
+    {
+        base_ = base;
+        num_bits_ = 0;
+        bitmap_.fill(0UL);
+    }
+
+    /**
+     * Returns whether the range is empty (i.e. has at least one bit set).
+     * 
+     * @return true if the range is empty, false otherwise.
+     */
+    bool empty() const noexcept { return num_bits_ == 0u; }
+
+    /**
+     * Returns the highest value set in the range.
+     * 
+     * @return the highest value set in the range. If the range is empty, the result is undetermined.
+     */
+    T max() const noexcept { return base_ + (num_bits_ - 1); }
+
+    /**
+     * Adds an element to the range.
+     * Adds an element to the bitmap if it is in the allowed range.
+     *
+     * @param item   Value to be added.
+     *
+     * @return true if the item has been added (i.e. is in the allowed range), false otherwise.
+     */
+    bool add(const T& item) noexcept
+    {
+        // Compute maximum allowed value and check item is inside the allowed range.
+        T max = base_ + (NBITS - 1);
+        if ((item >= base_) && (max >= item))
+        {
+            // Calc distance from base to item, and set the corresponding bit.
+            Diff d_func;
+            uint32_t diff = d_func(item, base_);
+            num_bits_ = std::max(diff + 1, num_bits_);
+            uint32_t pos = diff >> 5;
+            diff &= 31UL;
+            bitmap_[pos] |= (1UL << (31UL - diff) );
+            return true;
+        }
+
+        return false;
+    }
+
+    /**
+     * Gets the current value of the bitmap.
+     * This method is designed to be used when performing serialization of a bitmap range.
+     * 
+     * @param num_bits         Upon return, it will contain the number of significant bits in the bitmap.
+     * @param bitmap           Upon return, it will contain the current value of the bitmap.
+     * @param num_longs_used   Upon return, it will contain the number of valid elements on the returned bitmap.
+     */
+    void bitmap_get(uint32_t& num_bits, bitmap_type& bitmap, uint32_t& num_longs_used) const noexcept
+    {
+        num_bits = num_bits_;
+        num_longs_used = (num_bits_ + 31UL) / 32UL;
+        bitmap = bitmap_;
+    }
+
+    /**
+     * Sets the current value of the bitmap.
+     * This method is designed to be used when performing deserialization of a bitmap range.
+     * 
+     * @param num_bits   Number of significant bits in the input bitmap.
+     * @param bitmap     Points to the begining of a uint32_t array holding the input bitmap.
+     */
+    void bitmap_set(uint32_t num_bits, const uint32_t* bitmap) noexcept
+    {
+        num_bits_ = std::min(num_bits, NBITS);
+        uint32_t num_bytes = ( (num_bits_ + 31UL) / 32UL) * sizeof(uint32_t);
+        bitmap_.fill(0UL);
+        memcpy(bitmap_.data(), bitmap, num_bytes);
+    }
+
+    /**
+     * Apply a function on every item on the range.
+     *
+     * @param f   Function to apply on each item.
+     */
+    template<class UnaryFunc>
+    void for_each(UnaryFunc f) const
+    {
+        T item = base_;
+
+        // Traverse through the significant items on the bitmap
+        uint32_t n_longs = (num_bits_ + 31UL) / 32UL;
+        for (uint32_t i = 0; i < n_longs; i++)
+        {
+            // Traverse through the bits set on the item, msb first.
+            // Loop will stop when there are no bits set.
+            uint32_t bits = bitmap_[i];
+            while(bits)
+            {
+                // We use an intrinsic to find the index of the highest bit set.
+                // Most modern CPUs have an instruction to count the leading zeroes of a word.
+                // The number of leading zeroes will give us the index we need.
+#if _MSC_VER
+                unsigned long bit;
+                _BitScanReverse(&bit, bits);
+                uint32_t offset = 31UL - bit;
+#else
+                uint32_t offset = __builtin_clz(bits);
+                uint32_t bit = 31UL - offset;
+#endif
+
+                // Call the function for the corresponding item
+                f(item + offset);
+
+                // Clear the least significant bit
+                bits &= ~(1UL << bit);
+            }
+
+            // There are 32 items on each bitmap item.
+            item = item + 32UL;
+        }
+    }
+
+protected:
+    T base_;               ///< Holds base value of the range.
+    bitmap_type bitmap_;   ///< Holds the bitmap values.
+    uint32_t num_bits_;    ///< Holds the highest bit set in the bitmap.
+}; 
+    
+}   // namespace fastrtps
+}   // namespace eprosima
+
+#endif   // DOXYGEN_SHOULD_SKIP_THIS_PUBLIC
+
+#endif   // FASTRTPS_UTILS_FIXED_SIZE_BITMAP_HPP_

--- a/include/fastrtps/utils/fixed_size_bitmap.hpp
+++ b/include/fastrtps/utils/fixed_size_bitmap.hpp
@@ -62,7 +62,7 @@ public:
      * Default constructor.
      * Constructs an empty range with default base.
      */
-    BitmapRange() noexcept : base_(), bitmap_(), num_bits_(0u) {}
+    BitmapRange() noexcept : base_(), range_max_(base_ + (NBITS - 1)), bitmap_(), num_bits_(0u) {}
 
     /**
      * Base-specific constructor.
@@ -70,7 +70,7 @@ public:
      * 
      * @param base   Specific base value for the created range.
      */
-    explicit BitmapRange(T base) noexcept : base_(base), bitmap_(), num_bits_(0u) {}
+    explicit BitmapRange(T base) noexcept : base_(base), range_max_(base + (NBITS - 1)), bitmap_(), num_bits_(0u) {}
 
     // We don't need to define copy/move constructors/assignment operators as the default ones would be enough
 
@@ -89,6 +89,7 @@ public:
     void base(T base) noexcept
     {
         base_ = base;
+        range_max_ = base_ + (NBITS - 1);
         num_bits_ = 0;
         bitmap_.fill(0UL);
     }
@@ -117,9 +118,8 @@ public:
      */
     bool add(const T& item) noexcept
     {
-        // Compute maximum allowed value and check item is inside the allowed range.
-        T max = base_ + (NBITS - 1);
-        if ((item >= base_) && (max >= item))
+        // Check item is inside the allowed range.
+        if ((item >= base_) && (range_max_ >= item))
         {
             // Calc distance from base to item, and set the corresponding bit.
             Diff d_func;
@@ -198,7 +198,7 @@ public:
                 // Call the function for the corresponding item
                 f(item + offset);
 
-                // Clear the least significant bit
+                // Clear the most significant bit
                 bits &= ~(1UL << bit);
             }
 
@@ -209,6 +209,7 @@ public:
 
 protected:
     T base_;               ///< Holds base value of the range.
+    T range_max_;          ///< Holds maximum allowed value of the range.
     bitmap_type bitmap_;   ///< Holds the bitmap values.
     uint32_t num_bits_;    ///< Holds the highest bit set in the bitmap.
 }; 

--- a/src/cpp/rtps/messages/MessageReceiver.cpp
+++ b/src/cpp/rtps/messages/MessageReceiver.cpp
@@ -848,8 +848,7 @@ bool MessageReceiver::proc_Submsg_Acknack(CDRMessage_t* msg,SubmessageHeader_t* 
     CDRMessage::readEntityId(msg,&writerGUID.entityId);
 
 
-    SequenceNumberSet_t SNSet;
-    CDRMessage::readSequenceNumberSet(msg,&SNSet);
+    SequenceNumberSet_t SNSet = CDRMessage::readSequenceNumberSet(msg);
     uint32_t Ackcount;
     CDRMessage::readUInt32(msg,&Ackcount);
     //Is the final message?
@@ -903,8 +902,7 @@ bool MessageReceiver::proc_Submsg_Gap(CDRMessage_t* msg,SubmessageHeader_t* smh,
     CDRMessage::readEntityId(msg,&writerGUID.entityId);
     SequenceNumber_t gapStart;
     CDRMessage::readSequenceNumber(msg,&gapStart);
-    SequenceNumberSet_t gapList;
-    CDRMessage::readSequenceNumberSet(msg,&gapList);
+    SequenceNumberSet_t gapList = CDRMessage::readSequenceNumberSet(msg);
     if(gapStart <= SequenceNumber_t(0, 0))
         return false;
 

--- a/src/cpp/rtps/messages/RTPSMessageGroup.cpp
+++ b/src/cpp/rtps/messages/RTPSMessageGroup.cpp
@@ -55,8 +55,7 @@ void prepare_SequenceNumberSet(std::set<SequenceNumber_t>& changesSeqNum,
     {
         if(new_pair)
         {
-            SequenceNumberSet_t seqset;
-            seqset.base = (*it) + 1; // IN CASE IN THIS SEQNUMSET there is only 1 number.
+            SequenceNumberSet_t seqset((*it) + 1); // IN CASE IN THIS SEQNUMSET there is only 1 number.
             pair_T pair(*it,seqset);
             sequences.push_back(pair);
             new_pair = false;
@@ -67,14 +66,14 @@ void prepare_SequenceNumberSet(std::set<SequenceNumber_t>& changesSeqNum,
         if((*it - sequences.back().first).low == count) //CONTINUOUS FROM THE START
         {
             ++count;
-            sequences.back().second.base = (*it)+1;
+            sequences.back().second.base((*it)+1);
             continue;
         }
         else
         {
             if(seqnumset_init) //FIRST TIME SINCE it was continuous
             {
-                sequences.back().second.base = (*(std::prev(it)) + 1);
+                sequences.back().second.base((*(std::prev(it)) + 1));
                 seqnumset_init = false;
             }
             // Try to add, If it fails the diference between *it and base is greater than 255.

--- a/src/cpp/rtps/messages/submessages/AckNackMsg.hpp
+++ b/src/cpp/rtps/messages/submessages/AckNackMsg.hpp
@@ -57,18 +57,11 @@ bool RTPSMessageCreator::addSubmessageAcknack(CDRMessage_t* msg,
     if(finalFlag)
         flags = flags | BIT(1);
 
-    try{
-        CDRMessage::addEntityId(&submsgElem,&readerId);
-        CDRMessage::addEntityId(&submsgElem,&writerId);
-        //Add Sequence Number
-        CDRMessage::addSequenceNumberSet(&submsgElem,&SNSet);
-        CDRMessage::addInt32(&submsgElem,count);
-    }
-    catch(int e)
-    {
-        logError(RTPS_CDR_MSG,"Message creator fails"<<e<<endl)
-            return false;
-    }
+    CDRMessage::addEntityId(&submsgElem,&readerId);
+    CDRMessage::addEntityId(&submsgElem,&writerId);
+    //Add Sequence Number
+    CDRMessage::addSequenceNumberSet(&submsgElem,&SNSet);
+    CDRMessage::addInt32(&submsgElem,count);
 
     //Once the submessage elements are added, the header is created
     RTPSMessageCreator::addSubmessageHeader(msg,ACKNACK, flags, (uint16_t)submsgElem.length);
@@ -84,7 +77,8 @@ bool RTPSMessageCreator::addSubmessageAcknack(CDRMessage_t* msg,
 bool RTPSMessageCreator::addMessageNackFrag(CDRMessage_t* msg, const GuidPrefix_t& guidprefix,
         const GuidPrefix_t& remoteGuidPrefix,
         const EntityId_t& readerId, const EntityId_t& writerId,
-        SequenceNumber_t& writerSN, FragmentNumberSet_t fnState, int32_t count){
+        SequenceNumber_t& writerSN, FragmentNumberSet_t fnState, int32_t count)
+{
     try
     {
         RTPSMessageCreator::addHeader(msg, guidprefix);
@@ -114,20 +108,13 @@ bool RTPSMessageCreator::addSubmessageNackFrag(CDRMessage_t* msg,
     submsgElem.msg_endian = LITTLEEND;
 #endif
 
-    try{
-        CDRMessage::addEntityId(&submsgElem, &readerId);
-        CDRMessage::addEntityId(&submsgElem, &writerId);
-        //Add Sequence Number
-        CDRMessage::addSequenceNumber(&submsgElem, &writerSN);
-        // Add fragment number status
-        CDRMessage::addFragmentNumberSet(&submsgElem, &fnState);
-        CDRMessage::addUInt32(&submsgElem, count);
-    }
-    catch (int e)
-    {
-        logError(RTPS_CDR_MSG, "Message creator fails" << e << endl)
-            return false;
-    }
+    CDRMessage::addEntityId(&submsgElem, &readerId);
+    CDRMessage::addEntityId(&submsgElem, &writerId);
+    //Add Sequence Number
+    CDRMessage::addSequenceNumber(&submsgElem, &writerSN);
+    // Add fragment number status
+    CDRMessage::addFragmentNumberSet(&submsgElem, &fnState);
+    CDRMessage::addUInt32(&submsgElem, count);
 
     //Once the submessage elements are added, the header is created
     RTPSMessageCreator::addSubmessageHeader(msg, NACK_FRAG, flags, (uint16_t)submsgElem.length);

--- a/src/cpp/rtps/messages/submessages/GapMsg.hpp
+++ b/src/cpp/rtps/messages/submessages/GapMsg.hpp
@@ -54,19 +54,11 @@ bool RTPSMessageCreator::addSubmessageGap(CDRMessage_t* msg, const SequenceNumbe
     submsgElem.msg_endian   = LITTLEEND;
 #endif
 
-    try{
-        CDRMessage::addEntityId(&submsgElem,&readerId);
-        CDRMessage::addEntityId(&submsgElem,&writerId);
-        //Add Sequence Number
-        CDRMessage::addSequenceNumber(&submsgElem,&seqNumFirst);
-        CDRMessage::addSequenceNumberSet(&submsgElem,&seqNumList);
-    }
-    catch(int e)
-    {
-        logError(RTPS_CDR_MSG,"Gap submessage error"<<e<<endl)
-            return false;
-    }
-
+    CDRMessage::addEntityId(&submsgElem,&readerId);
+    CDRMessage::addEntityId(&submsgElem,&writerId);
+    //Add Sequence Number
+    CDRMessage::addSequenceNumber(&submsgElem,&seqNumFirst);
+    CDRMessage::addSequenceNumberSet(&submsgElem,&seqNumList);
 
     //Once the submessage elements are added, the header is created
     RTPSMessageCreator::addSubmessageHeader(msg, GAP, flags, (uint16_t)submsgElem.length);

--- a/src/cpp/rtps/reader/StatefulReader.cpp
+++ b/src/cpp/rtps/reader/StatefulReader.cpp
@@ -405,18 +405,18 @@ bool StatefulReader::processGapMsg(GUID_t &writerGUID, SequenceNumber_t &gapStar
     {
         std::lock_guard<std::recursive_mutex> guardWriterProxy(*pWP->getMutex());
         SequenceNumber_t auxSN;
-        SequenceNumber_t finalSN = gapList.base -1;
+        SequenceNumber_t finalSN = gapList.base() - 1;
         for(auxSN = gapStart; auxSN<=finalSN;auxSN++)
         {
             if(pWP->irrelevant_change_set(auxSN))
                 fragmentedChangePitStop_->try_to_remove(auxSN, pWP->m_att.guid);
         }
 
-        for(auto it = gapList.get_begin(); it != gapList.get_end();++it)
+        gapList.for_each([&](SequenceNumber_t it)
         {
-            if(pWP->irrelevant_change_set((*it)))
-                fragmentedChangePitStop_->try_to_remove((*it), pWP->m_att.guid);
-        }
+            if(pWP->irrelevant_change_set(it))
+                fragmentedChangePitStop_->try_to_remove(it, pWP->m_att.guid);
+        });
     }
 
     return true;

--- a/src/cpp/rtps/reader/timedevent/HeartbeatResponseDelay.cpp
+++ b/src/cpp/rtps/reader/timedevent/HeartbeatResponseDelay.cpp
@@ -127,7 +127,7 @@ void HeartbeatResponseDelay::event(EventCode code, const char* msg)
                 assert(fit != cit->getDataFragments()->end());
 
                 // Store FragmentNumberSet_t base.
-                frag_sns.base = frag_num;
+                frag_sns.base(frag_num);
 
                 // Fill the FragmentNumberSet_t bitmap.
                 for(; fit != cit->getDataFragments()->end(); ++fit)

--- a/src/cpp/rtps/reader/timedevent/HeartbeatResponseDelay.cpp
+++ b/src/cpp/rtps/reader/timedevent/HeartbeatResponseDelay.cpp
@@ -73,9 +73,7 @@ void HeartbeatResponseDelay::event(EventCode code, const char* msg)
 
         if(!missing_changes.empty() || !mp_WP->m_heartbeatFinalFlag)
         {
-            SequenceNumberSet_t sns;
-            sns.base = mp_WP->available_changes_max();
-            sns.base++;
+            SequenceNumberSet_t sns(mp_WP->available_changes_max() + 1);
 
             for(auto ch : missing_changes)
             {
@@ -87,7 +85,7 @@ void HeartbeatResponseDelay::event(EventCode code, const char* msg)
                     if(!sns.add(ch.getSequenceNumber()))
                     {
                         logInfo(RTPS_READER,"Sequence number " << ch.getSequenceNumber()
-                                << " exceeded bitmap limit of AckNack. SeqNumSet Base: " << sns.base);
+                                << " exceeded bitmap limit of AckNack. SeqNumSet Base: " << sns.base());
                     }
                 }
                 else
@@ -101,7 +99,7 @@ void HeartbeatResponseDelay::event(EventCode code, const char* msg)
             logInfo(RTPS_READER,"Sending ACKNACK: "<< sns;);
 
             bool final = false;
-            if(sns.isSetEmpty())
+            if(sns.empty())
                 final = true;
 
             group.add_acknack(m_remote_endpoints, sns, mp_WP->mp_SFR->m_acknackCount, final, m_destination_locators);

--- a/src/cpp/rtps/reader/timedevent/InitialAckNack.cpp
+++ b/src/cpp/rtps/reader/timedevent/InitialAckNack.cpp
@@ -71,8 +71,7 @@ void InitialAckNack::event(EventCode code, const char* msg)
         }
 
         // Send initial NACK.
-        SequenceNumberSet_t sns;
-        sns.base = SequenceNumber_t(0, 0);
+        SequenceNumberSet_t sns(SequenceNumber_t(0, 0));
 
         logInfo(RTPS_READER,"Sending ACKNACK: "<< sns);
 

--- a/src/cpp/rtps/writer/RTPSWriterCollector.h
+++ b/src/cpp/rtps/writer/RTPSWriterCollector.h
@@ -78,12 +78,12 @@ class RTPSWriterCollector
         {
             if(change->getFragmentSize() > 0)
             {
-                for(auto sn = optionalFragmentsNotSent.get_begin(); sn != optionalFragmentsNotSent.get_end(); ++sn)
+                optionalFragmentsNotSent.for_each([this, change, remoteReader](auto sn)
                 {
-                    assert(*sn <= change->getDataFragments()->size());
-                    auto it = mItems_.emplace(change->sequenceNumber, *sn, change);
+                    assert(sn <= change->getDataFragments()->size());
+                    auto it = mItems_.emplace(change->sequenceNumber, sn, change);
                     it.first->remoteReaders.push_back(remoteReader);
-                }
+                });
             }
             else
             {

--- a/src/cpp/rtps/writer/ReaderProxy.cpp
+++ b/src/cpp/rtps/writer/ReaderProxy.cpp
@@ -18,38 +18,41 @@
  */
 
 
+#include <fastrtps/log/Log.h>
+#include <fastrtps/rtps/history/WriterHistory.h>
+#include <fastrtps/rtps/resources/AsyncWriterThread.h>
 #include <fastrtps/rtps/writer/ReaderProxy.h>
 #include <fastrtps/rtps/writer/StatefulWriter.h>
-#include <fastrtps/utils/TimeConversion.h>
 #include <fastrtps/rtps/writer/timedevent/NackResponseDelay.h>
 #include <fastrtps/rtps/writer/timedevent/NackSupressionDuration.h>
-#include <fastrtps/log/Log.h>
-#include <fastrtps/rtps/resources/AsyncWriterThread.h>
-#include <fastrtps/rtps/history/WriterHistory.h>
+#include <fastrtps/utils/TimeConversion.h>
 
 #include <mutex>
 
 #include <cassert>
 
-using namespace eprosima::fastrtps::rtps;
+
+namespace eprosima {
+namespace fastrtps {
+namespace rtps {
 
 
-ReaderProxy::ReaderProxy(const RemoteReaderAttributes& rdata,const WriterTimes& times,StatefulWriter* SW) :
+ReaderProxy::ReaderProxy(const RemoteReaderAttributes& rdata, const WriterTimes& times, StatefulWriter* SW) :
     m_att(rdata), mp_SFW(SW),
     mp_nackResponse(nullptr), mp_nackSupression(nullptr), m_lastAcknackCount(0),
     mp_mutex(new std::recursive_mutex()), lastNackfragCount_(0)
 {
-    if(rdata.endpoint.reliabilityKind == RELIABLE)
+    if (rdata.endpoint.reliabilityKind == RELIABLE)
     {
-        mp_nackResponse = new NackResponseDelay(this,TimeConv::Time_t2MilliSecondsDouble(times.nackResponseDelay));
-        mp_nackSupression = new NackSupressionDuration(this,TimeConv::Time_t2MilliSecondsDouble(times.nackSupressionDuration));
+        mp_nackResponse = new NackResponseDelay(this, TimeConv::Time_t2MilliSecondsDouble(times.nackResponseDelay));
+        mp_nackSupression = new NackSupressionDuration(this, TimeConv::Time_t2MilliSecondsDouble(times.nackSupressionDuration));
     }
 
     // Use remoteLocatorList as joint unicast + multicast locators
     m_att.endpoint.remoteLocatorList.assign(m_att.endpoint.unicastLocatorList);
     m_att.endpoint.remoteLocatorList.push_back(m_att.endpoint.multicastLocatorList);
 
-    logInfo(RTPS_WRITER,"Reader Proxy created");
+    logInfo(RTPS_WRITER, "Reader Proxy created");
 }
 
 
@@ -61,13 +64,13 @@ ReaderProxy::~ReaderProxy()
 
 void ReaderProxy::destroy_timers()
 {
-    if(mp_nackResponse != nullptr)
+    if (mp_nackResponse != nullptr)
     {
         delete(mp_nackResponse);
         mp_nackResponse = nullptr;
     }
 
-    if(mp_nackSupression != nullptr)
+    if (mp_nackSupression != nullptr)
     {
         delete(mp_nackSupression);
         mp_nackSupression = nullptr;
@@ -80,11 +83,11 @@ void ReaderProxy::addChange(const ChangeForReader_t& change)
 
     assert(change.getSequenceNumber() > changesFromRLowMark_);
     assert(m_changesForReader.rbegin() != m_changesForReader.rend() ?
-            change.getSequenceNumber() > m_changesForReader.rbegin()->getSequenceNumber() :
-            true);
+        change.getSequenceNumber() > m_changesForReader.rbegin()->getSequenceNumber() :
+        true);
 
     // For best effort readers, changes are acked when being sent
-    if(m_changesForReader.size() == 0 && change.getStatus() == ACKNOWLEDGED)
+    if (m_changesForReader.empty() && change.getStatus() == ACKNOWLEDGED)
     {
         changesFromRLowMark_ = change.getSequenceNumber();
         return;
@@ -93,7 +96,9 @@ void ReaderProxy::addChange(const ChangeForReader_t& change)
     m_changesForReader.insert(change);
     //TODO (Ricardo) Remove this functionality from here. It is not his place.
     if (change.getStatus() == UNSENT)
+    {
         AsyncWriterThread::wakeUp(mp_SFW);
+    }
 }
 
 size_t ReaderProxy::countChangesForReader() const
@@ -106,8 +111,10 @@ bool ReaderProxy::change_is_acked(const SequenceNumber_t& sequence_number)
 {
     std::lock_guard<std::recursive_mutex> guard(*mp_mutex);
 
-    if(sequence_number <= changesFromRLowMark_)
+    if (sequence_number <= changesFromRLowMark_)
+    {
         return true;
+    }
 
     auto chit = m_changesForReader.find(ChangeForReader_t(sequence_number));
     assert(chit != m_changesForReader.end());
@@ -120,7 +127,7 @@ void ReaderProxy::acked_changes_set(const SequenceNumber_t& seqNum)
     std::lock_guard<std::recursive_mutex> guard(*mp_mutex);
     SequenceNumber_t future_low_mark = seqNum;
 
-    if(seqNum > changesFromRLowMark_)
+    if (seqNum > changesFromRLowMark_)
     {
         auto chit = m_changesForReader.find(seqNum);
         m_changesForReader.erase(m_changesForReader.begin(), chit);
@@ -131,17 +138,17 @@ void ReaderProxy::acked_changes_set(const SequenceNumber_t& seqNum)
         // after losing lease duration.
 
         SequenceNumber_t current_sequence = seqNum;
-        if(seqNum < mp_SFW->get_seq_num_min())
+        if (seqNum < mp_SFW->get_seq_num_min())
         {
             current_sequence = mp_SFW->get_seq_num_min();
         }
         future_low_mark = current_sequence;
 
-        for(; current_sequence <= changesFromRLowMark_; ++current_sequence)
+        for (; current_sequence <= changesFromRLowMark_; ++current_sequence)
         {
             CacheChange_t* change = nullptr;
 
-            if(mp_SFW->mp_history->get_change(current_sequence, mp_SFW->getGuid(), &change))
+            if (mp_SFW->mp_history->get_change(current_sequence, mp_SFW->getGuid(), &change))
             {
                 ChangeForReader_t cr(change);
                 cr.setStatus(UNACKNOWLEDGED);
@@ -160,16 +167,16 @@ void ReaderProxy::acked_changes_set(const SequenceNumber_t& seqNum)
     changesFromRLowMark_ = future_low_mark - 1;
 }
 
-bool ReaderProxy::requested_changes_set(std::vector<SequenceNumber_t>& seqNumSet)
+bool ReaderProxy::requested_changes_set(const SequenceNumberSet_t& seqNumSet)
 {
     bool isSomeoneWasSetRequested = false;
     std::lock_guard<std::recursive_mutex> guard(*mp_mutex);
 
-    for(std::vector<SequenceNumber_t>::iterator sit=seqNumSet.begin();sit!=seqNumSet.end();++sit)
+    for (auto sit = seqNumSet.get_begin(); sit != seqNumSet.get_end(); ++sit)
     {
         auto chit = m_changesForReader.find(ChangeForReader_t(*sit));
 
-        if(chit != m_changesForReader.end())
+        if (chit != m_changesForReader.end())
         {
             ChangeForReader_t newch(*chit);
             newch.setStatus(REQUESTED);
@@ -183,14 +190,14 @@ bool ReaderProxy::requested_changes_set(std::vector<SequenceNumber_t>& seqNumSet
         }
     }
 
-    if(isSomeoneWasSetRequested)
+    if (isSomeoneWasSetRequested)
     {
-        logInfo(RTPS_WRITER,"Requested Changes: " << seqNumSet);
+        logInfo(RTPS_WRITER, "Requested Changes: " << seqNumSet);
     }
-    else if(!seqNumSet.empty())
+    else if (!seqNumSet.isSetEmpty())
     {
-        logWarning(RTPS_WRITER,"Requested Changes: " << seqNumSet
-                   << " not found (low mark: " << changesFromRLowMark_ << ")");
+        logWarning(RTPS_WRITER, "Requested Changes: " << seqNumSet
+            << " not found (low mark: " << changesFromRLowMark_ << ")");
     }
 
     return isSomeoneWasSetRequested;
@@ -204,9 +211,13 @@ std::vector<ChangeForReader_t*> ReaderProxy::get_unsent_changes()
     std::vector<ChangeForReader_t*> unsent_changes;
     std::lock_guard<std::recursive_mutex> guard(*mp_mutex);
 
-    for(auto &change_for_reader : m_changesForReader)
-        if(change_for_reader.getStatus() == UNSENT)
+    for (auto &change_for_reader : m_changesForReader)
+    {
+        if (change_for_reader.getStatus() == UNSENT)
+        {
             unsent_changes.push_back(const_cast<ChangeForReader_t*>(&change_for_reader));
+        }
+    }
 
     return unsent_changes;
 }
@@ -217,24 +228,30 @@ std::vector<const ChangeForReader_t*> ReaderProxy::get_requested_changes() const
     std::lock_guard<std::recursive_mutex> guard(*mp_mutex);
 
     auto it = m_changesForReader.begin();
-    for (; it!= m_changesForReader.end(); ++it)
-        if(it->getStatus() == REQUESTED)
+    for (; it != m_changesForReader.end(); ++it)
+    {
+        if (it->getStatus() == REQUESTED)
+        {
             unsent_changes.push_back(&(*it));
+        }
+    }
 
     return unsent_changes;
 }
 
 void ReaderProxy::set_change_to_status(const SequenceNumber_t& seq_num, ChangeForReaderStatus_t status)
 {
-    if(seq_num <= changesFromRLowMark_)
+    if (seq_num <= changesFromRLowMark_)
+    {
         return;
+    }
 
     auto it = m_changesForReader.find(ChangeForReader_t(seq_num));
     bool mustWakeUpAsyncThread = false;
 
-    if(it != m_changesForReader.end())
+    if (it != m_changesForReader.end())
     {
-        if(status == ACKNOWLEDGED && it == m_changesForReader.begin())
+        if (status == ACKNOWLEDGED && it == m_changesForReader.begin())
         {
             m_changesForReader.erase(it);
             changesFromRLowMark_ = seq_num;
@@ -243,27 +260,34 @@ void ReaderProxy::set_change_to_status(const SequenceNumber_t& seq_num, ChangeFo
         {
             ChangeForReader_t newch(*it);
             newch.setStatus(status);
-            if (status == UNSENT) mustWakeUpAsyncThread = true;
+            if (status == UNSENT)
+            {
+                mustWakeUpAsyncThread = true;
+            }
             auto hint = m_changesForReader.erase(it);
             m_changesForReader.insert(hint, newch);
         }
     }
 
     if (mustWakeUpAsyncThread)
+    {
         AsyncWriterThread::wakeUp(mp_SFW);
+    }
 }
 
 bool ReaderProxy::mark_fragment_as_sent_for_change(const CacheChange_t* change, FragmentNumber_t fragment)
 {
-    if(change->sequenceNumber <= changesFromRLowMark_)
+    if (change->sequenceNumber <= changesFromRLowMark_)
+    {
         return false;
+    }
 
     bool allFragmentsSent = false;
     auto it = m_changesForReader.find(ChangeForReader_t(change->sequenceNumber));
 
-    bool mustWakeUpAsyncThread = false; 
+    bool mustWakeUpAsyncThread = false;
 
-    if(it != m_changesForReader.end())
+    if (it != m_changesForReader.end())
     {
         ChangeForReader_t newch(*it);
         newch.markFragmentsAsSent(fragment);
@@ -272,13 +296,17 @@ bool ReaderProxy::mark_fragment_as_sent_for_change(const CacheChange_t* change, 
             allFragmentsSent = true;
         }
         else
+        {
             mustWakeUpAsyncThread = true;
+        }
         auto hint = m_changesForReader.erase(it);
         m_changesForReader.insert(hint, newch);
     }
 
     if (mustWakeUpAsyncThread)
+    {
         AsyncWriterThread::wakeUp(mp_SFW);
+    }
 
     return allFragmentsSent;
 }
@@ -289,30 +317,34 @@ void ReaderProxy::convert_status_on_all_changes(ChangeForReaderStatus_t previous
     bool mustWakeUpAsyncThread = false;
 
     auto it = m_changesForReader.begin();
-    while(it != m_changesForReader.end())
+    while (it != m_changesForReader.end())
     {
-        if(it->getStatus() == previous)
+        if (it->getStatus() == previous)
         {
-            if(next == ACKNOWLEDGED && it == m_changesForReader.begin())
+            if (next == ACKNOWLEDGED && it == m_changesForReader.begin())
             {
                 changesFromRLowMark_ = it->getSequenceNumber();
                 it = m_changesForReader.erase(it);
                 continue;
             }
-            else
-            {
+
+
                 // Note: we can perform this cast as we are not touching the sorting field (seq_num)
-                const_cast<ChangeForReader_t&>(*it).setStatus(next);
-                if (next == UNSENT && previous != UNSENT)
-                    mustWakeUpAsyncThread = true;
+            const_cast<ChangeForReader_t&>(*it).setStatus(next);
+            if (next == UNSENT && previous != UNSENT)
+            {
+                mustWakeUpAsyncThread = true;
             }
+
         }
 
         ++it;
     }
 
     if (mustWakeUpAsyncThread)
+    {
         AsyncWriterThread::wakeUp(mp_SFW);
+    }
 }
 
 //TODO(Ricardo)
@@ -322,8 +354,10 @@ void ReaderProxy::setNotValid(CacheChange_t* change)
     std::lock_guard<std::recursive_mutex> guard(*mp_mutex);
 
     // Check sequence number is in the container, because it was not clean up.
-    if(m_changesForReader.size() == 0 || change->sequenceNumber < m_changesForReader.begin()->getSequenceNumber())
+    if (m_changesForReader.empty() || change->sequenceNumber < m_changesForReader.begin()->getSequenceNumber())
+    {
         return;
+    }
 
     auto chit = m_changesForReader.find(ChangeForReader_t(change));
 
@@ -333,7 +367,7 @@ void ReaderProxy::setNotValid(CacheChange_t* change)
     // Note: we can perform this cast as we are not touching the sorting field (seq_num)
     auto & newch = const_cast<ChangeForReader_t&>(*chit);
 
-    if(chit == m_changesForReader.begin())
+    if (chit == m_changesForReader.begin())
     {
         assert(chit->getStatus() != ACKNOWLEDGED);
 
@@ -347,7 +381,9 @@ void ReaderProxy::setNotValid(CacheChange_t* change)
         // In case its state is not ACKNOWLEDGED, set it to UNACKNOWLEDGE because from now reader has to confirm
         // it will not be expecting it.
         if (newch.getStatus() != ACKNOWLEDGED)
+        {
             newch.setStatus(UNACKNOWLEDGED);
+        }
     }
     newch.notValid();
 }
@@ -357,9 +393,9 @@ bool ReaderProxy::thereIsUnacknowledged() const
     bool returnedValue = false;
     std::lock_guard<std::recursive_mutex> guard(*mp_mutex);
 
-    for(auto it = m_changesForReader.begin(); it!=m_changesForReader.end(); ++it)
+    for (auto& it : m_changesForReader)
     {
-        if(it->getStatus() == UNACKNOWLEDGED)
+        if (it.getStatus() == UNACKNOWLEDGED)
         {
             returnedValue = true;
             break;
@@ -375,23 +411,27 @@ bool change_min(const ChangeForReader_t* ch1, const ChangeForReader_t* ch2)
 }
 
 bool ReaderProxy::minChange(std::vector<ChangeForReader_t*>* Changes,
-        ChangeForReader_t* changeForReader)
+    ChangeForReader_t* changeForReader)
 {
     std::lock_guard<std::recursive_mutex> guard(*mp_mutex);
-    *changeForReader = **std::min_element(Changes->begin(),Changes->end(),change_min);
+    *changeForReader = **std::min_element(Changes->begin(), Changes->end(), change_min);
     return true;
 }
 
-bool ReaderProxy::requested_fragment_set(SequenceNumber_t sequence_number, const FragmentNumberSet_t& frag_set)
+bool ReaderProxy::requested_fragment_set(const SequenceNumber_t& sequence_number, const FragmentNumberSet_t& frag_set)
 {
     std::lock_guard<std::recursive_mutex> guard(*mp_mutex);
 
     // Locate the outbound change referenced by the NACK_FRAG
-    auto changeIter = std::find_if(m_changesForReader.begin(), m_changesForReader.end(), 
-            [sequence_number](const ChangeForReader_t& change)
-            {return change.getSequenceNumber() == sequence_number;});
+    auto changeIter = std::find_if(m_changesForReader.begin(), m_changesForReader.end(),
+        [sequence_number](const ChangeForReader_t& change)
+    {
+        return change.getSequenceNumber() == sequence_number;
+    });
     if (changeIter == m_changesForReader.end())
+    {
         return false;
+    }
 
     ChangeForReader_t newch(*changeIter);
     auto hint = m_changesForReader.erase(changeIter);
@@ -399,8 +439,14 @@ bool ReaderProxy::requested_fragment_set(SequenceNumber_t sequence_number, const
 
     // If it was UNSENT, we shouldn't switch back to REQUESTED to prevent stalling.
     if (newch.getStatus() != UNSENT)
+    {
         newch.setStatus(REQUESTED);
+    }
     m_changesForReader.insert(hint, newch);
 
     return true;
 }
+
+}   // namespace rtps
+}   // namespace fastrtps
+}   // namespace eprosima

--- a/src/cpp/rtps/writer/ReaderProxy.cpp
+++ b/src/cpp/rtps/writer/ReaderProxy.cpp
@@ -172,9 +172,9 @@ bool ReaderProxy::requested_changes_set(const SequenceNumberSet_t& seqNumSet)
     bool isSomeoneWasSetRequested = false;
     std::lock_guard<std::recursive_mutex> guard(*mp_mutex);
 
-    for (auto sit = seqNumSet.get_begin(); sit != seqNumSet.get_end(); ++sit)
+    seqNumSet.for_each([&](SequenceNumber_t sit)
     {
-        auto chit = m_changesForReader.find(ChangeForReader_t(*sit));
+        auto chit = m_changesForReader.find(ChangeForReader_t(sit));
 
         if (chit != m_changesForReader.end())
         {
@@ -188,13 +188,13 @@ bool ReaderProxy::requested_changes_set(const SequenceNumberSet_t& seqNumSet)
 
             isSomeoneWasSetRequested = true;
         }
-    }
+    });
 
     if (isSomeoneWasSetRequested)
     {
         logInfo(RTPS_WRITER, "Requested Changes: " << seqNumSet);
     }
-    else if (!seqNumSet.isSetEmpty())
+    else if (!seqNumSet.empty())
     {
         logWarning(RTPS_WRITER, "Requested Changes: " << seqNumSet
             << " not found (low mark: " << changesFromRLowMark_ << ")");

--- a/src/cpp/rtps/writer/ReaderProxy.cpp
+++ b/src/cpp/rtps/writer/ReaderProxy.cpp
@@ -255,7 +255,7 @@ bool ReaderProxy::mark_fragment_as_sent_for_change(const CacheChange_t* change, 
     {
         ChangeForReader_t newch(*it);
         newch.markFragmentsAsSent(fragment);
-        if (newch.getUnsentFragments().isSetEmpty())
+        if (newch.getUnsentFragments().empty())
         {
             allFragmentsSent = true;
         }

--- a/src/cpp/rtps/writer/ReaderProxy.cpp
+++ b/src/cpp/rtps/writer/ReaderProxy.cpp
@@ -203,23 +203,6 @@ bool ReaderProxy::requested_changes_set(const SequenceNumberSet_t& seqNumSet)
     return isSomeoneWasSetRequested;
 }
 
-std::vector<const ChangeForReader_t*> ReaderProxy::get_requested_changes() const
-{
-    std::vector<const ChangeForReader_t*> unsent_changes;
-    std::lock_guard<std::recursive_mutex> guard(*mp_mutex);
-
-    auto it = m_changesForReader.begin();
-    for (; it != m_changesForReader.end(); ++it)
-    {
-        if (it->getStatus() == REQUESTED)
-        {
-            unsent_changes.push_back(&(*it));
-        }
-    }
-
-    return unsent_changes;
-}
-
 void ReaderProxy::set_change_to_status(const SequenceNumber_t& seq_num, ChangeForReaderStatus_t status)
 {
     if (seq_num <= changesFromRLowMark_)

--- a/src/cpp/rtps/writer/ReaderProxy.cpp
+++ b/src/cpp/rtps/writer/ReaderProxy.cpp
@@ -203,25 +203,6 @@ bool ReaderProxy::requested_changes_set(const SequenceNumberSet_t& seqNumSet)
     return isSomeoneWasSetRequested;
 }
 
-
-//TODO(Ricardo) Temporal
-//std::vector<const ChangeForReader_t*> ReaderProxy::get_unsent_changes() const
-std::vector<ChangeForReader_t*> ReaderProxy::get_unsent_changes()
-{
-    std::vector<ChangeForReader_t*> unsent_changes;
-    std::lock_guard<std::recursive_mutex> guard(*mp_mutex);
-
-    for (auto &change_for_reader : m_changesForReader)
-    {
-        if (change_for_reader.getStatus() == UNSENT)
-        {
-            unsent_changes.push_back(const_cast<ChangeForReader_t*>(&change_for_reader));
-        }
-    }
-
-    return unsent_changes;
-}
-
 std::vector<const ChangeForReader_t*> ReaderProxy::get_requested_changes() const
 {
     std::vector<const ChangeForReader_t*> unsent_changes;

--- a/src/cpp/rtps/writer/StatefulWriter.cpp
+++ b/src/cpp/rtps/writer/StatefulWriter.cpp
@@ -978,8 +978,7 @@ void StatefulWriter::process_acknack(const GUID_t reader_guid, uint32_t ack_coun
                 {
                     // Sequence numbers before Base are set as Acknowledged.
                     remote_reader->acked_changes_set(sn_set.base);
-                    std::vector<SequenceNumber_t> set_vec = sn_set.get_set();
-                    if (remote_reader->requested_changes_set(set_vec) && remote_reader->mp_nackResponse != nullptr)
+                    if (remote_reader->requested_changes_set(sn_set) && remote_reader->mp_nackResponse != nullptr)
                     {
                         remote_reader->mp_nackResponse->restart_timer();
                     }

--- a/src/cpp/rtps/writer/StatefulWriter.cpp
+++ b/src/cpp/rtps/writer/StatefulWriter.cpp
@@ -973,10 +973,10 @@ void StatefulWriter::process_acknack(const GUID_t reader_guid, uint32_t ack_coun
             if(remote_reader->m_lastAcknackCount < ack_count)
             {
                 remote_reader->m_lastAcknackCount = ack_count;
-                if(sn_set.base != SequenceNumber_t(0, 0))
+                if(sn_set.base() != SequenceNumber_t(0, 0))
                 {
                     // Sequence numbers before Base are set as Acknowledged.
-                    remote_reader->acked_changes_set(sn_set.base);
+                    remote_reader->acked_changes_set(sn_set.base());
                     if (remote_reader->requested_changes_set(sn_set) && remote_reader->mp_nackResponse != nullptr)
                     {
                         remote_reader->mp_nackResponse->restart_timer();
@@ -986,7 +986,7 @@ void StatefulWriter::process_acknack(const GUID_t reader_guid, uint32_t ack_coun
                         mp_periodicHB->restart_timer();
                     }
                 }
-                else if(sn_set.isSetEmpty() && !final_flag)
+                else if(sn_set.empty() && !final_flag)
                 {
                     send_heartbeat_to_nts(*remote_reader, true);
                 }

--- a/src/cpp/rtps/writer/StatelessWriter.cpp
+++ b/src/cpp/rtps/writer/StatelessWriter.cpp
@@ -190,7 +190,7 @@ void StatelessWriter::update_unsent_changes(ReaderLocator& reader_locator,
         {
             it->markFragmentsAsSent(fragNum);
             FragmentNumberSet_t fragment_sns = it->getUnsentFragments();
-            if(fragment_sns.isSetEmpty())
+            if(fragment_sns.empty())
                 reader_locator.unsent_changes.erase(it);
         }
         else

--- a/test/unittest/rtps/common/SequenceNumberTests.cpp
+++ b/test/unittest/rtps/common/SequenceNumberTests.cpp
@@ -426,11 +426,9 @@ TEST(SequenceNumber, SubtractionBetweenSesOperator)
  */
 TEST(SequenceNumberSet, AddOperation)
 {
-    SequenceNumberSet_t set;
-
     SequenceNumber_t seq(10, UINT32_MAX - 1);
 
-    set.base =  seq;
+    SequenceNumberSet_t set(seq);
 
     ASSERT_TRUE(set.add(seq));
 
@@ -458,11 +456,10 @@ TEST(SequenceNumberSet, AddOperation)
  */
 TEST(SequenceNumberSet, GetMaxSeqNumOperation)
 {
-    SequenceNumberSet_t set;
 
     SequenceNumber_t seq(10, UINT32_MAX - 3);
 
-    set.base =  seq;
+    SequenceNumberSet_t set(seq);
 
     seq.low = UINT32_MAX - 1;
 
@@ -490,7 +487,7 @@ TEST(SequenceNumberSet, GetMaxSeqNumOperation)
 
     SequenceNumber_t expected_seq(11, 20);
 
-    ASSERT_EQ(set.get_maxSeqNum(), expected_seq);
+    ASSERT_EQ(set.max(), expected_seq);
 }
 
 int main(int argc, char **argv)

--- a/test/unittest/rtps/flowcontrol/ThroughputControllerTests.cpp
+++ b/test/unittest/rtps/flowcontrol/ThroughputControllerTests.cpp
@@ -72,9 +72,9 @@ TEST_F(ThroughputControllerTests, if_changes_are_fragmented_throughput_controlle
     // Given fragmented changes
     testChangesForUse.clear();
 
-    std::set<FragmentNumber_t> fragmentSet;
+    FragmentNumberSet_t fragmentSet(1);
     for(uint32_t i = 1; i <= 10; i++)
-        fragmentSet.insert(i);
+        fragmentSet.add(i);
 
     for(auto& change : testChanges)
     {

--- a/test/unittest/utils/BitmapRangeTests.cpp
+++ b/test/unittest/utils/BitmapRangeTests.cpp
@@ -1,0 +1,248 @@
+// Copyright 2018 Proyectos y Sistemas de Mantenimiento SL (eProsima).
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <fastrtps/utils/fixed_size_bitmap.hpp>
+#include <gtest/gtest.h>
+
+#include <algorithm>
+#include <vector>
+#include <set>
+
+using ValueType = uint32_t;
+using TestType = eprosima::fastrtps::BitmapRange<ValueType>;
+
+struct TestResult
+{
+    bool result;
+    uint32_t num_bits;
+    uint32_t num_longs;
+    TestType::bitmap_type bitmap;
+
+    bool Check(bool ret_val, TestType& uut) const
+    {
+        if (result != ret_val)
+        {
+            return false;
+        }
+
+        TestResult check;
+        uut.bitmap_get(check.num_bits, check.bitmap, check.num_longs);
+        if (num_bits != check.num_bits || num_longs != check.num_longs)
+        {
+            return false;
+        }
+        return std::equal(bitmap.cbegin(), bitmap.cbegin() + num_longs, check.bitmap.cbegin());
+    }
+};
+
+struct TestStep
+{
+    uint32_t input_offset;
+    TestResult expected_result;
+};
+
+struct TestCase
+{
+    TestResult initialization;
+    std::vector<TestStep> steps;
+
+    void Test(ValueType base, TestType& uut) const
+    {
+        ASSERT_TRUE(initialization.Check(initialization.result, uut));
+
+        
+        for (auto step : steps)
+        {
+            bool result = uut.add(base + step.input_offset);
+            ASSERT_TRUE(step.expected_result.Check(result, uut));
+            ASSERT_EQ(base + step.expected_result.num_bits - 1, uut.max());
+        }
+    }
+};
+
+class BitmapRangeTests: public ::testing::Test
+{
+    public:
+        const ValueType explicit_base = 123UL;
+
+        const TestCase test0 =
+        {
+            // initialization
+            {
+                true, 0, 0, {0,0,0,0,0,0,0,0}
+            },
+            // steps
+            {
+                // Adding base
+                {
+                    0,
+                    {
+                        true, 1, 1, {0x80000000UL,0,0,0,0,0,0,0}
+                    }
+                },
+                // Adding base again
+                {
+                    0,
+                    {
+                        true, 1, 1, {0x80000000UL,0,0,0,0,0,0,0}
+                    }
+                },
+                // Adding out of range
+                {
+                    256,
+                    {
+                        false, 1, 1, {0x80000000UL,0,0,0,0,0,0,0}
+                    }
+                },
+                // Middle of first word
+                {
+                    16,
+                    {
+                        true, 17, 1, {0x80008000UL,0,0,0,0,0,0,0}
+                    }
+                },
+                // Before previous one
+                {
+                    15,
+                    {
+                        true, 17, 1, {0x80018000UL,0,0,0,0,0,0,0}
+                    }
+                },
+                // On third word
+                {
+                    67,
+                    {
+                        true, 68, 3, {0x80018000UL,0,0x10000000UL,0,0,0,0,0}
+                    }
+                },
+                // Last on third word
+                {
+                    94,
+                    {
+                        true, 95, 3, {0x80018000UL,0,0x10000002UL,0,0,0,0,0}
+                    }
+                },
+                // Last on third word
+                {
+                    95,
+                    {
+                        true, 96, 3, {0x80018000UL,0,0x10000003UL,0,0,0,0,0}
+                    }
+                },
+                // Last possible item
+                {
+                    255,
+                    {
+                        true, 256, 8, {0x80018000UL,0,0x10000003UL,0,0,0,0,0x00000001UL}
+                    }
+                }
+            }
+        };
+
+        const TestResult all_ones =
+        {
+            true,
+            256UL,
+            8UL,
+            { 0xFFFFFFFFUL, 0xFFFFFFFFUL, 0xFFFFFFFFUL, 0xFFFFFFFFUL, 0xFFFFFFFFUL, 0xFFFFFFFFUL, 0xFFFFFFFFUL, 0xFFFFFFFFUL }
+        };
+};
+
+TEST_F(BitmapRangeTests, default_constructor)
+{
+    TestType uut;
+    test0.Test(ValueType(), uut);
+}
+
+TEST_F(BitmapRangeTests, explicit_constructor)
+{
+    TestType uut(explicit_base);
+    test0.Test(explicit_base, uut);
+}
+
+TEST_F(BitmapRangeTests, change_base)
+{
+    // Test with default constructor
+    TestType uut;
+    test0.Test(ValueType(), uut);
+
+    // Change base and test again
+    uut.base(explicit_base);
+    test0.Test(explicit_base, uut);
+}
+
+TEST_F(BitmapRangeTests, full_range)
+{
+    TestType uut(explicit_base);
+
+    // Add all possible items in range
+    for (ValueType item = explicit_base, last = explicit_base + 256UL; item < last; item++)
+    {
+        ASSERT_TRUE(uut.add(item));
+    }
+
+    all_ones.Check(all_ones.result, uut);
+}
+
+TEST_F(BitmapRangeTests, serialization)
+{
+    uint32_t num_bits;
+    uint32_t num_longs;
+    TestType::bitmap_type bitmap;
+
+    // Populate the range using the test case
+    TestType uut(explicit_base);
+    test0.Test(explicit_base, uut);
+
+    // Get bitmap serialization and set it again
+    uut.bitmap_get(num_bits, bitmap, num_longs);
+    uut.bitmap_set(num_bits, bitmap.data());
+
+    // Bitmap should be equal to the one of the last result
+    auto last_result = test0.steps.rbegin()->expected_result;
+    last_result.Check(last_result.result, uut);
+}
+
+TEST_F(BitmapRangeTests, traversal)
+{
+    // Populate the range using the test case
+    TestType uut(explicit_base);
+    test0.Test(explicit_base, uut);
+
+    // Collect the items that should be processed
+    std::set<ValueType> items;
+    for (auto step : test0.steps)
+    {
+        if (step.expected_result.result)
+        {
+            items.insert(explicit_base + step.input_offset);
+        }
+    }
+
+    // Functor should only be called for items in the set, which are removed
+    uut.for_each([&](const ValueType& t)
+    {
+        ASSERT_NE(items.find(t), items.end());
+        items.erase(t);
+    });
+
+    // All items should have been processed
+    ASSERT_TRUE(items.empty());
+}
+
+int main(int argc, char **argv)
+{
+    testing::InitGoogleTest(&argc, argv);
+    return RUN_ALL_TESTS();
+}

--- a/test/unittest/utils/CMakeLists.txt
+++ b/test/unittest/utils/CMakeLists.txt
@@ -31,6 +31,9 @@ if(NOT ((MSVC OR MSVC_IDE) AND EPROSIMA_INSTALLER))
         set(FIXEDSIZESTRINGTESTS_SOURCE
             FixedSizeStringTests.cpp)
 
+        set(BITMAPRANGETESTS_SOURCE
+            BitmapRangeTests.cpp)
+
         include_directories(mock/)
 
         add_executable(StringMatchingTests ${STRINGMATCHINGTESTS_SOURCE})
@@ -51,5 +54,13 @@ if(NOT ((MSVC OR MSVC_IDE) AND EPROSIMA_INSTALLER))
             ${PROJECT_SOURCE_DIR}/include ${PROJECT_BINARY_DIR}/include)
         target_link_libraries(FixedSizeStringTests ${GTEST_LIBRARIES} ${MOCKS})
         add_gtest(FixedSizeStringTests SOURCES ${FIXEDSIZESTRINGTESTS_SOURCE})
+
+
+        add_executable(BitmapRangeTests ${BITMAPRANGETESTS_SOURCE})
+        target_compile_definitions(BitmapRangeTests PRIVATE FASTRTPS_NO_LIB)
+        target_include_directories(BitmapRangeTests PRIVATE ${GTEST_INCLUDE_DIRS}
+            ${PROJECT_SOURCE_DIR}/include ${PROJECT_BINARY_DIR}/include)
+        target_link_libraries(BitmapRangeTests ${GTEST_LIBRARIES} ${MOCKS})
+        add_gtest(BitmapRangeTests SOURCES ${BITMAPRANGETESTS_SOURCE})
     endif()
 endif()


### PR DESCRIPTION
# Fixed size bitmaps

A `template<class T, class Diff = DiffFunction<T>, size_t NBITS=256> BitmapRange` class holding a bitmap on a fixed size array of uint32_t.
Type T is required to behave like an unsigned integer type, and shall at least have addition with `uint32_t` and `>=` operators.
The `BitmapRange` class will have the following fields:
```
// Alias to improve readability.
using bitmap_type = std::array<uint32_t, (NBITS + 31) / 32>;

T base;              // Holds first item in the range.
bitmap_type bitmap;  // Holds bitmap.
size_t num_bits;     // Number of significant bits set in the bitmap.
```

Operations implemented:
- Default constructor
- Constructor from base: `explicit BitmapRange(const T& base)`
- Getter and setter for base
- Add an item: `bool add(const T& item)`
- Bitmap getter for serialization: `void bitmap_get(size_t& num_bits, bitmap_type& bitmap, size_t& num_longs_used)`
- Bitmap setter for deserialization: `void bitmap_set(size_t num_bits, const uint32_t* bitmap)`
- Basic traversal `void for_each(UnaryFunc f)`
