### PR TITLE
Refs #4642 Too old configuration method [#395]

### DIFF
--- a/examples/C++/Benchmark/BenchmarkPublisher.cpp
+++ b/examples/C++/Benchmark/BenchmarkPublisher.cpp
@@ -93,27 +93,12 @@ bool BenchMarkPublisher::init(int transport, ReliabilityQosPolicyKind reliabilit
     }
     else if (transport == 2)
     {
-        uint32_t kind = LOCATOR_KIND_TCPv4;
         PParam.rtps.useBuiltinTransports = false;
-
-        Locator_t unicast_locator;
-        unicast_locator.kind = kind;
-        IPLocator::setIPv4(unicast_locator, "127.0.0.1");
-        unicast_locator.port = 5100;
-        IPLocator::setLogicalPort(unicast_locator, 7410);
-        PParam.rtps.defaultUnicastLocatorList.push_back(unicast_locator); // Publisher's data channel
-
-        Locator_t meta_locator;
-        meta_locator.kind = kind;
-        IPLocator::setIPv4(meta_locator, "127.0.0.1");
-        meta_locator.port = 5100;
-        IPLocator::setLogicalPort(meta_locator, 7402);
-        PParam.rtps.builtin.metatrafficUnicastLocatorList.push_back(meta_locator);  // Publisher's meta channel
 
         std::shared_ptr<TCPv4TransportDescriptor> descriptor = std::make_shared<TCPv4TransportDescriptor>();
         descriptor->sendBufferSize = 8912896; // 8.5Mb
         descriptor->receiveBufferSize = 8912896; // 8.5Mb
-        descriptor->set_WAN_address("127.0.0.1");
+        //descriptor->set_WAN_address("127.0.0.1");
         descriptor->add_listener_port(5100);
         PParam.rtps.userTransports.push_back(descriptor);
     }
@@ -123,22 +108,7 @@ bool BenchMarkPublisher::init(int transport, ReliabilityQosPolicyKind reliabilit
     }
     else if (transport == 4)
     {
-        uint32_t kind = LOCATOR_KIND_TCPv6;
         PParam.rtps.useBuiltinTransports = false;
-
-        Locator_t unicast_locator;
-        unicast_locator.kind = kind;
-        IPLocator::setIPv6(unicast_locator, "::1");
-        unicast_locator.port = 5100;
-        IPLocator::setLogicalPort(unicast_locator, 7410);
-        PParam.rtps.defaultUnicastLocatorList.push_back(unicast_locator); // Publisher's data channel
-
-        Locator_t meta_locator;
-        meta_locator.kind = kind;
-        IPLocator::setIPv6(meta_locator, "::1");
-        meta_locator.port = 5100;
-        IPLocator::setLogicalPort(meta_locator, 7402);
-        PParam.rtps.builtin.metatrafficUnicastLocatorList.push_back(meta_locator);  // Publisher's meta channel
 
         std::shared_ptr<TCPv6TransportDescriptor> descriptor = std::make_shared<TCPv6TransportDescriptor>();
         descriptor->sendBufferSize = 8912896; // 8.5Mb

--- a/examples/C++/Benchmark/BenchmarkPublisher.cpp
+++ b/examples/C++/Benchmark/BenchmarkPublisher.cpp
@@ -98,7 +98,6 @@ bool BenchMarkPublisher::init(int transport, ReliabilityQosPolicyKind reliabilit
         std::shared_ptr<TCPv4TransportDescriptor> descriptor = std::make_shared<TCPv4TransportDescriptor>();
         descriptor->sendBufferSize = 8912896; // 8.5Mb
         descriptor->receiveBufferSize = 8912896; // 8.5Mb
-        //descriptor->set_WAN_address("127.0.0.1");
         descriptor->add_listener_port(5100);
         PParam.rtps.userTransports.push_back(descriptor);
     }
@@ -113,7 +112,6 @@ bool BenchMarkPublisher::init(int transport, ReliabilityQosPolicyKind reliabilit
         std::shared_ptr<TCPv6TransportDescriptor> descriptor = std::make_shared<TCPv6TransportDescriptor>();
         descriptor->sendBufferSize = 8912896; // 8.5Mb
         descriptor->receiveBufferSize = 8912896; // 8.5Mb
-        //descriptor->set_WAN_address("127.0.0.1");
         descriptor->add_listener_port(5100);
         PParam.rtps.userTransports.push_back(descriptor);
     }

--- a/examples/C++/Benchmark/BenchmarkSubscriber.cpp
+++ b/examples/C++/Benchmark/BenchmarkSubscriber.cpp
@@ -73,24 +73,7 @@ bool BenchMarkSubscriber::init(int transport, ReliabilityQosPolicyKind reliabili
         initial_peer_locator.kind = kind;
         IPLocator::setIPv4(initial_peer_locator, "127.0.0.1");
         initial_peer_locator.port = 5100;
-        IPLocator::setLogicalPort(initial_peer_locator, 7402);
-        PParam.rtps.builtin.initialPeersList.push_back(initial_peer_locator); // Publisher's meta channel
-        IPLocator::setLogicalPort(initial_peer_locator, 7410);
-        PParam.rtps.builtin.initialPeersList.push_back(initial_peer_locator); // Publisher's meta channel
-
-        Locator_t unicast_locator;
-        unicast_locator.kind = kind;
-        IPLocator::setIPv4(unicast_locator, "127.0.0.1");
-        unicast_locator.port = 5100;
-        IPLocator::setLogicalPort(unicast_locator, 7411);
-        PParam.rtps.defaultUnicastLocatorList.push_back(unicast_locator); // Subscriber's data channel
-
-        Locator_t meta_locator;
-        meta_locator.kind = kind;
-        IPLocator::setIPv4(meta_locator, "127.0.0.1");
-        meta_locator.port = 5100;
-        IPLocator::setLogicalPort(meta_locator, 7403);
-        PParam.rtps.builtin.metatrafficUnicastLocatorList.push_back(meta_locator); // Subscriber's meta channel
+        PParam.rtps.builtin.initialPeersList.push_back(initial_peer_locator); // Publisher's channel
 
         PParam.rtps.useBuiltinTransports = false;
         std::shared_ptr<TCPv4TransportDescriptor> descriptor = std::make_shared<TCPv4TransportDescriptor>();
@@ -111,24 +94,7 @@ bool BenchMarkSubscriber::init(int transport, ReliabilityQosPolicyKind reliabili
         initial_peer_locator.kind = kind;
         IPLocator::setIPv6(initial_peer_locator, "::1");
         initial_peer_locator.port = 5100;
-        IPLocator::setLogicalPort(initial_peer_locator, 7402);
-        PParam.rtps.builtin.initialPeersList.push_back(initial_peer_locator); // Publisher's meta channel
-        IPLocator::setLogicalPort(initial_peer_locator, 7410);
-        PParam.rtps.builtin.initialPeersList.push_back(initial_peer_locator); // Publisher's meta channel
-
-        Locator_t unicast_locator;
-        unicast_locator.kind = kind;
-        IPLocator::setIPv6(unicast_locator, "::1");
-        unicast_locator.port = 5100;
-        IPLocator::setLogicalPort(unicast_locator, 7411);
-        PParam.rtps.defaultUnicastLocatorList.push_back(unicast_locator); // Subscriber's data channel
-
-        Locator_t meta_locator;
-        meta_locator.kind = kind;
-        IPLocator::setIPv6(meta_locator, "::1");
-        meta_locator.port = 5100;
-        IPLocator::setLogicalPort(meta_locator, 7403);
-        PParam.rtps.builtin.metatrafficUnicastLocatorList.push_back(meta_locator); // Subscriber's meta channel
+        PParam.rtps.builtin.initialPeersList.push_back(initial_peer_locator); // Publisher's channel
 
         PParam.rtps.useBuiltinTransports = false;
         std::shared_ptr<TCPv6TransportDescriptor> descriptor = std::make_shared<TCPv6TransportDescriptor>();


### PR DESCRIPTION
This PR should fix the configuration error that prevent the Benchmark run with TCP enabled.

Fixes #395 