### PR TITLE
Removing warning message in ReaderProxy [4720]

### DIFF
--- a/src/cpp/rtps/writer/ReaderProxy.cpp
+++ b/src/cpp/rtps/writer/ReaderProxy.cpp
@@ -187,11 +187,6 @@ bool ReaderProxy::requested_changes_set(std::vector<SequenceNumber_t>& seqNumSet
     {
         logInfo(RTPS_WRITER,"Requested Changes: " << seqNumSet);
     }
-    else if(!seqNumSet.empty())
-    {
-        logWarning(RTPS_WRITER,"Requested Changes: " << seqNumSet
-                   << " not found (low mark: " << changesFromRLowMark_ << ")");
-    }
 
     return isSomeoneWasSetRequested;
 }


### PR DESCRIPTION
Guillaume (Clearpath) noticed the following warning:

"Requested Changes: 1068 [...]  not found (low mark: 1067)"

This warning is no longer relevant after changes to ReaderProxy PR #411 and this PR removes it.