### PR TITLE
Correctly handling octetsToNextHeader value zero [4665]

### DIFF
--- a/include/fastrtps/rtps/attributes/ReaderAttributes.h
+++ b/include/fastrtps/rtps/attributes/ReaderAttributes.h
@@ -49,9 +49,9 @@ public:
                (this->heartbeatResponseDelay == b.heartbeatResponseDelay);
     }
 
-    //!Initial AckNack delay. Default value ~45ms.
+    //!Initial AckNack delay. Default value ~70ms.
     Duration_t initialAcknackDelay;
-    //!Delay to be applied when a hearbeat message is received, default value ~4.5ms.
+    //!Delay to be applied when a hearbeat message is received, default value ~5ms.
     Duration_t heartbeatResponseDelay;
 };
 

--- a/include/fastrtps/rtps/attributes/WriterAttributes.h
+++ b/include/fastrtps/rtps/attributes/WriterAttributes.h
@@ -60,11 +60,11 @@ public:
                (this->nackSupressionDuration == b.nackSupressionDuration);
     }
 
-    //! Initial heartbeat delay. Default value ~45ms.
+    //! Initial heartbeat delay. Default value ~11ms.
     Duration_t initialHeartbeatDelay;
     //! Periodic HB period, default value 3s.
     Duration_t heartbeatPeriod;
-    //!Delay to apply to the response of a ACKNACK message, default value ~45ms.
+    //!Delay to apply to the response of a ACKNACK message, default value ~5ms.
     Duration_t nackResponseDelay;
     //!This time allows the RTPSWriter to ignore nack messages too soon after the data as sent, default value 0s.
     Duration_t nackSupressionDuration;

--- a/include/fastrtps/rtps/messages/MessageReceiver.h
+++ b/include/fastrtps/rtps/messages/MessageReceiver.h
@@ -127,21 +127,20 @@ class MessageReceiver
          *
          * @param msg
          * @param smh
-         * @param last
          * @return
          */
-        bool proc_Submsg_Data(CDRMessage_t*msg, SubmessageHeader_t* smh,bool*last);
-        bool proc_Submsg_DataFrag(CDRMessage_t*msg, SubmessageHeader_t* smh, bool*last);
-        bool proc_Submsg_Acknack(CDRMessage_t*msg, SubmessageHeader_t* smh,bool*last);
-        bool proc_Submsg_Heartbeat(CDRMessage_t*msg, SubmessageHeader_t* smh,bool*last);
-        bool proc_Submsg_Gap(CDRMessage_t*msg, SubmessageHeader_t* smh,bool*last);
-        bool proc_Submsg_InfoTS(CDRMessage_t*msg, SubmessageHeader_t* smh,bool*last);
-        bool proc_Submsg_InfoDST(CDRMessage_t*msg,SubmessageHeader_t* smh,bool*last);
-        bool proc_Submsg_InfoSRC(CDRMessage_t*msg,SubmessageHeader_t* smh,bool*last);
-        bool proc_Submsg_NackFrag(CDRMessage_t*msg, SubmessageHeader_t* smh, bool*last);
-        bool proc_Submsg_HeartbeatFrag(CDRMessage_t*msg, SubmessageHeader_t* smh, bool*last);
-        bool proc_Submsg_SecureMessage(CDRMessage_t*msg, SubmessageHeader_t* smh,bool*last);
-        bool proc_Submsg_SecureSubMessage(CDRMessage_t*msg, SubmessageHeader_t* smh,bool*last);
+        bool proc_Submsg_Data(CDRMessage_t*msg, SubmessageHeader_t* smh);
+        bool proc_Submsg_DataFrag(CDRMessage_t*msg, SubmessageHeader_t* smh);
+        bool proc_Submsg_Acknack(CDRMessage_t*msg, SubmessageHeader_t* smh);
+        bool proc_Submsg_Heartbeat(CDRMessage_t*msg, SubmessageHeader_t* smh);
+        bool proc_Submsg_Gap(CDRMessage_t*msg, SubmessageHeader_t* smh);
+        bool proc_Submsg_InfoTS(CDRMessage_t*msg, SubmessageHeader_t* smh);
+        bool proc_Submsg_InfoDST(CDRMessage_t*msg,SubmessageHeader_t* smh);
+        bool proc_Submsg_InfoSRC(CDRMessage_t*msg,SubmessageHeader_t* smh);
+        bool proc_Submsg_NackFrag(CDRMessage_t*msg, SubmessageHeader_t* smh);
+        bool proc_Submsg_HeartbeatFrag(CDRMessage_t*msg, SubmessageHeader_t* smh);
+        bool proc_Submsg_SecureMessage(CDRMessage_t*msg, SubmessageHeader_t* smh);
+        bool proc_Submsg_SecureSubMessage(CDRMessage_t*msg, SubmessageHeader_t* smh);
 
         RTPSParticipantImpl* participant_;
 };

--- a/include/fastrtps/rtps/messages/RTPS_messages.h
+++ b/include/fastrtps/rtps/messages/RTPS_messages.h
@@ -77,17 +77,18 @@ enum SubmessageId : uint8_t
  }
 
  //!@brief Structure SubmessageHeader_t, used to contain the header information of a submessage.
- struct SubmessageHeader_t{
+ struct SubmessageHeader_t
+ {
      octet submessageId;
-     uint16_t submessageLength;
-     uint32_t submsgLengthLarger;
+     uint32_t submessageLength;
      SubmessageFlag flags;
+     bool is_last;
 
-     SubmessageHeader_t():
-         submessageId(0),
-         submessageLength(0),
-         submsgLengthLarger(0),
-         flags(0)
+     SubmessageHeader_t()
+         : submessageId(0)
+         , submessageLength(0)
+         , flags(0)
+         , is_last(false)
      {}
  };
 

--- a/src/cpp/transport/test_UDPv4Transport.cpp
+++ b/src/cpp/transport/test_UDPv4Transport.cpp
@@ -93,13 +93,31 @@ bool test_UDPv4Transport::Send(const octet* sendBuffer, uint32_t sendBufferSize,
 
 static bool ReadSubmessageHeader(CDRMessage_t& msg, SubmessageHeader_t& smh)
 {
-    if(msg.length - msg.pos < 4)
+    if (msg.length - msg.pos < 4)
         return false;
 
     smh.submessageId = msg.buffer[msg.pos]; msg.pos++;
     smh.flags = msg.buffer[msg.pos]; msg.pos++;
     msg.msg_endian = smh.flags & BIT(0) ? LITTLEEND : BIGEND;
-    CDRMessage::readUInt16(&msg, &smh.submessageLength);
+    uint16_t length = 0;
+    CDRMessage::readUInt16(&msg, &length);
+
+    if (msg.pos + length > msg.length)
+    {
+        return false;
+    }
+
+    if ( (length == 0) && (smh.submessageId != INFO_TS) && (smh.submessageId != PAD) )
+    {
+        // THIS IS THE LAST SUBMESSAGE
+        smh.submessageLength = msg.length - msg.pos;
+        smh.is_last = true;
+    }
+    else
+    {
+        smh.submessageLength = length;
+        smh.is_last = false;
+    }
     return true;
 }
 


### PR DESCRIPTION
This should fix #375 by correctly handling the cases where the `octetsToNextHeader ` field on the submessage header is zero