### PR TITLE
Resource limited vector [4421]

### DIFF
--- a/include/fastrtps/utils/collections/ResourceLimitedContainerConfig.hpp
+++ b/include/fastrtps/utils/collections/ResourceLimitedContainerConfig.hpp
@@ -1,0 +1,88 @@
+// Copyright 2019 Proyectos y Sistemas de Mantenimiento SL (eProsima).
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+/**
+ * @file ResourceLimitedContainerConfig.hpp
+ *
+ */
+
+#ifndef FASTRTPS_UTILS_COLLECTIONS_RESOURCELIMITEDCONTAINERCONFIG_HPP_
+#define FASTRTPS_UTILS_COLLECTIONS_RESOURCELIMITEDCONTAINERCONFIG_HPP_
+
+#include <limits>
+
+namespace eprosima {
+namespace fastrtps {
+
+/**
+ * Specifies the configuration of a resource limited collection.
+ * @ingroup UTILITIES_MODULE
+ */
+struct ResourceLimitedContainerConfig
+{
+
+#if defined(_MSC_VER) && _MSC_VER <= 1900
+
+    // Initializer list construction won't work on MSVS 2015 if you have struct fields initializers
+    ResourceLimitsConfig(
+            size_t ini = 0, 
+            size_t max = std::numeric_limits<size_t>::max(),
+            size_t inc = 1u)
+        : initial(ini)
+        , maximum(max)
+        , increment(inc)
+    {
+    }
+
+    // MSVS 2015 is not able to treat our static inline methods as constexpr
+    #define ___CONSTEXPR___
+#else
+    #define ___CONSTEXPR___ constexpr
+#endif
+
+    //! Number of elements to be preallocated in the collection.
+    size_t initial = 0;
+    //! Maximum number of elements allowed in the collection.
+    size_t maximum = std::numeric_limits<size_t>::max();
+    //! Number of items to add when capacity limit is reached.
+    size_t increment = 1u;
+
+    /**
+     * Return a resource limits configuration for a fixed size collection.
+     * @param size Number of elements to allocate.
+     * @return Resource limits configuration.
+     */
+    inline static ___CONSTEXPR___
+    ResourceLimitedContainerConfig fixed_size_configuration(size_t size)
+    {
+        return { size, size, 0 };
+    }
+
+    /**
+     * Return a resource limits configuration for a linearly growing, dynamically allocated collection.
+     * @param increment Number of new elements to allocate when increasing the capacity of the collection.
+     * @return Resource limits configuration.
+     */
+    inline static ___CONSTEXPR___
+    ResourceLimitedContainerConfig dynamic_allocation_configuration(size_t increment = 1u)
+    {
+        return { 0, std::numeric_limits<size_t>::max(), increment ? increment : 1u };
+    }
+
+};
+
+}  // namespace fastrtps
+}  // namespace eprosima
+
+#endif /* FASTRTPS_UTILS_COLLECTIONS_RESOURCELIMITEDCONTAINERCONFIG_HPP_ */

--- a/include/fastrtps/utils/collections/ResourceLimitedContainerConfig.hpp
+++ b/include/fastrtps/utils/collections/ResourceLimitedContainerConfig.hpp
@@ -33,9 +33,6 @@ namespace fastrtps {
 struct ResourceLimitedContainerConfig
 {
 
-#if defined(_MSC_VER) && _MSC_VER <= 1900
-
-    // Initializer list construction won't work on MSVS 2015 if you have struct fields initializers
     ResourceLimitedContainerConfig(
             size_t ini = 0, 
             size_t max = std::numeric_limits<size_t>::max(),
@@ -45,12 +42,6 @@ struct ResourceLimitedContainerConfig
         , increment(inc)
     {
     }
-
-    // MSVS 2015 is not able to treat our static inline methods as constexpr
-    #define ___CONSTEXPR___
-#else
-    #define ___CONSTEXPR___ constexpr
-#endif
 
     //! Number of elements to be preallocated in the collection.
     size_t initial = 0;
@@ -64,10 +55,9 @@ struct ResourceLimitedContainerConfig
      * @param size Number of elements to allocate.
      * @return Resource limits configuration.
      */
-    inline static ___CONSTEXPR___
-    ResourceLimitedContainerConfig fixed_size_configuration(size_t size)
+    inline static ResourceLimitedContainerConfig fixed_size_configuration(size_t size)
     {
-        return { size, size, 0 };
+        return ResourceLimitedContainerConfig(size, size, 0u);
     }
 
     /**
@@ -75,10 +65,9 @@ struct ResourceLimitedContainerConfig
      * @param increment Number of new elements to allocate when increasing the capacity of the collection.
      * @return Resource limits configuration.
      */
-    inline static ___CONSTEXPR___
-    ResourceLimitedContainerConfig dynamic_allocation_configuration(size_t increment = 1u)
+    inline static ResourceLimitedContainerConfig dynamic_allocation_configuration(size_t increment = 1u)
     {
-        return { 0, std::numeric_limits<size_t>::max(), increment ? increment : 1u };
+        return ResourceLimitedContainerConfig(0u, std::numeric_limits<size_t>::max(), increment ? increment : 1u);
     }
 
 };

--- a/include/fastrtps/utils/collections/ResourceLimitedContainerConfig.hpp
+++ b/include/fastrtps/utils/collections/ResourceLimitedContainerConfig.hpp
@@ -20,6 +20,7 @@
 #ifndef FASTRTPS_UTILS_COLLECTIONS_RESOURCELIMITEDCONTAINERCONFIG_HPP_
 #define FASTRTPS_UTILS_COLLECTIONS_RESOURCELIMITEDCONTAINERCONFIG_HPP_
 
+#include <cstddef>
 #include <limits>
 
 namespace eprosima {
@@ -35,7 +36,7 @@ struct ResourceLimitedContainerConfig
 #if defined(_MSC_VER) && _MSC_VER <= 1900
 
     // Initializer list construction won't work on MSVS 2015 if you have struct fields initializers
-    ResourceLimitsConfig(
+    ResourceLimitedContainerConfig(
             size_t ini = 0, 
             size_t max = std::numeric_limits<size_t>::max(),
             size_t inc = 1u)

--- a/include/fastrtps/utils/collections/ResourceLimitedVector.hpp
+++ b/include/fastrtps/utils/collections/ResourceLimitedVector.hpp
@@ -281,6 +281,9 @@ public:
     size_type max_size() const noexcept { return std::min(configuration_.maximum, collection_.max_size()); }
 
     void clear() { collection_.clear(); }
+    iterator erase(const_iterator pos) { return collection_.erase(pos); }
+    iterator erase(const_iterator first, const_iterator last) { return collection_.erase(first, last); }
+    void pop_back() { collection_.pop_back(); }
     ///@}
 
     /**

--- a/include/fastrtps/utils/collections/ResourceLimitedVector.hpp
+++ b/include/fastrtps/utils/collections/ResourceLimitedVector.hpp
@@ -69,7 +69,6 @@ public:
     using const_iterator = typename collection_type::const_iterator;
     using reverse_iterator = typename collection_type::reverse_iterator;
     using const_reverse_iterator = typename collection_type::reverse_iterator;
-    using size_type = typename collection_type::size_type;
 
     /**
      * Construct a ResourceLimitedVector.

--- a/include/fastrtps/utils/collections/ResourceLimitedVector.hpp
+++ b/include/fastrtps/utils/collections/ResourceLimitedVector.hpp
@@ -1,0 +1,333 @@
+// Copyright 2019 Proyectos y Sistemas de Mantenimiento SL (eProsima).
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+/**
+ * @file ResourceLimitedVector.hpp
+ *
+ */
+
+#ifndef FASTRTPS_UTILS_COLLECTIONS_RESOURCELIMITEDVECTOR_HPP_
+#define FASTRTPS_UTILS_COLLECTIONS_RESOURCELIMITEDVECTOR_HPP_
+
+#include "ResourceLimitedContainerConfig.hpp"
+
+#include <assert.h>
+#include <algorithm>
+#include <type_traits>
+#include <vector>
+
+namespace eprosima {
+namespace fastrtps {
+
+/**
+ * Resource limited wrapper of std::vector.
+ *
+ * This template class holds an unordered collection of elements using a std::vector or a replacement.
+ * It makes use of a \ref ResourceLimitsConfig to setup the allocation behaviour regarding the number of
+ * elements in the collection.
+ *
+ * It features linear increment of the capacity, initial preallocation, and maximum number of elements control.
+ *
+ * @tparam _Ty                 Element type.
+ * @tparam _KeepOrderEnabler   Indicates if element order should be kept when removing items,
+ *                             defaults to std::false_type.
+ * @tparam _Alloc              Allocator to use on the underlying collection type, defaults to std::allocator<_Ty>.
+ * @tparam _Collection         Type used to store the collection of items, defaults to std::vector<_Ty, _Alloc>.
+ *
+ * @ingroup UTILITIES_MODULE
+ */
+template <
+    typename _Ty, 
+    typename _KeepOrderEnabler = std::false_type,
+    typename _Alloc = std::allocator<_Ty>, 
+    typename _Collection = std::vector<_Ty, _Alloc> >
+class ResourceLimitedVector
+{
+public:
+
+    using collection_type = _Collection;
+    using value_type = _Ty;
+    using allocator_type = _Alloc;
+    using pointer = typename collection_type::pointer;
+    using const_pointer = typename collection_type::const_pointer;
+    using reference = typename collection_type::reference;
+    using const_reference = typename collection_type::const_reference;
+    using size_type = typename collection_type::size_type;
+    using difference_type = typename collection_type::difference_type;
+    using iterator = typename collection_type::iterator;
+    using const_iterator = typename collection_type::const_iterator;
+    using reverse_iterator = typename collection_type::reverse_iterator;
+    using const_reverse_iterator = typename collection_type::reverse_iterator;
+    using size_type = typename collection_type::size_type;
+
+    /**
+     * Construct a ResourceLimitedVector.
+     *
+     * This constructor receives a \ref ResourceLimitsConfig to setup the allocation behaviour regarding the 
+     * number of elements in the collection.
+     *
+     * The cfg parameter indicates the initial number to be reserved, the maximum number of items allowed,
+     * and the capacity increment value.
+     *
+     * @param cfg     Resource limits configuration to use.
+     * @param alloc   Allocator object. Forwarded to collection constructor.
+     */
+    ResourceLimitedVector(
+            ResourceLimitedContainerConfig cfg = {}, 
+            const allocator_type& alloc = allocator_type())
+        : configuration_(cfg)
+        , collection_(alloc)
+    {
+        collection_.reserve(cfg.initial);
+    }
+
+    /**
+     * Add element at the end.
+     *
+     * Adds a new element at the end of the vector, after its current last element. 
+     * The content of val is copied to the new element.
+     *
+     * @param val   Value to be copied to the new element.
+     *
+     * @return pointer to the new element, nullptr if resource limit is reached.
+     */
+    pointer push_back(const value_type& val)
+    {
+        return emplace_back(val);
+    }
+
+    /**
+     * Add element at the end.
+     *
+     * Adds a new element at the end of the vector, after its current last element. 
+     * The content of val is moved to the new element.
+     *
+     * @param val   Value to be moved to the new element.
+     *
+     * @return pointer to the new element, nullptr if resource limit is reached.
+     */
+    pointer push_back(value_type&& val)
+    {
+        return emplace_back(std::move(val));
+    }
+
+    /**
+     * Construct and insert element at the end.
+     *
+     * Inserts a new element at the end of the vector, right after its current last element. 
+     * This new element is constructed in place using args as the arguments for its constructor.
+     *
+     * @param args   Arguments forwarded to construct the new element.
+     *
+     * @return pointer to the new element, nullptr if resource limit is reached.
+     */
+    template<typename ... Args>
+    pointer emplace_back(Args&& ... args)
+    {
+        if (!ensure_capacity())
+        {
+            // Indicate error by returning null pointer
+            return nullptr;
+        }
+
+        // Keep record of insertion position
+        size_type previous_size = collection_.size();
+
+        // Construct new element at the end of the collection
+        collection_.emplace_back(args...);
+
+        // Return pointer to newly created element
+        return &collection_[previous_size];
+    }
+
+    /**
+     * Remove element.
+     * 
+     * Removes the first element in the vector that compares equal to val.
+     * All iterators may become invalidated if this method returns true.
+     *
+     * @param val   Value to be compared.
+     *
+     * @return true if an element was removed, false otherwise.
+     */
+    bool remove(const value_type& val)
+    {
+        iterator it = std::find(collection_.begin(), collection_.end(), val);
+        return remove(it);
+    }
+
+    /**
+     * Remove element.
+     * 
+     * Removes the first element in the vector for which pred returns true.
+     * All iterators may become invalidated if this method returns true.
+     *
+     * @param pred   Unary function that accepts an element in the range as argument and returns a value
+     *               convertible to bool.
+     *               The value returned indicates whether the element is considered a match in the context
+     *               of this function.
+     *               The function shall not modify its argument.
+     *               This can either be a function pointer or a function object.
+     *
+     * @return true if an element was removed, false otherwise.
+     */
+    template<class UnaryPredicate>
+    bool remove_if(UnaryPredicate pred)
+    {
+        iterator it = std::find_if(collection_.begin(), collection_.end(), pred);
+        return remove(it);
+    }
+
+    /**
+     * Assign vector content.
+     * 
+     * Assigns new contents to the vector, replacing its current contents, and modifying its size accordingly.
+     *
+     * @param first, last   Input iterators to the initial and final positions in a sequence.
+     *                      The range used is [first,last), which includes all the elements between first and last,
+     *                      including the element pointed by first but not the element pointed by last.
+     *                      The function template argument InputIterator shall be an input iterator type that points
+     *                      to elements of a type from which value_type objects can be constructed.
+     *                      If the size of this range is greater than the maximum number of elements allowed on the
+     *                      resource limits configuration, the elements exceeding that maximum will be silently
+     *                      discarded.
+     */
+    template <class InputIterator>
+    void assign(InputIterator first, InputIterator last)
+    {
+        size_type n = std::distance(first, last);
+        n = std::min(n, configuration_.maximum);
+        collection_.assign(first, first + n);
+    }
+
+    /**
+     * Assign vector content.
+     * 
+     * Assigns new contents to the vector, replacing its current contents, and modifying its size accordingly.
+     *
+     * @param n     New size for the container.
+     *              Will be truncated if greater than the maximum allowed on the resource limits configuration.
+     * @param val   Value to fill the container with.
+     *              Each of the n elements in the container will be initialized to a copy of this value.
+     */
+    void assign(size_type n, const value_type& val)
+    {
+        n = std::min(n, configuration_.maximum);
+        collection_.assign(n, val);
+    }
+
+    /**
+     * Assign vector content.
+     * 
+     * Assigns new contents to the vector, replacing its current contents, and modifying its size accordingly.
+     *
+     * @param il   An initializer_list object. 
+     *             The compiler will automatically construct such objects from initializer list declarators.
+     *             Member type value_type is the type of the elements in the container.
+     *             If the size of this list is greater than the maximum number of elements allowed on the
+     *             resource limits configuration, the elements exceeding that maximum will be silently discarded.
+     */
+    void assign(std::initializer_list<value_type> il)
+    {
+        size_type n = std::min(il.size(), configuration_.maximum);
+        collection_.assign(il.begin(), il.begin() + n);
+    }
+
+    iterator begin() noexcept { return collection_.begin(); }
+    const_iterator begin() const noexcept { return collection_.begin(); }
+    iterator end() noexcept { return collection_.end(); }
+    const_iterator end() const noexcept { return collection_.end(); }
+
+    size_type capacity() const noexcept { return collection_.capacity(); }
+    size_type size() const noexcept { return collection_.size(); }
+    bool empty() const noexcept { return collection_.empty(); }
+    void clear() { collection_.clear(); }
+
+    /**
+     * Const cast to underlying collection.
+     *
+     * Useful to easy integration on old APIs where a traditional container was used.
+     *
+     * @return const reference to the underlying collection.
+     */
+    operator const collection_type& () const noexcept { return collection_; }
+
+private:
+    ResourceLimitedContainerConfig configuration_;
+    collection_type collection_;
+
+    /**
+     * Make room for one item.
+     *
+     * Tries to ensure that a new item can be added to the container.
+     *
+     * @return true if there is room for a new item, false if resource limit is reached.
+     */
+    bool ensure_capacity()
+    {
+        size_type size = collection_.size();
+        size_type cap = collection_.capacity();
+        if (size == cap)
+        {
+            // collection is full, check resource limit
+            if (cap < configuration_.maximum)
+            {
+                // increase collection capacity
+                assert(configuration_.increment > 0);
+                cap += configuration_.increment;
+                cap = std::min(cap, configuration_.maximum);
+                collection_.reserve(cap);
+            }
+            else
+            {
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    bool remove(iterator it)
+    {
+        if (it != collection_.end())
+        {
+            do_remove(it);
+            return true;
+        }
+
+        return false;
+    }
+
+    template <typename Enabler = _KeepOrderEnabler>
+    typename std::enable_if<!Enabler::value, void>::type do_remove(iterator it)
+    {
+        // Copy last element into the element being removed
+        if (collection_.size() > 1)
+            *it = collection_.back();
+
+        // Then drop last element
+        collection_.pop_back();
+    }
+
+    template <typename Enabler = _KeepOrderEnabler>
+    typename std::enable_if<Enabler::value, void>::type do_remove(iterator it)
+    { 
+        collection_.erase(it);
+    }
+};
+
+}  // namespace fastrtps
+}  // namespace eprosima
+
+#endif /* FASTRTPS_UTILS_COLLECTIONS_RESOURCELIMITEDVECTOR_HPP_ */

--- a/include/fastrtps/utils/collections/ResourceLimitedVector.hpp
+++ b/include/fastrtps/utils/collections/ResourceLimitedVector.hpp
@@ -261,11 +261,25 @@ public:
     ///@{
     iterator begin() noexcept { return collection_.begin(); }
     const_iterator begin() const noexcept { return collection_.begin(); }
+    const_iterator cbegin() const noexcept { return collection_.cbegin(); }
+
     iterator end() noexcept { return collection_.end(); }
     const_iterator end() const noexcept { return collection_.end(); }
-    size_type capacity() const noexcept { return collection_.capacity(); }
-    size_type size() const noexcept { return collection_.size(); }
+    const_iterator cend() const noexcept { return collection_.cend(); }
+
+    reverse_iterator rbegin() noexcept { return collection_.rbegin(); }
+    const_reverse_iterator rbegin() const noexcept { return collection_.rbegin(); }
+    const_reverse_iterator crbegin() const noexcept { return collection_.crbegin(); }
+
+    reverse_iterator rend() noexcept { return collection_.rend(); }
+    const_reverse_iterator rend() const noexcept { return collection_.rend(); }
+    const_reverse_iterator crend() const noexcept { return collection_.crend(); }
+
     bool empty() const noexcept { return collection_.empty(); }
+    size_type size() const noexcept { return collection_.size(); }
+    size_type capacity() const noexcept { return collection_.capacity(); }
+    size_type max_size() const noexcept { return std::min(configuration_.maximum, collection_.max_size()); }
+
     void clear() { collection_.clear(); }
     ///@}
 
@@ -328,7 +342,7 @@ private:
         // Copy last element into the element being removed
         if (it != --collection_.end())
         {
-            *it = collection_.back();
+            *it = std::move(collection_.back());
         }
 
         // Then drop last element

--- a/include/fastrtps/utils/collections/ResourceLimitedVector.hpp
+++ b/include/fastrtps/utils/collections/ResourceLimitedVector.hpp
@@ -259,6 +259,16 @@ public:
      * Please refer to https://en.cppreference.com/w/cpp/container/vector
      */
     ///@{
+    reference at(size_type pos) { return collection_.at(pos); }
+    const_reference at(size_type pos) const { return collection_.at(pos); }
+    reference operator[](size_type pos) { return collection_[pos]; }
+    const_reference operator[](size_type pos) const { return collection_[pos]; }
+
+    reference front() { return collection_.front(); }
+    const_reference front() const { return collection_.front(); }
+    reference back() { return collection_.back(); }
+    const_reference back() const { return collection_.back(); }
+
     iterator begin() noexcept { return collection_.begin(); }
     const_iterator begin() const noexcept { return collection_.begin(); }
     const_iterator cbegin() const noexcept { return collection_.cbegin(); }

--- a/include/fastrtps/utils/collections/ResourceLimitedVector.hpp
+++ b/include/fastrtps/utils/collections/ResourceLimitedVector.hpp
@@ -243,15 +243,20 @@ public:
         collection_.assign(il.begin(), il.begin() + n);
     }
 
+    /**
+     * Wrappers to other basic vector methods.
+     * Please refer to https://en.cppreference.com/w/cpp/container/vector
+     */
+    ///@{
     iterator begin() noexcept { return collection_.begin(); }
     const_iterator begin() const noexcept { return collection_.begin(); }
     iterator end() noexcept { return collection_.end(); }
     const_iterator end() const noexcept { return collection_.end(); }
-
     size_type capacity() const noexcept { return collection_.capacity(); }
     size_type size() const noexcept { return collection_.size(); }
     bool empty() const noexcept { return collection_.empty(); }
     void clear() { collection_.clear(); }
+    ///@}
 
     /**
      * Const cast to underlying collection.

--- a/test/unittest/utils/CMakeLists.txt
+++ b/test/unittest/utils/CMakeLists.txt
@@ -34,9 +34,8 @@ if(NOT ((MSVC OR MSVC_IDE) AND EPROSIMA_INSTALLER))
         set(BITMAPRANGETESTS_SOURCE
             BitmapRangeTests.cpp)
 
-        set(TMUTEXTESTS_SOURCE
-            ${PROJECT_SOURCE_DIR}/src/cpp/utils/Mutex.cpp
-            TMutexTests.cpp)
+        set(RESOURCELIMITEDVECTORTESTS_SOURCE
+            ResourceLimitedVectorTests.cpp)
 
         include_directories(mock/)
 
@@ -66,5 +65,13 @@ if(NOT ((MSVC OR MSVC_IDE) AND EPROSIMA_INSTALLER))
             ${PROJECT_SOURCE_DIR}/include ${PROJECT_BINARY_DIR}/include)
         target_link_libraries(BitmapRangeTests ${GTEST_LIBRARIES} ${MOCKS})
         add_gtest(BitmapRangeTests SOURCES ${BITMAPRANGETESTS_SOURCE})
+
+
+        add_executable(ResourceLimitedVectorTests ${RESOURCELIMITEDVECTORTESTS_SOURCE})
+        target_compile_definitions(ResourceLimitedVectorTests PRIVATE FASTRTPS_NO_LIB)
+        target_include_directories(ResourceLimitedVectorTests PRIVATE ${GTEST_INCLUDE_DIRS}
+            ${PROJECT_SOURCE_DIR}/include ${PROJECT_BINARY_DIR}/include)
+        target_link_libraries(ResourceLimitedVectorTests ${GTEST_LIBRARIES} ${MOCKS})
+        add_gtest(ResourceLimitedVectorTests SOURCES ${RESOURCELIMITEDVECTORTESTS_SOURCE})
     endif()
 endif()

--- a/test/unittest/utils/ResourceLimitedVectorTests.cpp
+++ b/test/unittest/utils/ResourceLimitedVectorTests.cpp
@@ -230,13 +230,13 @@ TEST_F(ResourceLimitedVectorTests, remove_if)
     auto is_odd = [](int i) { return (i & 1) != 0; };
 
     // Remove all odd items and check no errors
-    for (int i = 0; i < NUM_ITEMS / 2; i++)
+    for (size_t i = 0; i < NUM_ITEMS / 2; i++)
     {
         ASSERT_TRUE(uut.remove_if(is_odd));
     }
 
     // Trying to remove odd items should give errors
-    for (int i = 0; i < NUM_ITEMS / 2; i++)
+    for (size_t i = 0; i < NUM_ITEMS / 2; i++)
     {
         ASSERT_FALSE(uut.remove_if(is_odd));
     }

--- a/test/unittest/utils/ResourceLimitedVectorTests.cpp
+++ b/test/unittest/utils/ResourceLimitedVectorTests.cpp
@@ -37,7 +37,7 @@ TEST_F(ResourceLimitedVectorTests, default_constructor)
 
     // Should be empty and non-allocated
     ASSERT_TRUE(uut.empty());
-    ASSERT_EQ(uut.capacity(), 0);
+    ASSERT_EQ(uut.capacity(), 0u);
 
     // Add all items and check no errors
     for (int i : testbed)
@@ -108,7 +108,7 @@ TEST_F(ResourceLimitedVectorTests, prealocated_growing_1_config)
     ASSERT_TRUE(uut.empty());
 
     // Capacity should have been reserved
-    ASSERT_EQ(uut.size(), 0);
+    ASSERT_EQ(uut.size(), 0u);
     ASSERT_EQ(uut.capacity(), NUM_ITEMS);
 
     // Values should be correctly added

--- a/test/unittest/utils/ResourceLimitedVectorTests.cpp
+++ b/test/unittest/utils/ResourceLimitedVectorTests.cpp
@@ -1,0 +1,254 @@
+// Copyright 2019 Proyectos y Sistemas de Mantenimiento SL (eProsima).
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <fastrtps/utils/collections/ResourceLimitedVector.hpp>
+#include <gtest/gtest.h>
+
+using namespace eprosima::fastrtps;
+
+// Power of two has been chosen to allow for ASSERT_EQ on capacity, as
+// some implementations of std::vector would enforce power of two capacities
+constexpr size_t NUM_ITEMS = 32;
+
+class ResourceLimitedVectorTests: public ::testing::Test
+{
+    public:
+        const int testbed[NUM_ITEMS] = 
+        {
+             1,  2,  3,  4,  5,  6,  7,  8,  9, 10, 11, 12, 13, 14, 15, 16,
+            17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32
+        };
+};
+
+TEST_F(ResourceLimitedVectorTests, default_constructor)
+{
+    ResourceLimitedVector<int> uut;
+
+    // Should be empty and non-allocated
+    ASSERT_TRUE(uut.empty());
+    ASSERT_EQ(uut.capacity(), 0);
+
+    // Add all items and check no errors
+    for (int i : testbed)
+    {
+        ASSERT_NE (uut.push_back(i), nullptr);
+    }
+
+    // Vector should be filled
+    ASSERT_EQ(uut.size(), NUM_ITEMS);
+    ASSERT_EQ(uut.capacity(), NUM_ITEMS);
+
+    // Remove all items and check no errors
+    for (int i : testbed)
+    {
+        ASSERT_TRUE(uut.remove(i));
+        ASSERT_FALSE(uut.remove(i));
+    }
+
+    // Should be empty
+    ASSERT_TRUE(uut.empty());
+    ASSERT_EQ(uut.capacity(), NUM_ITEMS);
+}
+
+TEST_F(ResourceLimitedVectorTests, static_config)
+{
+    ResourceLimitedVector<int> uut(ResourceLimitedContainerConfig::fixed_size_configuration(NUM_ITEMS));
+
+    // Capacity should have been reserved
+    ASSERT_TRUE(uut.empty());
+    ASSERT_EQ(uut.capacity(), NUM_ITEMS);
+
+    // Values should be correctly added
+    for (int i : testbed)
+    {
+        ASSERT_NE(uut.push_back(i), nullptr);
+    }
+
+    // Vector should be filled
+    ASSERT_EQ(uut.size(), NUM_ITEMS);
+    ASSERT_EQ(uut.capacity(), NUM_ITEMS);
+
+    // Adding more values should return error
+    for (int i : testbed)
+    {
+        ASSERT_EQ(uut.push_back(i), nullptr);
+    }
+
+    // Size and capacity should not have changed
+    ASSERT_EQ(uut.size(), NUM_ITEMS);
+    ASSERT_EQ(uut.capacity(), NUM_ITEMS);
+
+    // Remove all items and check no errors
+    for (int i : testbed)
+    {
+        ASSERT_TRUE(uut.remove(i));
+        ASSERT_FALSE(uut.remove(i));
+    }
+
+    // Should be empty
+    ASSERT_TRUE(uut.empty());
+    ASSERT_EQ(uut.capacity(), NUM_ITEMS);
+}
+
+TEST_F(ResourceLimitedVectorTests, prealocated_growing_1_config)
+{
+    ResourceLimitedVector<int> uut(ResourceLimitedContainerConfig{ NUM_ITEMS, NUM_ITEMS*2, 1});
+
+    ASSERT_TRUE(uut.empty());
+
+    // Capacity should have been reserved
+    ASSERT_EQ(uut.size(), 0);
+    ASSERT_EQ(uut.capacity(), NUM_ITEMS);
+
+    // Values should be correctly added
+    for (int i : testbed)
+    {
+        ASSERT_NE(uut.push_back(i), nullptr);
+    }
+
+    // Vector should be filled
+    ASSERT_EQ(uut.size(), NUM_ITEMS);
+    ASSERT_EQ(uut.capacity(), NUM_ITEMS);
+
+    // More values should be correctly added
+    for (int i : testbed)
+    {
+        ASSERT_NE(uut.push_back(i), nullptr);
+        ASSERT_EQ(uut.size(), NUM_ITEMS + i);
+        ASSERT_GE(uut.capacity(), NUM_ITEMS + i);
+    }
+
+    // Vector should be filled
+    ASSERT_EQ(uut.size(), NUM_ITEMS*2);
+    ASSERT_EQ(uut.capacity(), NUM_ITEMS*2);
+
+    // Adding more values should return error
+    for (int i : testbed)
+    {
+        ASSERT_EQ(uut.push_back(i), nullptr);
+    }
+
+    // Size and capacity should not have changed
+    ASSERT_EQ(uut.size(), NUM_ITEMS * 2);
+    ASSERT_EQ(uut.capacity(), NUM_ITEMS * 2);
+
+    // Remove all items and check no errors
+    for (int i : testbed)
+    {
+        ASSERT_TRUE(uut.remove(i));
+        ASSERT_TRUE(uut.remove(i));
+        ASSERT_FALSE(uut.remove(i));
+    }
+
+    // Should be empty
+    ASSERT_TRUE(uut.empty());
+    ASSERT_EQ(uut.capacity(), NUM_ITEMS * 2);
+}
+
+TEST_F(ResourceLimitedVectorTests, prealocated_growing_n_config)
+{
+    ResourceLimitedVector<int> uut(ResourceLimitedContainerConfig{ NUM_ITEMS, NUM_ITEMS * 2, NUM_ITEMS });
+
+    // Capacity should have been reserved
+    ASSERT_TRUE(uut.empty());
+    ASSERT_EQ(uut.capacity(), NUM_ITEMS);
+
+    // Values should be correctly added
+    for (int i : testbed)
+    {
+        ASSERT_NE(uut.push_back(i), nullptr);
+    }
+
+    // Vector should be filled
+    ASSERT_EQ(uut.size(), NUM_ITEMS);
+    ASSERT_EQ(uut.capacity(), NUM_ITEMS);
+
+    // More values should be correctly added
+    for (int i : testbed)
+    {
+        ASSERT_NE(uut.push_back(i), nullptr);
+        ASSERT_EQ(uut.size(), NUM_ITEMS + i);
+        ASSERT_EQ(uut.capacity(), NUM_ITEMS * 2);
+    }
+
+    // Vector should be filled
+    ASSERT_EQ(uut.size(), NUM_ITEMS * 2);
+    ASSERT_EQ(uut.capacity(), NUM_ITEMS * 2);
+
+    // Adding more values should return error
+    for (int i : testbed)
+    {
+        ASSERT_EQ(uut.push_back(i), nullptr);
+    }
+
+    // Size and capacity should not have changed
+    ASSERT_EQ(uut.size(), NUM_ITEMS * 2);
+    ASSERT_EQ(uut.capacity(), NUM_ITEMS * 2);
+
+    // Remove all items and check no errors
+    for (int i : testbed)
+    {
+        ASSERT_TRUE(uut.remove(i));
+        ASSERT_TRUE(uut.remove(i));
+        ASSERT_FALSE(uut.remove(i));
+    }
+
+    // Should be empty
+    ASSERT_TRUE(uut.empty());
+    ASSERT_EQ(uut.capacity(), NUM_ITEMS * 2);
+}
+
+TEST_F(ResourceLimitedVectorTests, remove_if)
+{
+    ResourceLimitedVector<int> uut(ResourceLimitedContainerConfig::fixed_size_configuration(NUM_ITEMS));
+
+    // Capacity should have been reserved
+    ASSERT_TRUE(uut.empty());
+    ASSERT_EQ(uut.capacity(), NUM_ITEMS);
+
+    // Add all items and check no errors
+    for (int i : testbed)
+    {
+        ASSERT_NE(uut.push_back(i), nullptr);
+    }
+
+    // Vector should be filled
+    ASSERT_EQ(uut.size(), NUM_ITEMS);
+    ASSERT_EQ(uut.capacity(), NUM_ITEMS);
+
+    auto is_odd = [](int i) { return (i & 1) != 0; };
+
+    // Remove all odd items and check no errors
+    for (int i = 0; i < NUM_ITEMS / 2; i++)
+    {
+        ASSERT_TRUE(uut.remove_if(is_odd));
+    }
+
+    // Trying to remove odd items should give errors
+    for (int i = 0; i < NUM_ITEMS / 2; i++)
+    {
+        ASSERT_FALSE(uut.remove_if(is_odd));
+    }
+
+    // Should be half-empty
+    ASSERT_EQ(uut.size(), NUM_ITEMS / 2);
+    ASSERT_EQ(uut.capacity(), NUM_ITEMS);
+}
+
+
+int main(int argc, char **argv)
+{
+    testing::InitGoogleTest(&argc, argv);
+    return RUN_ALL_TESTS();
+}


### PR DESCRIPTION
Adding a wrapper of `std::vector` with control over the initial and maximum number of allocated elements, and linear capacity grow with configurable increment.

This is an initial step towards allocation behavior configuration.

This PR introduces two new data types

#### ResourceLimitedContainerConfig
A struct with `initial`, `maximum` and `increment` fields of type `size_t`, defining the allocation behaviour of a collection. 

Setting the same value on `initial` and `maximum` will define a preallocated fixed-size policy.

#### ResourceLimitedVector
A wrapper of `std::vector` with the following functionality:
* Constructor receiving a `ResourceLimitedContainerConfig`
* Adding elements: `T* push_back()` (copy and move) and `T* emplace_back(...)`
* Removing elements: `bool remove(const T&)` and `bool remove_if(predicate)`
* Traversing the collection: `begin`, `end`
* Other basics as `empty`, `clear`, `size`, `capacity`