### PR TITLE
Modify Windows version of UDPTransportInterface [4546]

### DIFF
--- a/include/fastrtps/transport/UDPTransportInterface.h
+++ b/include/fastrtps/transport/UDPTransportInterface.h
@@ -179,7 +179,7 @@ protected:
 
     virtual void SetReceiveBufferSize(uint32_t size) = 0;
     virtual void SetSendBufferSize(uint32_t size) = 0;
-    virtual void SetSocketOutbountInterface(eProsimaUDPSocket&, const std::string&) = 0;
+    virtual void SetSocketOutboundInterface(eProsimaUDPSocket&, const std::string&) = 0;
 
     /*
         struct LocatorCompare {

--- a/include/fastrtps/transport/UDPv4Transport.h
+++ b/include/fastrtps/transport/UDPv4Transport.h
@@ -114,7 +114,7 @@ protected:
 
     virtual void SetReceiveBufferSize(uint32_t size) override;
     virtual void SetSendBufferSize(uint32_t size) override;
-    virtual void SetSocketOutbountInterface(eProsimaUDPSocket&, const std::string&) override;
+    virtual void SetSocketOutboundInterface(eProsimaUDPSocket&, const std::string&) override;
 };
 
 } // namespace rtps

--- a/include/fastrtps/transport/UDPv6Transport.h
+++ b/include/fastrtps/transport/UDPv6Transport.h
@@ -114,7 +114,7 @@ protected:
 
     virtual void SetReceiveBufferSize(uint32_t size) override;
     virtual void SetSendBufferSize(uint32_t size) override;
-    virtual void SetSocketOutbountInterface(eProsimaUDPSocket&, const std::string&) override;
+    virtual void SetSocketOutboundInterface(eProsimaUDPSocket&, const std::string&) override;
 };
 
 } // namespace rtps

--- a/src/cpp/transport/UDPTransportInterface.cpp
+++ b/src/cpp/transport/UDPTransportInterface.cpp
@@ -276,13 +276,16 @@ bool UDPTransportInterface::OpenAndBindOutputSockets(const Locator_t& locator)
             eProsimaUDPSocket unicastSocket = OpenAndBindUnicastOutputSocket(GenerateAnyAddressEndpoint(port), port);
             getSocketPtr(unicastSocket)->set_option(ip::multicast::enable_loopback(true));
 
+            // Outbounding first interface with already created socket.
+            if(!locNames.empty())
+            {
+                SetSocketOutbountInterface(unicastSocket, (*locNames.begin()).name);
+            }
+
             // If more than one interface, then create sockets for outbounding multicast.
             if (locNames.size() > 1)
             {
                 auto locIt = locNames.begin();
-
-                // Outbounding first interface with already created socket.
-                SetSocketOutbountInterface(unicastSocket, (*locIt).name);
                 mOutputSockets.push_back(new UDPChannelResource(unicastSocket));
 
                 // Create other socket for outbounding rest of interfaces.

--- a/src/cpp/transport/UDPv4Transport.cpp
+++ b/src/cpp/transport/UDPv4Transport.cpp
@@ -478,7 +478,7 @@ void UDPv4Transport::SetSendBufferSize(uint32_t size)
     mConfiguration_.sendBufferSize = size;
 }
 
-void UDPv4Transport::SetSocketOutbountInterface(eProsimaUDPSocket& socket, const std::string& sIp)
+void UDPv4Transport::SetSocketOutboundInterface(eProsimaUDPSocket& socket, const std::string& sIp)
 {
 	getSocketPtr(socket)->set_option(ip::multicast::outbound_interface(asio::ip::address_v4::from_string(sIp)));
 }

--- a/src/cpp/transport/UDPv6Transport.cpp
+++ b/src/cpp/transport/UDPv6Transport.cpp
@@ -432,7 +432,7 @@ void UDPv6Transport::SetSendBufferSize(uint32_t size)
     mConfiguration_.sendBufferSize = size;
 }
 
-void UDPv6Transport::SetSocketOutbountInterface(eProsimaUDPSocket& socket, const std::string& sIp)
+void UDPv6Transport::SetSocketOutboundInterface(eProsimaUDPSocket& socket, const std::string& sIp)
 {
 	getSocketPtr(socket)->set_option(ip::multicast::outbound_interface(asio::ip::address_v6::from_string(sIp).scope_id()));
 }

--- a/src/cpp/utils/IPFinder.cpp
+++ b/src/cpp/utils/IPFinder.cpp
@@ -90,6 +90,7 @@ bool IPFinder::getIPs(std::vector<info_IP>* vec_name, bool return_loopback)
                     info_IP info;
                     info.type = family == AF_INET ? IP4 : IP6;
                     info.name = std::string(buf);
+                    info.dev = std::string(aa->AdapterName);
 
                     // Currently not supported interfaces that not support multicast.
                     if(aa->Flags & 0x0010)


### PR DESCRIPTION
HelloWorldExample execution finished on Windows logging several errors.

Fast RTPS closes several transport related async threads by sending dummy messages in order to awake them. On Windows these messages lead to a socket failure so UDPTransportInterface should be modified in order to make them fail quietly.