### PR TITLE
Fixed error sending multicast on Windows in some scenarios. [4542]

### DIFF
--- a/src/cpp/transport/UDPTransportInterface.cpp
+++ b/src/cpp/transport/UDPTransportInterface.cpp
@@ -276,13 +276,16 @@ bool UDPTransportInterface::OpenAndBindOutputSockets(const Locator_t& locator)
             eProsimaUDPSocket unicastSocket = OpenAndBindUnicastOutputSocket(GenerateAnyAddressEndpoint(port), port);
             getSocketPtr(unicastSocket)->set_option(ip::multicast::enable_loopback(true));
 
+            // Outbounding first interface with already created socket.
+            if(!locNames.empty())
+            {
+                SetSocketOutbountInterface(unicastSocket, (*locNames.begin()).name);
+            }
+
             // If more than one interface, then create sockets for outbounding multicast.
             if (locNames.size() > 1)
             {
                 auto locIt = locNames.begin();
-
-                // Outbounding first interface with already created socket.
-                SetSocketOutbountInterface(unicastSocket, (*locIt).name);
                 mOutputSockets.push_back(new UDPChannelResource(unicastSocket));
 
                 // Create other socket for outbounding rest of interfaces.

--- a/src/cpp/utils/IPFinder.cpp
+++ b/src/cpp/utils/IPFinder.cpp
@@ -90,6 +90,7 @@ bool IPFinder::getIPs(std::vector<info_IP>* vec_name, bool return_loopback)
                     info_IP info;
                     info.type = family == AF_INET ? IP4 : IP6;
                     info.name = std::string(buf);
+                    info.dev = std::string(aa->AdapterName);
 
                     // Currently not supported interfaces that not support multicast.
                     if(aa->Flags & 0x0010)


### PR DESCRIPTION
This solves an issue when sending multicast on Windows machines with more than one interface where some of them are disconnected. In that case, the default multicast route may not be the first one.

This PR may fix ros2/rmw_fastrtps#246