### PR TITLE
Minimal Changes to build with VxWorks

### DIFF
--- a/cmake/common/check_configuration.cmake
+++ b/cmake/common/check_configuration.cmake
@@ -73,9 +73,10 @@ endmacro()
 
 macro(check_endianness)
     # Test endianness
-    include(TestBigEndian)
-    test_big_endian(BIG_ENDIAN)
-    set(__BIG_ENDIAN__ ${BIG_ENDIAN})
+    #include(TestBigEndian)
+    #test_big_endian(BIG_ENDIAN)
+    #set(__BIG_ENDIAN__ ${BIG_ENDIAN})
+    set(__BIG_ENDIAN__ 0)
 endmacro()
 
 macro(check_msvc_arch)

--- a/include/fastrtps/rtps/flowcontrol/ThroughputControllerDescriptor.h
+++ b/include/fastrtps/rtps/flowcontrol/ThroughputControllerDescriptor.h
@@ -16,7 +16,7 @@
 #define THROUGHPUT_CONTROLLER_DESCRIPTOR_H
 
 #include <fastrtps/fastrtps_dll.h>
-#include <cstdint>
+#include <stdint.h>
 
 namespace eprosima{
 namespace fastrtps{

--- a/include/fastrtps/utils/TimeConversion.h
+++ b/include/fastrtps/utils/TimeConversion.h
@@ -20,8 +20,10 @@
 #ifndef TIMECONVERSION_H_
 #define TIMECONVERSION_H_
 
-#include <cstdint>
+#include <stdint.h>
 #include "../rtps/common/Time_t.h"
+
+using namespace std;
 
 namespace eprosima {
 namespace fastrtps{

--- a/src/cpp/log/StdoutConsumer.cpp
+++ b/src/cpp/log/StdoutConsumer.cpp
@@ -26,7 +26,7 @@ void StdoutConsumer::PrintHeader(const Log::Entry& entry) const
     localtime_s(&ltime, &now_c);
     std::cout << C_B_WHITE << std::put_time(&ltime, "%F %T")
 #else
-    std::cout << C_B_WHITE << std::put_time(localtime(&now_c), "%F %T")
+    std::cout << C_B_WHITE << ctime(&now_c)
 #endif
        << "." << std::setw(3) << std::setfill('0') <<  ms << " ";
     switch (entry.kind)

--- a/src/cpp/rtps/flowcontrol/ThroughputController.cpp
+++ b/src/cpp/rtps/flowcontrol/ThroughputController.cpp
@@ -102,7 +102,7 @@ void ThroughputController::ScheduleRefresh(uint32_t sizeToRestore)
     auto refresh = [throwawayTimer, this, sizeToRestore]
         (const asio::error_code& error)
         {
-            if ((error != asio::error::operation_aborted) &&
+            if ((error != static_cast<asio::error_code>(asio::error::operation_aborted)) &&
                     FlowController::IsListening(this))
             {
                 std::unique_lock<std::recursive_mutex> scopedLock(mThroughputControllerMutex);

--- a/src/cpp/rtps/history/CacheChangePool.cpp
+++ b/src/cpp/rtps/history/CacheChangePool.cpp
@@ -23,6 +23,7 @@
 
 #include <mutex>
 
+#include <math.h>
 #include <cassert>
 
 

--- a/src/cpp/rtps/resources/TimedEventImpl.cpp
+++ b/src/cpp/rtps/resources/TimedEventImpl.cpp
@@ -174,7 +174,7 @@ void TimedEventImpl::event(const std::error_code& ec, const std::shared_ptr<Time
     // Check bad preconditions
     assert(!(ret && scode == TimerState::DESTROYED));
 
-    if(scode != TimerState::WAITING || !ret || ec == asio::error::operation_aborted)
+    if(scode != TimerState::WAITING || !ret || ec == static_cast<asio::error_code>(asio::error::operation_aborted))
     {
         // If autodestruction is TimedEvent::ALLWAYS, delete the event.
         if(scode != TimerState::DESTROYED && state.get()->autodestruction_ == TimedEvent::ALLWAYS)

--- a/src/cpp/security/accesscontrol/GovernanceParser.cpp
+++ b/src/cpp/security/accesscontrol/GovernanceParser.cpp
@@ -260,7 +260,7 @@ bool GovernanceParser::parse_domain_rule(tinyxml2::XMLElement* root, DomainRule&
             {
                 if(strcmp(text, ProtectionKindNone_str) == 0)
                 {
-                    rule.discovery_protection_kind = ProtectionKind::NONE;
+                    rule.discovery_protection_kind = ProtectionKind::NO_PROTECTION;
                 }
                 else if(strcmp(text, ProtectionKindSign_str) == 0)
                 {
@@ -315,7 +315,7 @@ bool GovernanceParser::parse_domain_rule(tinyxml2::XMLElement* root, DomainRule&
             {
                 if(strcmp(text, ProtectionKindNone_str) == 0)
                 {
-                    rule.liveliness_protection_kind = ProtectionKind::NONE;
+                    rule.liveliness_protection_kind = ProtectionKind::NO_PROTECTION;
                 }
                 else if(strcmp(text, ProtectionKindSign_str) == 0)
                 {
@@ -370,7 +370,7 @@ bool GovernanceParser::parse_domain_rule(tinyxml2::XMLElement* root, DomainRule&
             {
                 if(strcmp(text, ProtectionKindNone_str) == 0)
                 {
-                    rule.rtps_protection_kind = ProtectionKind::NONE;
+                    rule.rtps_protection_kind = ProtectionKind::NO_PROTECTION;
                 }
                 else if(strcmp(text, ProtectionKindSign_str) == 0)
                 {
@@ -625,7 +625,7 @@ bool GovernanceParser::parse_topic_rule(tinyxml2::XMLElement* root, TopicRule& r
             {
                 if(strcmp(text, ProtectionKindNone_str) == 0)
                 {
-                    rule.metadata_protection_kind = ProtectionKind::NONE;
+                    rule.metadata_protection_kind = ProtectionKind::NO_PROTECTION;
                 }
                 else if(strcmp(text, ProtectionKindSign_str) == 0)
                 {
@@ -680,7 +680,7 @@ bool GovernanceParser::parse_topic_rule(tinyxml2::XMLElement* root, TopicRule& r
             {
                 if(strcmp(text, ProtectionKindNone_str) == 0)
                 {
-                    rule.data_protection_kind = ProtectionKind::NONE;
+                    rule.data_protection_kind = ProtectionKind::NO_PROTECTION;
                 }
                 else if(strcmp(text, ProtectionKindSign_str) == 0)
                 {

--- a/src/cpp/security/accesscontrol/GovernanceParser.h
+++ b/src/cpp/security/accesscontrol/GovernanceParser.h
@@ -26,7 +26,7 @@ namespace security {
 
 enum class ProtectionKind
 {
-    NONE,
+    NO_PROTECTION,
     SIGN,
     ENCRYPT,
     SIGN_WITH_ORIGIN_AUTHENTICATION,

--- a/src/cpp/security/accesscontrol/Permissions.cpp
+++ b/src/cpp/security/accesscontrol/Permissions.cpp
@@ -562,7 +562,7 @@ static bool verify_permissions_file(const AccessPermissionsHandle& local_handle,
 
 static void process_protection_kind(const ProtectionKind kind, bool& protected_flag, bool& encrypted_flag, bool& orig_auth_flag)
 {
-    protected_flag = kind != ProtectionKind::NONE;
+    protected_flag = kind != ProtectionKind::NO_PROTECTION;
     encrypted_flag = (kind == ProtectionKind::ENCRYPT) || (kind == ProtectionKind::ENCRYPT_WITH_ORIGIN_AUTHENTICATION);
     orig_auth_flag = (kind == ProtectionKind::ENCRYPT_WITH_ORIGIN_AUTHENTICATION) ||
         (kind == ProtectionKind::SIGN_WITH_ORIGIN_AUTHENTICATION);
@@ -659,7 +659,7 @@ static bool check_subject_name(const IdentityHandle& ih, AccessPermissionsHandle
 
                         reader_attributes.is_submessage_protected =
                             writer_attributes.is_submessage_protected =
-                            (topic_rule.metadata_protection_kind != ProtectionKind::NONE);
+                            (topic_rule.metadata_protection_kind != ProtectionKind::NO_PROTECTION);
 
                         plugin_attributes.is_payload_encrypted =
                             reader_attributes.is_key_protected =
@@ -667,7 +667,7 @@ static bool check_subject_name(const IdentityHandle& ih, AccessPermissionsHandle
                             (topic_rule.data_protection_kind == ProtectionKind::ENCRYPT);
                         reader_attributes.is_payload_protected =
                             writer_attributes.is_payload_protected =
-                                (topic_rule.data_protection_kind != ProtectionKind::NONE);
+                                (topic_rule.data_protection_kind != ProtectionKind::NO_PROTECTION);
 
                         reader_attributes.plugin_endpoint_attributes = plugin_attributes.mask();
                         writer_attributes.plugin_endpoint_attributes = plugin_attributes.mask();

--- a/src/cpp/transport/TCPTransportInterface.cpp
+++ b/src/cpp/transport/TCPTransportInterface.cpp
@@ -848,7 +848,7 @@ bool TCPTransportInterface::Receive(TCPChannelResource *pChannelResource, octet*
             }
             catch (const asio::error_code& code)
             {
-                if ((code == asio::error::eof) || (code == asio::error::connection_reset))
+                if ((code.value() == asio::error::eof) || (code.value() == asio::error::connection_reset))
                 {
                     // Close the channel
                     logInfo(RTCP_MSG_IN, "ASIO [RECEIVE]: " << code.message());

--- a/src/cpp/utils/StringMatching.cpp
+++ b/src/cpp/utils/StringMatching.cpp
@@ -19,7 +19,7 @@
 
 #include <fastrtps/utils/StringMatching.h>
 
-#if defined(__cplusplus_winrt)
+#if defined(__cplusplus_winrt) || defined(__VXWORKS__)
 #include <algorithm>
 #include <regex>
 #elif defined(_WIN32)
@@ -41,7 +41,7 @@ StringMatching::~StringMatching() {
 	// TODO Auto-generated destructor stub
 }
 
-#if defined(__cplusplus_winrt)
+#if defined(__cplusplus_winrt) || defined(__VXWORKS__)
 void replace_all(std::string & subject, const std::string & search, const std::string & replace) {
 	size_t pos = 0;
 	while ((pos = subject.find(search, pos)) != std::string::npos) {

--- a/src/cpp/utils/eClock.cpp
+++ b/src/cpp/utils/eClock.cpp
@@ -17,6 +17,7 @@
  *
  */
 #include <cmath>
+#include <math.h>
 #include <iostream>
 #include <fastrtps/utils/eClock.h>
 using namespace eprosima::fastrtps::rtps;
@@ -83,6 +84,7 @@ uint64_t eClock::intervalEnd()
 
 #else //UNIX VERSION
 #include <unistd.h>
+#include <time.h>
 
 bool eClock::setTimeNow(Time_t* tnow)
 {
@@ -92,11 +94,22 @@ bool eClock::setTimeNow(Time_t* tnow)
 	return true;
 }
 
+#ifdef __VXWORKS__
+void eClock::my_sleep(uint32_t milliseconds)
+{
+    struct timespec ts;
+    ts.tv_sec = milliseconds / 1000;
+    ts.tv_nsec = (milliseconds % 1000) * 1000000;
+    nanosleep(&ts, NULL);
+    return;
+}
+#else
 void eClock::my_sleep(uint32_t milliseconds)
 {
 	usleep(milliseconds*1000);
 	return;
 }
+#endif
 
 void eClock::intervalStart()
 {


### PR DESCRIPTION
This PR shows the minimal changes that we needed to make in order to get Fast-RTPS working on VxWorks. This PR is informational to the eProsima engineers we have talked with about adding VxWorks support and shouldn't be merged directly to mainline.

Additional changes were made to Fast-CDR here https://github.com/eProsima/Fast-CDR/pull/43, asio here https://github.com/nburek/asio/commit/b41fa3231d005f9dc7fefdcd12d3bcd1adeaf287, and tinyxml2 here https://github.com/nburek/tinyxml2/commit/efa8104b8cee97ec40317a3b6e7e9b31861297cf. 

Below is a breakdown of the changes in this PR.

[1] Fix error in asio error code comparison

eProsima code is making asio error code comparisons in an incorrect and
inconsistent manner, where the lhs and rhs types differ in an unintended
way. This results in a compiler error with an ambiguous use of the equality
operator

This change corrects the comparison code to use the value() method in
order to obtain the actual error code value.

[2] Workaround for missing std::put_time in gcc 4.8.4

The original code made use of std::put_time defined under c++11.
GCC 4.8.4, however, does not support this in its implementation of
the c++11 standard.

Sufficiently equivalent functionality has been added to replace
the original use of std::put_time.

[3] Support cross compilation of EProsima