### PR TITLE
Add option for sanitizers enabled so that pthread library can be expl… [4772]

### DIFF
--- a/src/cpp/CMakeLists.txt
+++ b/src/cpp/CMakeLists.txt
@@ -277,19 +277,16 @@ elseif(NOT EPROSIMA_INSTALLER)
         set(PRIVACY "PRIVATE")
     endif()
 
+    # Define option to link pthread library when sanitizers are enabled
+    option(SANITIZER_ENABLED "Add pthread library when sanitizers are enabled" OFF)
+
     # Link library to external libraries.
     target_link_libraries(${PROJECT_NAME} ${PRIVACY} fastcdr
-        ${CMAKE_THREAD_LIBS_INIT} ${CMAKE_DL_LIBS}
-        ${TINYXML2_LIBRARY}
+        $<$<BOOL:${SANITIZER_ENABLED}>:pthread$<SEMICOLON>${CMAKE_THREAD_LIBS_INIT}>
+        ${CMAKE_DL_LIBS} ${TINYXML2_LIBRARY}
         $<$<BOOL:${SECURITY}>:OpenSSL::SSL$<SEMICOLON>OpenSSL::Crypto>
         $<$<BOOL:${WIN32}>:iphlpapi$<SEMICOLON>Shlwapi>
         )
-
-    # Define option to link pthread library when sanitizers are enabled
-    option(SANITIZER_ENABLED "Add pthread library when sanitizers are enabled" OFF)
-    if(SANITIZER_ENABLED)
-        target_link_libraries(${PROJECT_NAME} ${PRIVACY} pthread)
-    endif()
 
     if(MSVC OR MSVC_IDE)
         set_target_properties(${PROJECT_NAME} PROPERTIES RELEASE_POSTFIX -${PROJECT_VERSION_MAJOR}.${PROJECT_VERSION_MINOR})

--- a/src/cpp/CMakeLists.txt
+++ b/src/cpp/CMakeLists.txt
@@ -285,6 +285,12 @@ elseif(NOT EPROSIMA_INSTALLER)
         $<$<BOOL:${WIN32}>:iphlpapi$<SEMICOLON>Shlwapi>
         )
 
+    # Define option to link pthread library when sanitizers are enabled
+    option(SANITIZER_ENABLED "Add pthread library when sanitizers are enabled" OFF)
+    if(SANITIZER_ENABLED)
+        target_link_libraries(${PROJECT_NAME} ${PRIVACY} pthread)
+    endif()
+
     if(MSVC OR MSVC_IDE)
         set_target_properties(${PROJECT_NAME} PROPERTIES RELEASE_POSTFIX -${PROJECT_VERSION_MAJOR}.${PROJECT_VERSION_MINOR})
         set_target_properties(${PROJECT_NAME} PROPERTIES RELWITHDEBINFO_POSTFIX -${PROJECT_VERSION_MAJOR}.${PROJECT_VERSION_MINOR})

--- a/src/cpp/CMakeLists.txt
+++ b/src/cpp/CMakeLists.txt
@@ -282,8 +282,9 @@ elseif(NOT EPROSIMA_INSTALLER)
 
     # Link library to external libraries.
     target_link_libraries(${PROJECT_NAME} ${PRIVACY} fastcdr
-        $<$<BOOL:${SANITIZER_ENABLED}>:pthread$<SEMICOLON>${CMAKE_THREAD_LIBS_INIT}>
-        ${CMAKE_DL_LIBS} ${TINYXML2_LIBRARY}
+        ${CMAKE_THREAD_LIBS_INIT} ${CMAKE_DL_LIBS}
+        $<$<BOOL:${SANITIZER_ENABLED}>:pthread>
+        ${TINYXML2_LIBRARY}
         $<$<BOOL:${SECURITY}>:OpenSSL::SSL$<SEMICOLON>OpenSSL::Crypto>
         $<$<BOOL:${WIN32}>:iphlpapi$<SEMICOLON>Shlwapi>
         )


### PR DESCRIPTION
…icitly linked

Sanitizers like ASan and TSan have their own flavor thread libraries which prevent
cmake from linking the pthread library. Explicity linking this library when SANITIZER_ENABLED
option is on.

Connects to ros2/ci#245