### PR TITLE
Made Subscriber history resource limits dependent on history depth [4782]

### DIFF
--- a/src/cpp/subscriber/SubscriberHistory.cpp
+++ b/src/cpp/subscriber/SubscriberHistory.cpp
@@ -42,7 +42,17 @@ SubscriberHistory::SubscriberHistory(
         const HistoryQosPolicy& history,
         const ResourceLimitsQosPolicy& resource,
         MemoryManagementPolicy_t mempolicy)
-    : ReaderHistory(HistoryAttributes(mempolicy, payloadMaxSize,resource.allocated_samples,resource.max_samples + 1))
+    : ReaderHistory(HistoryAttributes(mempolicy, payloadMaxSize,
+                history.kind == KEEP_ALL_HISTORY_QOS ?
+                        resource.allocated_samples :
+                        simpl->getAttributes().topic.getTopicKind() == NO_KEY ?
+                            std::min(resource.allocated_samples, history.depth) :
+                            std::min(resource.allocated_samples, history.depth * resource.max_instances),
+                history.kind == KEEP_ALL_HISTORY_QOS ?
+                        resource.max_samples :
+                        simpl->getAttributes().topic.getTopicKind() == NO_KEY ?
+                            history.depth :
+                            history.depth * resource.max_instances))
     , m_unreadCacheCount(0)
     , m_historyQos(history)
     , m_resourceLimitsQos(resource)


### PR DESCRIPTION
This makes the behavior on the allocation resource limits consistent on the subscriber and publisher history.

For any entity with a `KEEP_LAST` history policy, its history depth is taken into consideration for the resource limits.