### PR TITLE
Readers: Resource limits on the number of matched writers [4654]

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -13,6 +13,3 @@
 [submodule "thirdparty/tinyxml2"]
 	path = thirdparty/tinyxml2
 	url = https://github.com/leethomason/tinyxml2.git
-[submodule "thirdparty/foonathan_memory"]
-	path = thirdparty/foonathan_memory
-	url = https://github.com/foonathan/memory

--- a/.gitmodules
+++ b/.gitmodules
@@ -13,3 +13,6 @@
 [submodule "thirdparty/tinyxml2"]
 	path = thirdparty/tinyxml2
 	url = https://github.com/leethomason/tinyxml2.git
+[submodule "thirdparty/foonathan_memory"]
+	path = thirdparty/foonathan_memory
+	url = https://github.com/foonathan/memory

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -212,6 +212,7 @@ include(${PROJECT_SOURCE_DIR}/cmake/common/eprosima_libraries.cmake)
 eprosima_find_package(fastcdr REQUIRED)
 eprosima_find_thirdparty(Asio asio)
 eprosima_find_thirdparty(TinyXML2 tinyxml2)
+eprosima_find_package(foonathan_memory REQUIRED)
 
 if(ANDROID)
     eprosima_find_thirdparty(android-ifaddrs android-ifaddrs)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -212,7 +212,7 @@ include(${PROJECT_SOURCE_DIR}/cmake/common/eprosima_libraries.cmake)
 eprosima_find_package(fastcdr REQUIRED)
 eprosima_find_thirdparty(Asio asio)
 eprosima_find_thirdparty(TinyXML2 tinyxml2)
-eprosima_find_package(foonathan_memory REQUIRED)
+find_package(foonathan_memory REQUIRED)
 
 if(ANDROID)
     eprosima_find_thirdparty(android-ifaddrs android-ifaddrs)

--- a/colcon.pkg
+++ b/colcon.pkg
@@ -1,0 +1,5 @@
+{
+    "name": "fastrtps",
+    "type": "cmake",
+    "build-dependencies" : ["fastcdr", "FOONATHAN_MEMORY"]
+}

--- a/examples/C++/Benchmark/CMakeLists.txt
+++ b/examples/C++/Benchmark/CMakeLists.txt
@@ -25,6 +25,10 @@ if(NOT fastcdr_FOUND)
     find_package(fastcdr REQUIRED)
 endif()
 
+if(NOT foonathan_memory_FOUND)
+    find_package(foonathan_memory REQUIRED)
+endif()
+
 if(NOT fastrtps_FOUND)
     find_package(fastrtps REQUIRED)
 endif()
@@ -50,7 +54,7 @@ file(GLOB BENCHMARK_SOURCES_CPP "*.cpp")
 # configure_file("BenchmarkPublisher.xml" "BenchmarkPublisher.xml" COPYONLY)
 
 add_executable(Benchmark ${BENCHMARK_SOURCES_CXX} ${BENCHMARK_SOURCES_CPP})
-target_link_libraries(Benchmark fastrtps fastcdr)
+target_link_libraries(Benchmark fastrtps fastcdr foonathan_memory)
 install(TARGETS Benchmark
     RUNTIME DESTINATION examples/C++/Benchmark/${BIN_INSTALL_DIR})
 

--- a/examples/C++/ClientServerTest/CMakeLists.txt
+++ b/examples/C++/ClientServerTest/CMakeLists.txt
@@ -25,6 +25,10 @@ if(NOT fastcdr_FOUND)
     find_package(fastcdr REQUIRED)
 endif()
 
+if(NOT foonathan_memory_FOUND)
+    find_package(foonathan_memory REQUIRED)
+endif()
+
 if(NOT fastrtps_FOUND)
 find_package(fastrtps REQUIRED)
 endif()
@@ -45,7 +49,7 @@ message(STATUS "Configuring ClientServerTest...")
 file(GLOB CLIENTSERVERTEST_SOURCES "*.cpp")
 
 add_executable(ClientServerTest ${CLIENTSERVERTEST_SOURCES})
-target_link_libraries(ClientServerTest fastrtps fastcdr)
+target_link_libraries(ClientServerTest fastrtps fastcdr foonathan_memory)
 install(TARGETS ClientServerTest
 	RUNTIME DESTINATION examples/C++/ClientServerTest/${BIN_INSTALL_DIR}
     )

--- a/examples/C++/Configurability/CMakeLists.txt
+++ b/examples/C++/Configurability/CMakeLists.txt
@@ -25,6 +25,10 @@ if(NOT fastcdr_FOUND)
     find_package(fastcdr REQUIRED)
 endif()
 
+if(NOT foonathan_memory_FOUND)
+    find_package(foonathan_memory REQUIRED)
+endif()
+
 if(NOT fastrtps_FOUND)
     find_package(fastrtps REQUIRED)
 endif()
@@ -45,13 +49,13 @@ message(STATUS "Configuring UseCaseDemonstrator example...")
 file(GLOB USECASEDEMONSTRATOR_EXAMPLE_SOURCES "*.cxx")
 
 add_executable(UseCasePublisher ${USECASEDEMONSTRATOR_EXAMPLE_SOURCES} UseCasePublisher.cpp)
-target_link_libraries(UseCasePublisher fastrtps fastcdr)
+target_link_libraries(UseCasePublisher fastrtps fastcdr foonathan_memory)
 install(TARGETS UseCasePublisher
     RUNTIME DESTINATION examples/C++/UseCaseDemonstrator/${BIN_INSTALL_DIR}
     )
 
 add_executable(UseCaseSubscriber ${USECASEDEMONSTRATOR_EXAMPLE_SOURCES} UseCaseSubscriber.cpp)
-target_link_libraries(UseCaseSubscriber fastrtps fastcdr)
+target_link_libraries(UseCaseSubscriber fastrtps fastcdr foonathan_memory)
 install(TARGETS UseCaseSubscriber
     RUNTIME DESTINATION examples/C++/UseCaseDemonstrator/${BIN_INSTALL_DIR}
     )

--- a/examples/C++/DeadlineQoSExample/CMakeLists.txt
+++ b/examples/C++/DeadlineQoSExample/CMakeLists.txt
@@ -25,6 +25,10 @@ if(NOT fastcdr_FOUND)
     find_package(fastcdr REQUIRED)
 endif()
 
+if(NOT foonathan_memory_FOUND)
+    find_package(foonathan_memory REQUIRED)
+endif()
+
 if(NOT fastrtps_FOUND)
     find_package(fastrtps REQUIRED)
 endif()
@@ -67,7 +71,7 @@ add_definitions(
 include_directories(${ASIO_INCLUDE_DIR})
 
 add_executable(DeadlineQoSExample ${DEADLINEQOS_EXAMPLE_SOURCES})
-target_link_libraries(DeadlineQoSExample fastrtps fastcdr)
+target_link_libraries(DeadlineQoSExample fastrtps fastcdr foonathan_memory)
 if(UNIX)
   target_link_libraries(DeadlineQoSExample pthread)
 endif()

--- a/examples/C++/DynamicHelloWorldExample/CMakeLists.txt
+++ b/examples/C++/DynamicHelloWorldExample/CMakeLists.txt
@@ -25,6 +25,10 @@ if(NOT fastcdr_FOUND)
     find_package(fastcdr REQUIRED)
 endif()
 
+if(NOT foonathan_memory_FOUND)
+    find_package(foonathan_memory REQUIRED)
+endif()
+
 if(NOT fastrtps_FOUND)
     find_package(fastrtps REQUIRED)
 endif()
@@ -46,6 +50,6 @@ file(GLOB HELLOWORLD_EXAMPLE_SOURCES_CXX "*.cxx")
 file(GLOB HELLOWORLD_EXAMPLE_SOURCES_CPP "*.cpp")
 
 add_executable(DynamicHelloWorldExample ${HELLOWORLD_EXAMPLE_SOURCES_CXX} ${HELLOWORLD_EXAMPLE_SOURCES_CPP})
-target_link_libraries(DynamicHelloWorldExample fastrtps fastcdr)
+target_link_libraries(DynamicHelloWorldExample fastrtps fastcdr foonathan_memory)
 install(TARGETS DynamicHelloWorldExample
     RUNTIME DESTINATION examples/C++/DynamicHelloWorldExample/${BIN_INSTALL_DIR})

--- a/examples/C++/Filtering/CMakeLists.txt
+++ b/examples/C++/Filtering/CMakeLists.txt
@@ -25,6 +25,10 @@ if(NOT fastcdr_FOUND)
     find_package(fastcdr REQUIRED)
 endif()
 
+if(NOT foonathan_memory_FOUND)
+    find_package(foonathan_memory REQUIRED)
+endif()
+
 if(NOT fastrtps_FOUND)
     find_package(fastrtps REQUIRED)
 endif()
@@ -45,7 +49,7 @@ message(STATUS "Configuring Filtering example...")
 file(GLOB DEADLINEQOS_EXAMPLE_SOURCES "*.cxx")
 
 add_executable(FilteringExample ${DEADLINEQOS_EXAMPLE_SOURCES})
-target_link_libraries(FilteringExample fastrtps fastcdr)
+target_link_libraries(FilteringExample fastrtps fastcdr foonathan_memory)
 install(TARGETS FilteringExample
     RUNTIME DESTINATION examples/C++/FilteringExample/${BIN_INSTALL_DIR}
     )

--- a/examples/C++/FlowControlExample/CMakeLists.txt
+++ b/examples/C++/FlowControlExample/CMakeLists.txt
@@ -25,6 +25,10 @@ if(NOT fastcdr_FOUND)
     find_package(fastcdr REQUIRED)
 endif()
 
+if(NOT foonathan_memory_FOUND)
+    find_package(foonathan_memory REQUIRED)
+endif()
+
 if(NOT fastrtps_FOUND)
     find_package(fastrtps REQUIRED)
 endif()
@@ -46,6 +50,6 @@ file(GLOB FLOWCONTROL_EXAMPLE_SOURCES_CXX "*.cxx")
 file(GLOB FLOWCONTROL_EXAMPLE_SOURCES_CPP "*.cpp")
 
 add_executable(FlowControlExample ${FLOWCONTROL_EXAMPLE_SOURCES_CXX} ${FLOWCONTROL_EXAMPLE_SOURCES_CPP})
-target_link_libraries(FlowControlExample fastrtps fastcdr)
+target_link_libraries(FlowControlExample fastrtps fastcdr foonathan_memory)
 install(TARGETS FlowControlExample
     RUNTIME DESTINATION examples/C++/FlowControlExample/${BIN_INSTALL_DIR})

--- a/examples/C++/HelloWorldExample/CMakeLists.txt
+++ b/examples/C++/HelloWorldExample/CMakeLists.txt
@@ -25,6 +25,10 @@ if(NOT fastcdr_FOUND)
     find_package(fastcdr REQUIRED)
 endif()
 
+if(NOT foonathan_memory_FOUND)
+    find_package(foonathan_memory REQUIRED)
+endif()
+
 if(NOT fastrtps_FOUND)
     find_package(fastrtps REQUIRED)
 endif()
@@ -46,6 +50,6 @@ file(GLOB HELLOWORLD_EXAMPLE_SOURCES_CXX "*.cxx")
 file(GLOB HELLOWORLD_EXAMPLE_SOURCES_CPP "*.cpp")
 
 add_executable(HelloWorldExample ${HELLOWORLD_EXAMPLE_SOURCES_CXX} ${HELLOWORLD_EXAMPLE_SOURCES_CPP})
-target_link_libraries(HelloWorldExample fastrtps fastcdr)
+target_link_libraries(HelloWorldExample fastrtps fastcdr foonathan_memory)
 install(TARGETS HelloWorldExample
     RUNTIME DESTINATION examples/C++/HelloWorldExample/${BIN_INSTALL_DIR})

--- a/examples/C++/HelloWorldExampleTCP/CMakeLists.txt
+++ b/examples/C++/HelloWorldExampleTCP/CMakeLists.txt
@@ -25,6 +25,10 @@ if(NOT fastcdr_FOUND)
     find_package(fastcdr REQUIRED)
 endif()
 
+if(NOT foonathan_memory_FOUND)
+    find_package(foonathan_memory REQUIRED)
+endif()
+
 if(NOT fastrtps_FOUND)
     find_package(fastrtps REQUIRED)
 endif()
@@ -54,6 +58,6 @@ configure_file("ca.pem" "ca.pem" COPYONLY)
 
 
 add_executable(HelloWorldExampleTCP ${HELLOWORLD_EXAMPLE_SOURCES_CXX} ${HELLOWORLD_EXAMPLE_SOURCES_CPP})
-target_link_libraries(HelloWorldExampleTCP fastrtps fastcdr)
+target_link_libraries(HelloWorldExampleTCP fastrtps fastcdr foonathan_memory)
 install(TARGETS HelloWorldExampleTCP
     RUNTIME DESTINATION examples/C++/HelloWorldExampleTCP/${BIN_INSTALL_DIR})

--- a/examples/C++/HistoryKind/CMakeLists.txt
+++ b/examples/C++/HistoryKind/CMakeLists.txt
@@ -25,6 +25,10 @@ if(NOT fastcdr_FOUND)
     find_package(fastcdr REQUIRED)
 endif()
 
+if(NOT foonathan_memory_FOUND)
+    find_package(foonathan_memory REQUIRED)
+endif()
+
 if(NOT fastrtps_FOUND)
     find_package(fastrtps REQUIRED)
 endif()
@@ -45,7 +49,7 @@ message(STATUS "Configuring UseCaseDemonstrator example...")
 file(GLOB USECASEDEMONSTRATOR_EXAMPLE_SOURCES "*.cxx")
 
 add_executable(historykind ${USECASEDEMONSTRATOR_EXAMPLE_SOURCES} pastsamples.cpp)
-target_link_libraries(historykind fastrtps fastcdr)
+target_link_libraries(historykind fastrtps fastcdr foonathan_memory)
 install(TARGETS historykind
     RUNTIME DESTINATION examples/C++/UseCaseDemonstrator/${BIN_INSTALL_DIR}
     )

--- a/examples/C++/Keys/CMakeLists.txt
+++ b/examples/C++/Keys/CMakeLists.txt
@@ -25,6 +25,10 @@ if(NOT fastcdr_FOUND)
     find_package(fastcdr REQUIRED)
 endif()
 
+if(NOT foonathan_memory_FOUND)
+    find_package(foonathan_memory REQUIRED)
+endif()
+
 if(NOT fastrtps_FOUND)
     find_package(fastrtps REQUIRED)
 endif()
@@ -45,7 +49,7 @@ message(STATUS "Configuring UseCaseDemonstrator example...")
 file(GLOB USECASEDEMONSTRATOR_EXAMPLE_SOURCES "*.cxx")
 
 add_executable(keys ${USECASEDEMONSTRATOR_EXAMPLE_SOURCES} keys.cpp)
-target_link_libraries(keys fastrtps fastcdr)
+target_link_libraries(keys fastrtps fastcdr foonathan_memory)
 install(TARGETS keys
     RUNTIME DESTINATION examples/C++/UseCaseDemonstrator/${BIN_INSTALL_DIR}
     )

--- a/examples/C++/LateJoiners/CMakeLists.txt
+++ b/examples/C++/LateJoiners/CMakeLists.txt
@@ -25,6 +25,10 @@ if(NOT fastcdr_FOUND)
     find_package(fastcdr REQUIRED)
 endif()
 
+if(NOT foonathan_memory_FOUND)
+    find_package(foonathan_memory REQUIRED)
+endif()
+
 if(NOT fastrtps_FOUND)
     find_package(fastrtps REQUIRED)
 endif()
@@ -45,7 +49,7 @@ message(STATUS "Configuring UseCaseDemonstrator example...")
 file(GLOB USECASEDEMONSTRATOR_EXAMPLE_SOURCES "*.cxx")
 
 add_executable(latejoiners ${USECASEDEMONSTRATOR_EXAMPLE_SOURCES} latejoiners.cpp)
-target_link_libraries(latejoiners fastrtps fastcdr)
+target_link_libraries(latejoiners fastrtps fastcdr foonathan_memory)
 install(TARGETS latejoiners
     RUNTIME DESTINATION examples/C++/UseCaseDemonstrator/${BIN_INSTALL_DIR}
     )

--- a/examples/C++/OwnershipStrengthQoSExample/CMakeLists.txt
+++ b/examples/C++/OwnershipStrengthQoSExample/CMakeLists.txt
@@ -25,6 +25,10 @@ if(NOT fastcdr_FOUND)
     find_package(fastcdr REQUIRED)
 endif()
 
+if(NOT foonathan_memory_FOUND)
+    find_package(foonathan_memory REQUIRED)
+endif()
+
 if(NOT fastrtps_FOUND)
     find_package(fastrtps REQUIRED)
 endif()
@@ -45,7 +49,7 @@ message(STATUS "Configuring OwnershipStrengthQoS example...")
 file(GLOB OWNERSHIPSTRENGTH_EXAMPLE_SOURCES "*.cxx")
 
 add_executable(OwnershipStrengthQoSExample ${OWNERSHIPSTRENGTH_EXAMPLE_SOURCES})
-target_link_libraries(OwnershipStrengthQoSExample fastrtps fastcdr)
+target_link_libraries(OwnershipStrengthQoSExample fastrtps fastcdr foonathan_memory)
 install(TARGETS OwnershipStrengthQoSExample
     RUNTIME DESTINATION examples/C++/OwnershipStrengthQoSExample/${BIN_INSTALL_DIR}
     )

--- a/examples/C++/RTPSTest_as_socket/CMakeLists.txt
+++ b/examples/C++/RTPSTest_as_socket/CMakeLists.txt
@@ -25,6 +25,10 @@ if(NOT fastcdr_FOUND)
     find_package(fastcdr REQUIRED)
 endif()
 
+if(NOT foonathan_memory_FOUND)
+    find_package(foonathan_memory REQUIRED)
+endif()
+
 if(NOT fastrtps_FOUND)
     find_package(fastrtps REQUIRED)
 endif()
@@ -45,7 +49,7 @@ message(STATUS "Configuring RTPSTest_as_socket...")
 file(GLOB RTPSTESTASSOCKET_SOURCES "*.cpp")
 
 add_executable(RTPSTest_as_socket ${RTPSTESTASSOCKET_SOURCES})
-target_link_libraries(RTPSTest_as_socket fastrtps fastcdr)
+target_link_libraries(RTPSTest_as_socket fastrtps fastcdr foonathan_memory)
 install(TARGETS RTPSTest_as_socket
     RUNTIME DESTINATION examples/C++/RTPSTest_as_socket/${BIN_INSTALL_DIR}
     )

--- a/examples/C++/RTPSTest_persistent/CMakeLists.txt
+++ b/examples/C++/RTPSTest_persistent/CMakeLists.txt
@@ -25,6 +25,10 @@ if(NOT fastcdr_FOUND)
     find_package(fastcdr REQUIRED)
 endif()
 
+if(NOT foonathan_memory_FOUND)
+    find_package(foonathan_memory REQUIRED)
+endif()
+
 if(NOT fastrtps_FOUND)
     find_package(fastrtps REQUIRED)
 endif()
@@ -45,7 +49,7 @@ message(STATUS "Configuring RTPSTest_persistent...")
 file(GLOB RTPSTESTPERSISTENT_SOURCES "*.cpp")
 
 add_executable(RTPSTest_persistent ${RTPSTESTPERSISTENT_SOURCES})
-target_link_libraries(RTPSTest_persistent fastrtps fastcdr)
+target_link_libraries(RTPSTest_persistent fastrtps fastcdr foonathan_memory)
 install(TARGETS RTPSTest_persistent
     RUNTIME DESTINATION examples/C++/RTPSTest_persistent/${BIN_INSTALL_DIR}
     )

--- a/examples/C++/RTPSTest_registered/CMakeLists.txt
+++ b/examples/C++/RTPSTest_registered/CMakeLists.txt
@@ -25,6 +25,10 @@ if(NOT fastcdr_FOUND)
     find_package(fastcdr REQUIRED)
 endif()
 
+if(NOT foonathan_memory_FOUND)
+    find_package(foonathan_memory REQUIRED)
+endif()
+
 if(NOT fastrtps_FOUND)
     find_package(fastrtps REQUIRED)
 endif()
@@ -45,7 +49,7 @@ message(STATUS "Configuring RTPSTest_registered...")
 file(GLOB RTPSTESTREGISTERED_SOURCES "*.cpp")
 
 add_executable(RTPSTest_registered ${RTPSTESTREGISTERED_SOURCES})
-target_link_libraries(RTPSTest_registered fastrtps fastcdr)
+target_link_libraries(RTPSTest_registered fastrtps fastcdr foonathan_memory)
 install(TARGETS RTPSTest_registered
     RUNTIME DESTINATION examples/C++/RTPSTest_registered/${BIN_INSTALL_DIR}
     )

--- a/examples/C++/SampleConfig_Controller/CMakeLists.txt
+++ b/examples/C++/SampleConfig_Controller/CMakeLists.txt
@@ -25,6 +25,10 @@ if(NOT fastcdr_FOUND)
     find_package(fastcdr REQUIRED)
 endif()
 
+if(NOT foonathan_memory_FOUND)
+    find_package(foonathan_memory REQUIRED)
+endif()
+
 if(NOT fastrtps_FOUND)
     find_package(fastrtps REQUIRED)
 endif()
@@ -45,7 +49,7 @@ message(STATUS "Configuring UseCaseDemonstrator example...")
 file(GLOB USECASEDEMONSTRATOR_EXAMPLE_SOURCES "*.cxx")
 
 add_executable(sampleconfig_controller ${USECASEDEMONSTRATOR_EXAMPLE_SOURCES} sampleconfig_safest.cpp)
-target_link_libraries(sampleconfig_controller fastrtps fastcdr)
+target_link_libraries(sampleconfig_controller fastrtps fastcdr foonathan_memory)
 install(TARGETS sampleconfig_controller
     RUNTIME DESTINATION examples/C++/UseCaseDemonstrator/${BIN_INSTALL_DIR}
     )

--- a/examples/C++/SampleConfig_Events/CMakeLists.txt
+++ b/examples/C++/SampleConfig_Events/CMakeLists.txt
@@ -25,6 +25,10 @@ if(NOT fastcdr_FOUND)
     find_package(fastcdr REQUIRED)
 endif()
 
+if(NOT foonathan_memory_FOUND)
+    find_package(foonathan_memory REQUIRED)
+endif()
+
 if(NOT fastrtps_FOUND)
     find_package(fastrtps REQUIRED)
 endif()
@@ -45,7 +49,7 @@ message(STATUS "Configuring UseCaseDemonstrator example...")
 file(GLOB USECASEDEMONSTRATOR_EXAMPLE_SOURCES "*.cxx")
 
 add_executable(sampleconfig_events ${USECASEDEMONSTRATOR_EXAMPLE_SOURCES} sampleconfig_triggers.cpp)
-target_link_libraries(sampleconfig_events fastrtps fastcdr)
+target_link_libraries(sampleconfig_events fastrtps fastcdr foonathan_memory)
 install(TARGETS sampleconfig_events
     RUNTIME DESTINATION examples/C++/UseCaseDemonstrator/${BIN_INSTALL_DIR}
     )

--- a/examples/C++/SampleConfig_Multimedia/CMakeLists.txt
+++ b/examples/C++/SampleConfig_Multimedia/CMakeLists.txt
@@ -25,6 +25,10 @@ if(NOT fastcdr_FOUND)
     find_package(fastcdr REQUIRED)
 endif()
 
+if(NOT foonathan_memory_FOUND)
+    find_package(foonathan_memory REQUIRED)
+endif()
+
 if(NOT fastrtps_FOUND)
     find_package(fastrtps REQUIRED)
 endif()
@@ -45,7 +49,7 @@ message(STATUS "Configuring UseCaseDemonstrator example...")
 file(GLOB USECASEDEMONSTRATOR_EXAMPLE_SOURCES "*.cxx")
 
 add_executable(sampleconfig_multimedia ${USECASEDEMONSTRATOR_EXAMPLE_SOURCES} sampleconfig_fastest.cpp)
-target_link_libraries(sampleconfig_multimedia fastrtps fastcdr)
+target_link_libraries(sampleconfig_multimedia fastrtps fastcdr foonathan_memory)
 install(TARGETS sampleconfig_multimedia
     RUNTIME DESTINATION examples/C++/UseCaseDemonstrator/${BIN_INSTALL_DIR}
     )

--- a/examples/C++/SecureHelloWorldExample/CMakeLists.txt
+++ b/examples/C++/SecureHelloWorldExample/CMakeLists.txt
@@ -25,6 +25,10 @@ if(NOT fastcdr_FOUND)
     find_package(fastcdr REQUIRED)
 endif()
 
+if(NOT foonathan_memory_FOUND)
+    find_package(foonathan_memory REQUIRED)
+endif()
+
 if(NOT fastrtps_FOUND)
     find_package(fastrtps REQUIRED)
 endif()
@@ -47,7 +51,7 @@ file(GLOB HELLOWORLD_EXAMPLE_SOURCES_CPP "*.cpp")
 
 add_executable(SecureHelloWorldExample ${HELLOWORLD_EXAMPLE_SOURCES_CXX} ${HELLOWORLD_EXAMPLE_SOURCES_CPP})
 target_include_directories(SecureHelloWorldExample PRIVATE)
-target_link_libraries(SecureHelloWorldExample fastrtps fastcdr)
+target_link_libraries(SecureHelloWorldExample fastrtps fastcdr foonathan_memory)
 install(TARGETS SecureHelloWorldExample
     RUNTIME DESTINATION examples/C++/SecureHelloWorldExample/${BIN_INSTALL_DIR})
 

--- a/examples/C++/SecureHelloWorldExample/HelloWorld_main.cpp
+++ b/examples/C++/SecureHelloWorldExample/HelloWorld_main.cpp
@@ -25,8 +25,6 @@
 #include <fastrtps/utils/eClock.h>
 #include <fastrtps/log/Log.h>
 
-#include <fastrtps/rtps/rtps_all.h>
-
 using namespace eprosima;
 using namespace fastrtps;
 using namespace rtps;

--- a/examples/C++/StaticHelloWorldExample/CMakeLists.txt
+++ b/examples/C++/StaticHelloWorldExample/CMakeLists.txt
@@ -25,6 +25,10 @@ if(NOT fastcdr_FOUND)
     find_package(fastcdr REQUIRED)
 endif()
 
+if(NOT foonathan_memory_FOUND)
+    find_package(foonathan_memory REQUIRED)
+endif()
+
 if(NOT fastrtps_FOUND)
     find_package(fastrtps REQUIRED)
 endif()
@@ -51,6 +55,6 @@ file(COPY ${CMAKE_CURRENT_SOURCE_DIR}/HelloWorldPublisher.xml
     )
 
 add_executable(StaticHelloWorldExample ${HELLOWORLD_EXAMPLE_SOURCES_CXX} ${HELLOWORLD_EXAMPLE_SOURCES_CPP})
-target_link_libraries(StaticHelloWorldExample fastrtps fastcdr)
+target_link_libraries(StaticHelloWorldExample fastrtps fastcdr foonathan_memory)
 install(TARGETS StaticHelloWorldExample
     RUNTIME DESTINATION examples/C++/HelloWorldExample/${BIN_INSTALL_DIR})

--- a/examples/C++/UserDefinedTransportExample/CMakeLists.txt
+++ b/examples/C++/UserDefinedTransportExample/CMakeLists.txt
@@ -25,6 +25,10 @@ if(NOT fastcdr_FOUND)
     find_package(fastcdr REQUIRED)
 endif()
 
+if(NOT foonathan_memory_FOUND)
+    find_package(foonathan_memory REQUIRED)
+endif()
+
 if(NOT fastrtps_FOUND)
     find_package(fastrtps REQUIRED)
 endif()
@@ -47,6 +51,6 @@ file(GLOB USERDEFINEDTRANSPORTEXAMPLE_SOURCES_HXX "*.cpp")
 include_directories(${PROJECT_SOURCE_DIR}/../../../thirdparty/asio/asio/include)
 
 add_executable(UserDefinedTransportExample ${USERDEFINEDTRANSPORTEXAMPLE_SOURCES_HXX})
-target_link_libraries(UserDefinedTransportExample fastrtps fastcdr)
+target_link_libraries(UserDefinedTransportExample fastrtps fastcdr foonathan_memory)
 install(TARGETS UserDefinedTransportExample
     RUNTIME DESTINATION examples/C++/UserDefinedTransportExample/${BIN_INSTALL_DIR})

--- a/examples/C++/XMLProfiles/CMakeLists.txt
+++ b/examples/C++/XMLProfiles/CMakeLists.txt
@@ -25,6 +25,10 @@ if(NOT fastcdr_FOUND)
     find_package(fastcdr REQUIRED)
 endif()
 
+if(NOT foonathan_memory_FOUND)
+    find_package(foonathan_memory REQUIRED)
+endif()
+
 if(NOT fastrtps_FOUND)
     find_package(fastrtps REQUIRED)
 endif()
@@ -49,6 +53,6 @@ file(COPY ${PROJECT_SOURCE_DIR}/XMLProfilesExample.xml
     )
 
 add_executable(XMLProfiles ${XMLPROFILESEXAMPLE_SOURCES_CXX} ${XMLPROFILESEXAMPLE_SOURCES_CPP})
-target_link_libraries(XMLProfiles fastrtps fastcdr)
+target_link_libraries(XMLProfiles fastrtps fastcdr foonathan_memory)
 install(TARGETS XMLProfiles
     RUNTIME DESTINATION examples/C++/XMLProfilesExample/${BIN_INSTALL_DIR})

--- a/include/fastrtps/attributes/SubscriberAttributes.h
+++ b/include/fastrtps/attributes/SubscriberAttributes.h
@@ -78,6 +78,7 @@ public:
     //!Underlying History memory policy
     rtps::MemoryManagementPolicy_t historyMemoryPolicy;
     rtps::PropertyPolicy properties;
+    ResourceLimitedContainerConfig matched_publisher_allocation;
 
     /**
      * Get the user defined ID

--- a/include/fastrtps/rtps/attributes/ReaderAttributes.h
+++ b/include/fastrtps/rtps/attributes/ReaderAttributes.h
@@ -23,6 +23,8 @@
 #include "../common/Time_t.h"
 #include "../common/Guid.h"
 #include "EndpointAttributes.h"
+#include "../../utils/collections/ResourceLimitedContainerConfig.hpp"
+
 namespace eprosima{
 namespace fastrtps{
 namespace rtps{
@@ -80,6 +82,9 @@ class  ReaderAttributes
 
         //!Indicates if the reader expects Inline qos, default value 0.
         bool expectsInlineQos;
+
+        //! Define the allocation behaviour for matched-writer-dependent collections.
+        ResourceLimitedContainerConfig matched_writers_allocation;
 };
 
 /**

--- a/include/fastrtps/rtps/attributes/ReaderAttributes.h
+++ b/include/fastrtps/rtps/attributes/ReaderAttributes.h
@@ -17,18 +17,19 @@
  *
  */
 
-#ifndef READERATTRIBUTES_H_
-#define READERATTRIBUTES_H_
+#ifndef FASTRTPS_RTPS_ATTRIBUTES_READERATTRIBUTES_H_
+#define FASTRTPS_RTPS_ATTRIBUTES_READERATTRIBUTES_H_
 
 #include "../common/Time_t.h"
 #include "../common/Guid.h"
 #include "EndpointAttributes.h"
 #include "../../utils/collections/ResourceLimitedContainerConfig.hpp"
 
-namespace eprosima{
-namespace fastrtps{
-namespace rtps{
+#include <functional>
 
+namespace eprosima {
+namespace fastrtps {
+namespace rtps {
 
 /**
  * Class ReaderTimes, defining the times associated with the Reliable Readers events.
@@ -61,11 +62,12 @@ public:
  * Class ReaderAttributes, to define the attributes of a RTPSReader.
  * @ingroup RTPS_ATTRIBUTES_MODULE
  */
-class  ReaderAttributes
+class ReaderAttributes
 {
     public:
 
-        ReaderAttributes() : expectsInlineQos(false)
+        ReaderAttributes() 
+            : expectsInlineQos(false)
         {
             endpoint.endpointKind = READER;
             endpoint.durabilityKind = VOLATILE;
@@ -94,21 +96,32 @@ class  ReaderAttributes
 class  RemoteWriterAttributes
 {
     public:
-        RemoteWriterAttributes() : livelinessLeaseDuration(c_TimeInfinite), ownershipStrength(0),
-        is_eprosima_endpoint(true)
+        RemoteWriterAttributes() 
+            : livelinessLeaseDuration(c_TimeInfinite)
+            , ownershipStrength(0)
+            , is_eprosima_endpoint(true)
         {
             endpoint.endpointKind = WRITER;
         }
 
-        RemoteWriterAttributes(const VendorId_t& vendor_id) : livelinessLeaseDuration(c_TimeInfinite), ownershipStrength(0),
-        is_eprosima_endpoint(vendor_id == c_VendorId_eProsima)
+        RemoteWriterAttributes(const VendorId_t& vendor_id) 
+            : livelinessLeaseDuration(c_TimeInfinite)
+            , ownershipStrength(0)
+            , is_eprosima_endpoint(vendor_id == c_VendorId_eProsima)
         {
             endpoint.endpointKind = WRITER;
         }
 
         virtual ~RemoteWriterAttributes()
         {
+        }
 
+        std::function<bool(const RemoteWriterAttributes&)> compare_guid_function() const
+        {
+            return [this](const RemoteWriterAttributes& rhs)
+            {
+                return this->guid == rhs.guid;
+            };
         }
 
         //!Attributes of the associated endpoint.
@@ -125,9 +138,9 @@ class  RemoteWriterAttributes
 
         bool is_eprosima_endpoint;
 };
-}
-}
-}
 
+} /* namespace rtps */
+} /* namespace fastrtps */
+} /* namespace eprosima */
 
-#endif /* WRITERATTRIBUTES_H_ */
+#endif /* FASTRTPS_RTPS_ATTRIBUTES_READERATTRIBUTES_H_ */

--- a/include/fastrtps/rtps/common/CacheChange.h
+++ b/include/fastrtps/rtps/common/CacheChange.h
@@ -444,6 +444,11 @@ namespace eprosima
                     is_relevant_ = false;
                 }
 
+                bool operator < (const ChangeFromWriter_t& rhs) const
+                {
+                    return seq_num_ < rhs.seq_num_;
+                }
+
                 private:
 
                 //! Status
@@ -454,14 +459,6 @@ namespace eprosima
 
                 //! Sequence number
                 SequenceNumber_t seq_num_;
-            };
-
-            struct ChangeFromWriterCmp
-            {
-                bool operator()(const ChangeFromWriter_t& a, const ChangeFromWriter_t& b) const
-                {
-                    return a.seq_num_ < b.seq_num_;
-                }
             };
 #endif
         }

--- a/include/fastrtps/rtps/messages/RTPSMessageCreator.h
+++ b/include/fastrtps/rtps/messages/RTPSMessageCreator.h
@@ -141,9 +141,9 @@ class RTPSMessageCreator
                 SequenceNumber_t& firstSN, FragmentNumber_t& lastFN, Count_t count);
 
         static bool addMessageAcknack(CDRMessage_t* msg,const GuidPrefix_t& guidprefix, const GuidPrefix_t& remoteGuidPrefix,
-                const EntityId_t& readerId,const EntityId_t& writerId,SequenceNumberSet_t& SNSet,int32_t count,bool finalFlag);
+                const EntityId_t& readerId,const EntityId_t& writerId,const SequenceNumberSet_t& SNSet,int32_t count,bool finalFlag);
         static bool addSubmessageAcknack(CDRMessage_t* msg,
-                const EntityId_t& readerId,const EntityId_t& writerId,SequenceNumberSet_t& SNSet,int32_t count,bool finalFlag);
+                const EntityId_t& readerId,const EntityId_t& writerId,const SequenceNumberSet_t& SNSet,int32_t count,bool finalFlag);
 
         static bool addMessageNackFrag(CDRMessage_t* msg, const GuidPrefix_t& guidprefix, const GuidPrefix_t& remoteGuidPrefix,
                 const EntityId_t& readerId, const EntityId_t& writerId, SequenceNumber_t& writerSN, FragmentNumberSet_t fnState, int32_t count);

--- a/include/fastrtps/rtps/messages/RTPSMessageGroup.h
+++ b/include/fastrtps/rtps/messages/RTPSMessageGroup.h
@@ -164,7 +164,7 @@ class RTPSMessageGroup
          * @param locators List of destination locators.
          * @return True when message was added to the group.
          */
-        bool add_acknack(const std::vector<GUID_t>& remote_writers, SequenceNumberSet_t& SNSet,
+        bool add_acknack(const std::vector<GUID_t>& remote_writers, const SequenceNumberSet_t& SNSet,
                 int32_t count, bool finalFlag, const LocatorList_t& locators);
 
         /**

--- a/include/fastrtps/rtps/reader/RTPSReader.h
+++ b/include/fastrtps/rtps/reader/RTPSReader.h
@@ -18,8 +18,8 @@
 
 
 
-#ifndef RTPSREADER_H_
-#define RTPSREADER_H_
+#ifndef FASTRTPS_RTPS_READER_RTPSREADER_H_
+#define FASTRTPS_RTPS_READER_RTPSREADER_H_
 
 
 #include "../Endpoint.h"
@@ -28,240 +28,276 @@
 
 #include <map>
 
-namespace eprosima
+namespace eprosima {
+namespace fastrtps {
+namespace rtps {
+
+// Forward declarations
+class ReaderListener;
+class ReaderHistory;
+struct CacheChange_t;
+class WriterProxy;
+class FragmentedChangePitStop;
+
+/**
+ * Class RTPSReader, manages the reception of data from its matched writers.
+ * @ingroup READER_MODULE
+ */
+class RTPSReader : public Endpoint
 {
-    namespace fastrtps
+    friend class ReaderHistory;
+    friend class RTPSParticipantImpl;
+    friend class MessageReceiver;
+    friend class EDP;
+
+protected:
+    RTPSReader(
+            RTPSParticipantImpl*, 
+            const GUID_t& guid,
+            const ReaderAttributes& att,
+            ReaderHistory* hist, 
+            ReaderListener* listen = nullptr);
+
+    virtual ~RTPSReader();
+
+public:
+
+    /**
+     * Add a matched writer represented by its attributes.
+     * @param wdata Attributes of the writer to add.
+     * @return True if correctly added.
+     */
+    RTPS_DllAPI virtual bool matched_writer_add(const RemoteWriterAttributes& wdata) = 0;
+
+    /**
+     * Remove a writer represented by its attributes from the matched writers.
+     * @param wdata Attributes of the writer to remove.
+     * @return True if correctly removed.
+     */
+    RTPS_DllAPI virtual bool matched_writer_remove(const RemoteWriterAttributes& wdata) = 0;
+
+    /**
+     * Tells us if a specific Writer is matched against this reader
+     * @param wdata Pointer to the WriterProxyData object
+     * @return True if it is matched.
+     */
+    RTPS_DllAPI virtual bool matched_writer_is_matched(const RemoteWriterAttributes& wdata) const = 0;
+
+    /**
+     * Returns true if the reader accepts a message directed to entityId.
+     */
+    RTPS_DllAPI bool acceptMsgDirectedTo(const EntityId_t& entityId) const;
+
+    /**
+     * Processes a new DATA message. Previously the message must have been accepted by function acceptMsgDirectedTo.
+     *
+     * @param change Pointer to the CacheChange_t.
+     * @return true if the reader accepts messages from the.
+     */
+    RTPS_DllAPI virtual bool processDataMsg(CacheChange_t* change) = 0;
+
+    /**
+     * Processes a new DATA FRAG message. Previously the message must have been accepted by function acceptMsgDirectedTo.
+     *
+     * @param change Pointer to the CacheChange_t.
+     * @param sampleSize Size of the complete, assembled message.
+     * @param fragmentStartingNum Starting number of this particular fragment.
+     * @return true if the reader accepts message.
+     */
+    RTPS_DllAPI virtual bool processDataFragMsg(
+            CacheChange_t* change, 
+            uint32_t sampleSize, 
+            uint32_t fragmentStartingNum) = 0;
+
+    /**
+     * Processes a new HEARTBEAT message. Previously the message must have been accepted by function acceptMsgDirectedTo.
+     *
+     * @return true if the reader accepts messages from the.
+     */
+    RTPS_DllAPI virtual bool processHeartbeatMsg(
+            const GUID_t& writerGUID, 
+            uint32_t hbCount, 
+            const SequenceNumber_t& firstSN,
+            const SequenceNumber_t& lastSN, 
+            bool finalFlag, 
+            bool livelinessFlag) = 0;
+
+    RTPS_DllAPI virtual bool processGapMsg(
+            const GUID_t& writerGUID, 
+            const SequenceNumber_t& gapStart, 
+            const SequenceNumberSet_t& gapList) = 0;
+
+    /**
+     * Method to indicate the reader that some change has been removed due to HistoryQos requirements.
+     * @param change Pointer to the CacheChange_t.
+     * @param prox Pointer to the WriterProxy.
+     * @return True if correctly removed.
+     */
+    RTPS_DllAPI virtual bool change_removed_by_history(
+            CacheChange_t* change, 
+            WriterProxy* prox = nullptr) = 0;
+
+    /**
+     * Get the associated listener, secondary attached Listener in case it is of coumpound type
+     * @return Pointer to the associated reader listener.
+     */
+    RTPS_DllAPI ReaderListener* getListener() const;
+
+    /**
+     * Switch the ReaderListener kind for the Reader.
+     * If the RTPSReader does not belong to the built-in protocols it switches out the old one.
+     * If it belongs to the built-in protocols, it sets the new ReaderListener callbacks to be called after the
+     * built-in ReaderListener ones.
+     * @param target Pointed to ReaderLister to attach
+     * @return True is correctly set.
+     */
+    RTPS_DllAPI bool setListener(ReaderListener* target);
+
+    /**
+     * Reserve a CacheChange_t.
+     * @param change Pointer to pointer to the Cache.
+     * @return True if correctly reserved.
+     */
+    RTPS_DllAPI bool reserveCache(
+            CacheChange_t** change, 
+            uint32_t dataCdrSerializedSize);
+
+    /**
+     * Release a cacheChange.
+     */
+    RTPS_DllAPI void releaseCache(CacheChange_t* change);
+
+    /**
+     * Read the next unread CacheChange_t from the history
+     * @param change POinter to pointer of CacheChange_t
+     * @param wp Pointer to pointer to the WriterProxy
+     * @return True if read.
+     */
+    RTPS_DllAPI virtual bool nextUnreadCache(
+            CacheChange_t** change, 
+            WriterProxy** wp) = 0;
+
+    /**
+     * Get the next CacheChange_t from the history to take.
+     * @param change Pointer to pointer of CacheChange_t.
+     * @param wp Pointer to pointer to the WriterProxy.
+     * @return True if read.
+     */
+    RTPS_DllAPI virtual bool nextUntakenCache(
+            CacheChange_t** change, 
+            WriterProxy** wp) = 0;
+
+    /**
+     * @return True if the reader expects Inline QOS.
+     */
+    RTPS_DllAPI inline bool expectsInlineQos()
     {
-        namespace rtps
-        {
+        return m_expectsInlineQos;
+    }
+    
+    //! Returns a pointer to the associated History.
+    RTPS_DllAPI inline ReaderHistory* getHistory()
+    {
+        return mp_history;
+    };
 
-            // Forward declarations
-            class ReaderListener;
-            class ReaderHistory;
-            struct CacheChange_t;
-            class WriterProxy;
-            class FragmentedChangePitStop;
+    /*!
+     * @brief Search if there is a CacheChange_t, giving SequenceNumber_t and writer GUID_t,
+     * waiting to be completed because it is fragmented.
+     * @param sequence_number SequenceNumber_t of the searched CacheChange_t.
+     * @param writer_guid writer GUID_t of the searched CacheChange_t.
+     * @return If a CacheChange_t was found, it will be returned. In other case nullptr is returned.
+     */
+    CacheChange_t* findCacheInFragmentedCachePitStop(
+            const SequenceNumber_t& sequence_number,
+            const GUID_t& writer_guid) const;
 
-            /**
-             * Class RTPSReader, manages the reception of data from its matched writers.
-             * @ingroup READER_MODULE
-             */
-            class RTPSReader : public Endpoint
-            {
-                friend class ReaderHistory;
-                friend class RTPSParticipantImpl;
-                friend class MessageReceiver;
-                friend class EDP;
-                protected:
-                RTPSReader(RTPSParticipantImpl*,GUID_t& guid,
-                        ReaderAttributes& att,ReaderHistory* hist,ReaderListener* listen=nullptr);
-                virtual ~RTPSReader();
-                public:
-                /**
-                 * Add a matched writer represented by its attributes.
-                 * @param wdata Attributes of the writer to add.
-                 * @return True if correctly added.
-                 */
-                RTPS_DllAPI virtual bool matched_writer_add(RemoteWriterAttributes& wdata) = 0;
+    /*!
+     * @brief Returns there is a clean state with all Writers.
+     * It occurs when the Reader received all samples sent by Writers. In other words,
+     * its WriterProxies are up to date.
+     * @return There is a clean state with all Writers.
+     */
+    virtual bool isInCleanState() const = 0;
 
-                /**
-                 * Remove a writer represented by its attributes from the matched writers.
-                 * @param wdata Attributes of the writer to remove.
-                 * @return True if correctly removed.
-                 */
-                RTPS_DllAPI virtual bool matched_writer_remove(const RemoteWriterAttributes& wdata) = 0;
+protected:
+    void setTrustedWriter(const EntityId_t& writer)
+    {
+        m_acceptMessagesFromUnkownWriters = false;
+        m_trustedWriterEntityId = writer;
+    }
 
-                /**
-                 * Tells us if a specific Writer is matched against this reader
-                 * @param wdata Pointer to the WriterProxyData object
-                 * @return True if it is matched.
-                 */
-                RTPS_DllAPI virtual bool matched_writer_is_matched(const RemoteWriterAttributes& wdata) = 0;
+    /*!
+     * @brief Add a remote writer to the persistence_guid map
+     * @param wdata Info of the remote writer
+     */
+    void add_persistence_guid(const RemoteWriterAttributes& wdata);
 
-                /**
-                 * Returns true if the reader accepts a message directed to entityId.
-                 */
-                RTPS_DllAPI bool acceptMsgDirectedTo(EntityId_t& entityId);
+    /*!
+    * @brief Remove a remote writer from the persistence_guid map
+    * @param wdata Info of the remote writer
+    */
+    void remove_persistence_guid(const RemoteWriterAttributes& wdata);
 
-                /**
-                 * Processes a new DATA message. Previously the message must have been accepted by function acceptMsgDirectedTo.
-                 *
-                 * @param change Pointer to the CacheChange_t.
-                 * @return true if the reader accepts messages from the.
-                 */
-                RTPS_DllAPI virtual bool processDataMsg(CacheChange_t *change) = 0;
+    /*!
+    * @brief Get the last notified sequence for a RTPS guid
+    * @param guid The RTPS guid to query
+    * @return Last notified sequence number for input guid
+    * @remarks Takes persistence_guid into consideration
+    */
+    SequenceNumber_t get_last_notified(const GUID_t& guid) const;
 
-                /**
-                 * Processes a new DATA FRAG message. Previously the message must have been accepted by function acceptMsgDirectedTo.
-                 *
-                 * @param change Pointer to the CacheChange_t.
-                 * @param sampleSize Size of the complete, assembled message.
-                 * @param fragmentStartingNum Starting number of this particular fragment.
-                 * @return true if the reader accepts message.
-                 */
-                RTPS_DllAPI virtual bool processDataFragMsg(CacheChange_t *change, uint32_t sampleSize, uint32_t fragmentStartingNum) = 0;
+    /*!
+    * @brief Update the last notified sequence for a RTPS guid
+    * @param guid The RTPS guid of the writer
+    * @param seq Max sequence number available on writer
+    * @return Previous value of last notified sequence number for input guid
+    * @remarks Takes persistence_guid into consideration
+    */
+    SequenceNumber_t update_last_notified(
+            const GUID_t& guid, 
+            const SequenceNumber_t& seq);
 
-                /**
-                 * Processes a new HEARTBEAT message. Previously the message must have been accepted by function acceptMsgDirectedTo.
-                 *
-                 * @return true if the reader accepts messages from the.
-                 */
-                RTPS_DllAPI virtual bool processHeartbeatMsg(GUID_t &writerGUID, uint32_t hbCount, SequenceNumber_t &firstSN,
-                        SequenceNumber_t &lastSN, bool finalFlag, bool livelinessFlag) = 0;
+    /*!
+    * @brief Set the last notified sequence for a persistence guid
+    * @param guid The persistence guid to update
+    * @param seq Sequence number to set for input guid
+    * @remarks Persistent readers will write to DB
+    */
+    virtual void set_last_notified(
+            const GUID_t& peristence_guid, 
+            const SequenceNumber_t& seq);
 
-                RTPS_DllAPI virtual bool processGapMsg(GUID_t &writerGUID, SequenceNumber_t &gapStart, SequenceNumberSet_t &gapList) = 0;
+    //!ReaderHistory
+    ReaderHistory* mp_history;
+    //!Listener
+    ReaderListener* mp_listener;
+    //!Accept msg to unknwon readers (default=true)
+    bool m_acceptMessagesToUnknownReaders;
+    //!Accept msg from unknwon writers (BE-true,RE-false)
+    bool m_acceptMessagesFromUnkownWriters;
+    //!Trusted writer (for Builtin)
+    EntityId_t m_trustedWriterEntityId;
+    //!Expects Inline Qos.
+    bool m_expectsInlineQos;
 
-                /**
-                 * Method to indicate the reader that some change has been removed due to HistoryQos requirements.
-                 * @param change Pointer to the CacheChange_t.
-                 * @param prox Pointer to the WriterProxy.
-                 * @return True if correctly removed.
-                 */
-                RTPS_DllAPI virtual bool change_removed_by_history(CacheChange_t* change, WriterProxy* prox = nullptr) = 0;
+    //!Physical GUID to persistence GUID map
+    std::map<GUID_t, GUID_t> persistence_guid_map_;
+    //!Persistence GUID count map
+    std::map<GUID_t, uint16_t> persistence_guid_count_;
+    //!Information about max notified change
+    std::map<GUID_t, SequenceNumber_t> history_record_;
 
-                /**
-                 * Get the associated listener, secondary attached Listener in case it is of coumpound type
-                 * @return Pointer to the associated reader listener.
-                 */
-                RTPS_DllAPI ReaderListener* getListener();
+    //TODO Select one
+    FragmentedChangePitStop* fragmentedChangePitStop_;
 
-                /**
-                 * Switch the ReaderListener kind for the Reader.
-                 * If the RTPSReader does not belong to the built-in protocols it switches out the old one.
-                 * If it belongs to the built-in protocols, it sets the new ReaderListener callbacks to be called after the
-                 * built-in ReaderListener ones.
-                 * @param target Pointed to ReaderLister to attach
-                 * @return True is correctly set.
-                 */
-                RTPS_DllAPI bool setListener(ReaderListener* target);
+private:
 
-                /**
-                 * Reserve a CacheChange_t.
-                 * @param change Pointer to pointer to the Cache.
-                 * @return True if correctly reserved.
-                 */
-                RTPS_DllAPI bool reserveCache(CacheChange_t** change, uint32_t dataCdrSerializedSize);
+    RTPSReader& operator=(const RTPSReader&) = delete;
+};
 
-                /**
-                 * Release a cacheChange.
-                 */
-                RTPS_DllAPI void releaseCache(CacheChange_t* change);
-
-                /**
-                 * Read the next unread CacheChange_t from the history
-                 * @param change POinter to pointer of CacheChange_t
-                 * @param wp Pointer to pointer to the WriterProxy
-                 * @return True if read.
-                 */
-                RTPS_DllAPI virtual bool nextUnreadCache(CacheChange_t** change, WriterProxy** wp) = 0;
-
-                /**
-                 * Get the next CacheChange_t from the history to take.
-                 * @param change Pointer to pointer of CacheChange_t.
-                 * @param wp Pointer to pointer to the WriterProxy.
-                 * @return True if read.
-                 */
-                RTPS_DllAPI virtual bool nextUntakenCache(CacheChange_t** change, WriterProxy** wp) = 0;
-
-                /**
-                 * @return True if the reader expects Inline QOS.
-                 */
-                RTPS_DllAPI inline bool expectsInlineQos(){ return m_expectsInlineQos; };
-                //! Returns a pointer to the associated History.
-                RTPS_DllAPI inline ReaderHistory* getHistory() {return mp_history;};
-
-                /*!
-                 * @brief Search if there is a CacheChange_t, giving SequenceNumber_t and writer GUID_t,
-                 * waiting to be completed because it is fragmented.
-                 * @param sequence_number SequenceNumber_t of the searched CacheChange_t.
-                 * @param writer_guid writer GUID_t of the searched CacheChange_t.
-                 * @return If a CacheChange_t was found, it will be returned. In other case nullptr is returned.
-                 */
-                CacheChange_t* findCacheInFragmentedCachePitStop(const SequenceNumber_t& sequence_number,
-                        const GUID_t& writer_guid);
-
-                /*!
-                 * @brief Returns there is a clean state with all Writers.
-                 * It occurs when the Reader received all samples sent by Writers. In other words,
-                 * its WriterProxies are up to date.
-                 * @return There is a clean state with all Writers.
-                */
-                virtual bool isInCleanState() const = 0;
-
-                protected:
-                void setTrustedWriter(EntityId_t writer)
-                {
-                    m_acceptMessagesFromUnkownWriters=false;
-                    m_trustedWriterEntityId = writer;
-                }
-
-                /*!
-                 * @brief Add a remote writer to the persistence_guid map
-                 * @param wdata Info of the remote writer
-                 */
-                void add_persistence_guid(const RemoteWriterAttributes& wdata);
-
-                /*!
-                * @brief Remove a remote writer from the persistence_guid map
-                * @param wdata Info of the remote writer
-                */
-                void remove_persistence_guid(const RemoteWriterAttributes& wdata);
-
-                /*!
-                * @brief Get the last notified sequence for a RTPS guid
-                * @param guid The RTPS guid to query
-                * @return Last notified sequence number for input guid
-                * @remarks Takes persistence_guid into consideration
-                */
-                SequenceNumber_t get_last_notified(const GUID_t& guid) const;
-
-                /*!
-                * @brief Update the last notified sequence for a RTPS guid
-                * @param guid The RTPS guid of the writer
-                * @param seq Max sequence number available on writer
-                * @return Previous value of last notified sequence number for input guid
-                * @remarks Takes persistence_guid into consideration
-                */
-                SequenceNumber_t update_last_notified(const GUID_t& guid, const SequenceNumber_t& seq);
-
-                /*!
-                * @brief Set the last notified sequence for a persistence guid
-                * @param guid The persistence guid to update
-                * @param seq Sequence number to set for input guid
-                * @remarks Persistent readers will write to DB
-                */
-                virtual void set_last_notified(const GUID_t& peristence_guid, const SequenceNumber_t& seq);
-
-                //!ReaderHistory
-                ReaderHistory* mp_history;
-                //!Listener
-                ReaderListener* mp_listener;
-                //!Accept msg to unknwon readers (default=true)
-                bool m_acceptMessagesToUnknownReaders;
-                //!Accept msg from unknwon writers (BE-true,RE-false)
-                bool m_acceptMessagesFromUnkownWriters;
-                //!Trusted writer (for Builtin)
-                EntityId_t m_trustedWriterEntityId;
-                //!Expects Inline Qos.
-                bool m_expectsInlineQos;
-
-                //!Physical GUID to persistence GUID map
-                std::map<GUID_t, GUID_t> persistence_guid_map_;
-                //!Persistence GUID count map
-                std::map<GUID_t, uint16_t> persistence_guid_count_;
-                //!Information about max notified change
-                std::map<GUID_t, SequenceNumber_t> history_record_;
-
-                //TODO Select one
-                FragmentedChangePitStop* fragmentedChangePitStop_;
-
-                private:
-
-                RTPSReader& operator=(const RTPSReader&) = delete;
-            };
-
-        } /* namespace rtps */
-    } /* namespace fastrtps */
+} /* namespace rtps */
+} /* namespace fastrtps */
 } /* namespace eprosima */
 
-#endif /* RTPSREADER_H_ */
+#endif /* FASTRTPS_RTPS_READER_RTPSREADER_H_ */

--- a/include/fastrtps/rtps/reader/RTPSReader.h
+++ b/include/fastrtps/rtps/reader/RTPSReader.h
@@ -26,6 +26,9 @@
 #include "../attributes/ReaderAttributes.h"
 #include "../common/SequenceNumber.h"
 
+#include <foonathan/memory/container.hpp>
+#include <foonathan/memory/memory_pool.hpp>
+
 #include <map>
 
 namespace eprosima {
@@ -281,12 +284,19 @@ protected:
     //!Expects Inline Qos.
     bool m_expectsInlineQos;
 
+    using pool_allocator_t =
+        foonathan::memory::memory_pool<foonathan::memory::node_pool, foonathan::memory::heap_allocator>;
+
+    pool_allocator_t persistence_guid_map_allocator_;
+    pool_allocator_t persistence_guid_count_allocator_;
+    pool_allocator_t history_record_allocator_;
+
     //!Physical GUID to persistence GUID map
-    std::map<GUID_t, GUID_t> persistence_guid_map_;
+    foonathan::memory::map<GUID_t, GUID_t, pool_allocator_t> persistence_guid_map_;
     //!Persistence GUID count map
-    std::map<GUID_t, uint16_t> persistence_guid_count_;
+    foonathan::memory::map<GUID_t, uint16_t, pool_allocator_t> persistence_guid_count_;
     //!Information about max notified change
-    std::map<GUID_t, SequenceNumber_t> history_record_;
+    foonathan::memory::map<GUID_t, SequenceNumber_t, pool_allocator_t> history_record_;
 
     //TODO Select one
     FragmentedChangePitStop* fragmentedChangePitStop_;

--- a/include/fastrtps/rtps/reader/StatefulReader.h
+++ b/include/fastrtps/rtps/reader/StatefulReader.h
@@ -193,7 +193,7 @@ class StatefulReader:public RTPSReader
          */
         inline ReaderTimes& getTimes()
         {
-            return m_times;
+            return times_;
         }
 
         /**
@@ -202,7 +202,7 @@ class StatefulReader:public RTPSReader
          */
         inline size_t getMatchedWritersSize() const 
         { 
-            return matched_writers.size(); 
+            return matched_writers_.size(); 
         }
 
         /*!

--- a/include/fastrtps/rtps/reader/StatefulReader.h
+++ b/include/fastrtps/rtps/reader/StatefulReader.h
@@ -29,6 +29,7 @@ namespace fastrtps{
 namespace rtps {
 
 class WriterProxy;
+class RTPSMessageGroup_t;
 
 /**
  * Class StatefulReader, specialization of RTPSReader than stores the state of the matched writers.
@@ -211,6 +212,21 @@ class StatefulReader:public RTPSReader
          * @return There is a clean state with all Writers.
          */
         bool isInCleanState() const;
+
+        /**
+         * Sends an acknack message from this reader
+         * @param sns Sequence number bitmap with the acknack information.
+         * @param buffer Message buffer to use for serialization.
+         * @param locators List of destination locators.
+         * @param guids List of destination writer GUIDs.
+         * @param is_final Value for final flag.
+         */
+        void send_acknack(
+                const SequenceNumberSet_t& sns,
+                RTPSMessageGroup_t& buffer,
+                const LocatorList_t& locators,
+                const std::vector<GUID_t>& guids,
+                bool is_final);
 
         //! Acknack Count
         uint32_t m_acknackCount;

--- a/include/fastrtps/rtps/reader/StatefulReader.h
+++ b/include/fastrtps/rtps/reader/StatefulReader.h
@@ -37,7 +37,7 @@ class RTPSMessageGroup_t;
  * Class StatefulReader, specialization of RTPSReader than stores the state of the matched writers.
  * @ingroup READER_MODULE
  */
-class StatefulReader:public RTPSReader
+class StatefulReader : public RTPSReader
 {
     public:
 
@@ -213,7 +213,7 @@ class StatefulReader:public RTPSReader
          * its WriterProxies are up to date.
          * @return There is a clean state with all Writers.
          */
-        bool isInCleanState() const;
+        bool isInCleanState() const override;
 
         /**
          * Sends an acknack message from this reader.

--- a/include/fastrtps/rtps/reader/StatefulReader.h
+++ b/include/fastrtps/rtps/reader/StatefulReader.h
@@ -270,6 +270,8 @@ class StatefulReader : public RTPSReader
         ResourceLimitedVector<WriterProxy*> matched_writers_;
         //! Vector containing pointers to all the inactive, ready for reuse, WriterProxies.
         ResourceLimitedVector<WriterProxy*> matched_writers_pool_;
+        //!
+        ResourceLimitedContainerConfig proxy_changes_config_;
 };
 
 } /* namespace rtps */

--- a/include/fastrtps/rtps/reader/StatefulReader.h
+++ b/include/fastrtps/rtps/reader/StatefulReader.h
@@ -16,8 +16,9 @@
  * @file StatefulReader.h
  */
 
-#ifndef STATEFULREADER_H_
-#define STATEFULREADER_H_
+#ifndef FASTRTPS_RTPS_READER_STATEFULREADER_H_
+#define FASTRTPS_RTPS_READER_STATEFULREADER_H_
+
 #ifndef DOXYGEN_SHOULD_SKIP_THIS_PUBLIC
 
 #include "RTPSReader.h"
@@ -43,8 +44,13 @@ class StatefulReader:public RTPSReader
 
     protected:
 
-        StatefulReader(RTPSParticipantImpl*,GUID_t& guid,
-                ReaderAttributes& att,ReaderHistory* hist,ReaderListener* listen=nullptr);
+        StatefulReader(
+                RTPSParticipantImpl*,
+                const GUID_t& guid,
+                const ReaderAttributes& att,
+                ReaderHistory* hist,
+                ReaderListener* listen = nullptr);
+
     public:
 
         /**
@@ -52,40 +58,48 @@ class StatefulReader:public RTPSReader
          * @param wdata Pointer to the WPD object to add.
          * @return True if correctly added.
          */
-        bool matched_writer_add(RemoteWriterAttributes& wdata);
+        bool matched_writer_add(const RemoteWriterAttributes& wdata) override;
+
         /**
          * Remove a WriterProxyData from the matached writers.
          * @param wdata Pointer to the WPD object.
          * @param deleteWP If the Reader has to delete the associated WP object or not.
          * @return True if correct.
          */
-        bool matched_writer_remove(const RemoteWriterAttributes& wdata,bool deleteWP);
+        bool matched_writer_remove(
+                const RemoteWriterAttributes& wdata,
+                bool deleteWP);
+
         /**
          * Remove a WriterProxyData from the matached writers.
          * @param wdata Pointer to the WPD object.
          * @return True if correct.
          */
-        bool matched_writer_remove(const RemoteWriterAttributes& wdata);
+        bool matched_writer_remove(const RemoteWriterAttributes& wdata) override;
+
         /**
          * Tells us if a specific Writer is matched against this reader
          * @param wdata Pointer to the WriterProxyData object
          * @return True if it is matched.
          */
-        bool matched_writer_is_matched(const RemoteWriterAttributes& wdata);
+        bool matched_writer_is_matched(const RemoteWriterAttributes& wdata) const override;
+
         /**
          * Look for a specific WriterProxy.
          * @param writerGUID GUID_t of the writer we are looking for.
          * @param WP Pointer to pointer to a WriterProxy.
          * @return True if found.
          */
-        bool matched_writer_lookup(const GUID_t& writerGUID, WriterProxy** WP);
+        bool matched_writer_lookup(
+                const GUID_t& writerGUID, 
+                WriterProxy** WP);
 
         /**
          * Processes a new DATA message. Previously the message must have been accepted by function acceptMsgDirectedTo.
          * @param change Pointer to the CacheChange_t.
          * @return true if the reader accepts messages.
          */
-        bool processDataMsg(CacheChange_t *change);
+        bool processDataMsg(CacheChange_t* change) override;
 
         /**
          * Processes a new DATA FRAG message. Previously the message must have been accepted by function acceptMsgDirectedTo.
@@ -94,17 +108,28 @@ class StatefulReader:public RTPSReader
          * @param fragmentStartingNum fragment number of this particular fragment.
          * @return true if the reader accepts messages.
          */
-        bool processDataFragMsg(CacheChange_t *change, uint32_t sampleSize, uint32_t fragmentStartingNum);
+        bool processDataFragMsg(
+                CacheChange_t* change, 
+                uint32_t sampleSize, 
+                uint32_t fragmentStartingNum) override;
 
         /**
          * Processes a new HEARTBEAT message. Previously the message must have been accepted by function acceptMsgDirectedTo.
          *
          * @return true if the reader accepts messages.
          */
-        bool processHeartbeatMsg(GUID_t &writerGUID, uint32_t hbCount, SequenceNumber_t &firstSN,
-                SequenceNumber_t &lastSN, bool finalFlag, bool livelinessFlag);
+        bool processHeartbeatMsg(
+                const GUID_t& writerGUID, 
+                uint32_t hbCount, 
+                const SequenceNumber_t& firstSN,
+                const SequenceNumber_t& lastSN, 
+                bool finalFlag, 
+                bool livelinessFlag) override;
 
-        bool processGapMsg(GUID_t &writerGUID, SequenceNumber_t &gapStart, SequenceNumberSet_t &gapList);
+        bool processGapMsg(
+                const GUID_t& writerGUID, 
+                const SequenceNumber_t& gapStart, 
+                const SequenceNumberSet_t& gapList) override;
 
         /**
          * Method to indicate the reader that some change has been removed due to HistoryQos requirements.
@@ -112,7 +137,9 @@ class StatefulReader:public RTPSReader
          * @param prox Pointer to the WriterProxy.
          * @return True if correctly removed.
          */
-        bool change_removed_by_history(CacheChange_t* change ,WriterProxy* prox = nullptr);
+        bool change_removed_by_history(
+                CacheChange_t* change,
+                WriterProxy* prox = nullptr) override;
 
         /**
          * This method is called when a new change is received. This method calls the received_change of the History
@@ -122,13 +149,18 @@ class StatefulReader:public RTPSReader
          * @param lock mutex protecting the StatefulReader.
          * @return True if added.
          */
-        bool change_received(CacheChange_t* a_change, WriterProxy* prox);
+        bool change_received(
+                CacheChange_t* a_change, 
+                WriterProxy* prox);
 
         /**
          * Get the RTPS participant
          * @return Associated RTPS participant
          */
-        inline RTPSParticipantImpl* getRTPSParticipant() const {return mp_RTPSParticipant;}
+        inline RTPSParticipantImpl* getRTPSParticipant() const 
+        {
+            return mp_RTPSParticipant;
+        }
 
         /**
          * Read the next unread CacheChange_t from the history
@@ -136,7 +168,9 @@ class StatefulReader:public RTPSReader
          * @param wpout Pointer to pointer the matched writer proxy
          * @return True if read.
          */
-        bool nextUnreadCache(CacheChange_t** change,WriterProxy** wpout=nullptr);
+        bool nextUnreadCache(
+                CacheChange_t** change,
+                WriterProxy** wpout = nullptr) override;
 
         /**
          * Take the next CacheChange_t from the history;
@@ -144,8 +178,9 @@ class StatefulReader:public RTPSReader
          * @param wpout Pointer to pointer the matched writer proxy
          * @return True if read.
          */
-        bool nextUntakenCache(CacheChange_t** change,WriterProxy** wpout=nullptr);
-
+        bool nextUntakenCache(
+                CacheChange_t** change,
+                WriterProxy** wpout = nullptr) override;
 
         /**
          * Update the times parameters of the Reader.
@@ -153,17 +188,24 @@ class StatefulReader:public RTPSReader
          * @return True if correctly updated.
          */
         bool updateTimes(const ReaderTimes& times);
+
         /**
          *
          * @return Reference to the ReaderTimes.
          */
-        inline ReaderTimes& getTimes(){return m_times;};
+        inline ReaderTimes& getTimes()
+        {
+            return m_times;
+        }
 
         /**
          * Get the number of matched writers
          * @return Number of matched writers
          */
-        inline size_t getMatchedWritersSize() const { return matched_writers.size(); }
+        inline size_t getMatchedWritersSize() const 
+        { 
+            return matched_writers.size(); 
+        }
 
         /*!
          * @brief Returns there is a clean state with all Writers.
@@ -180,12 +222,16 @@ class StatefulReader:public RTPSReader
 
     private:
 
-        bool acceptMsgFrom(GUID_t &entityGUID ,WriterProxy **wp);
+        bool acceptMsgFrom(
+                const GUID_t& entityGUID,
+                WriterProxy** wp) const;
 
         /*!
          * @remarks Nn thread-safe.
          */
-        bool findWriterProxy(const GUID_t& writerGUID, WriterProxy** wp);
+        bool findWriterProxy(
+                const GUID_t& writerGUID, 
+                WriterProxy** wp) const;
 
         void NotifyChanges(WriterProxy* wp);
 
@@ -195,8 +241,10 @@ class StatefulReader:public RTPSReader
         std::vector<WriterProxy*> matched_writers;
 };
 
-}
 } /* namespace rtps */
+} /* namespace fastrtps */
 } /* namespace eprosima */
+
 #endif
-#endif /* STATEFULREADER_H_ */
+
+#endif /* FASTRTPS_RTPS_READER_STATEFULREADER_H_ */

--- a/include/fastrtps/rtps/reader/StatefulReader.h
+++ b/include/fastrtps/rtps/reader/StatefulReader.h
@@ -214,7 +214,7 @@ class StatefulReader:public RTPSReader
         bool isInCleanState() const;
 
         /**
-         * Sends an acknack message from this reader
+         * Sends an acknack message from this reader.
          * @param sns Sequence number bitmap with the acknack information.
          * @param buffer Message buffer to use for serialization.
          * @param locators List of destination locators.
@@ -228,10 +228,20 @@ class StatefulReader:public RTPSReader
                 const std::vector<GUID_t>& guids,
                 bool is_final);
 
-        //! Acknack Count
-        uint32_t m_acknackCount;
-        //! NACKFRAG Count
-        uint32_t m_nackfragCount;
+        /**
+         * Sends an acknack message from this reader in response to a heartbeat.
+         * @param writer Pointer to the proxy representing the writer to send the acknack to.
+         * @param buffer Message buffer to use for serialization.
+         * @param locators List of destination locators.
+         * @param guids List of destination writer GUIDs.
+         * @param heartbeat_was_final Final flag of the last received heartbeat.
+         */
+        void send_acknack(
+                const WriterProxy* writer,
+                RTPSMessageGroup_t& buffer,
+                const LocatorList_t& locators,
+                const std::vector<GUID_t>& guids,
+                bool heartbeat_was_final);
 
     private:
 
@@ -248,10 +258,14 @@ class StatefulReader:public RTPSReader
 
         void NotifyChanges(WriterProxy* wp);
 
+        //! Acknack Count
+        uint32_t acknack_count_;
+        //! NACKFRAG Count
+        uint32_t nackfrag_count_;
         //!ReaderTimes of the StatefulReader.
-        ReaderTimes m_times;
+        ReaderTimes times_;
         //! Vector containing pointers to the matched writers.
-        std::vector<WriterProxy*> matched_writers;
+        std::vector<WriterProxy*> matched_writers_;
 };
 
 } /* namespace rtps */

--- a/include/fastrtps/rtps/reader/StatefulReader.h
+++ b/include/fastrtps/rtps/reader/StatefulReader.h
@@ -61,14 +61,11 @@ class StatefulReader:public RTPSReader
         bool matched_writer_add(const RemoteWriterAttributes& wdata) override;
 
         /**
-         * Remove a WriterProxyData from the matached writers.
-         * @param wdata Pointer to the WPD object.
-         * @param deleteWP If the Reader has to delete the associated WP object or not.
+         * Remove a WriterProxyData from the matached writers due to liveliness expiration.
+         * @param writer_guid GUID of the writer proxy for which livelines expired.
          * @return True if correct.
          */
-        bool matched_writer_remove(
-                const RemoteWriterAttributes& wdata,
-                bool deleteWP);
+        bool liveliness_expired(const GUID_t& writer_guid);
 
         /**
          * Remove a WriterProxyData from the matached writers.

--- a/include/fastrtps/rtps/reader/StatefulReader.h
+++ b/include/fastrtps/rtps/reader/StatefulReader.h
@@ -22,6 +22,8 @@
 #ifndef DOXYGEN_SHOULD_SKIP_THIS_PUBLIC
 
 #include "RTPSReader.h"
+#include "../../utils/collections/ResourceLimitedVector.hpp"
+
 #include <mutex>
 
 namespace eprosima {
@@ -264,8 +266,10 @@ class StatefulReader:public RTPSReader
         uint32_t nackfrag_count_;
         //!ReaderTimes of the StatefulReader.
         ReaderTimes times_;
-        //! Vector containing pointers to the matched writers.
-        std::vector<WriterProxy*> matched_writers_;
+        //! Vector containing pointers to all the active WriterProxies.
+        ResourceLimitedVector<WriterProxy*> matched_writers_;
+        //! Vector containing pointers to all the inactive, ready for reuse, WriterProxies.
+        ResourceLimitedVector<WriterProxy*> matched_writers_pool_;
 };
 
 } /* namespace rtps */

--- a/include/fastrtps/rtps/reader/StatelessReader.h
+++ b/include/fastrtps/rtps/reader/StatelessReader.h
@@ -23,6 +23,7 @@
 #ifndef DOXYGEN_SHOULD_SKIP_THIS_PUBLIC
 
 #include "RTPSReader.h"
+#include "../../utils/collections/ResourceLimitedVector.hpp"
 
 #include <mutex>
 #include <map>
@@ -182,7 +183,7 @@ private:
 
     //!List of GUID_t os matched writers.
     //!Is only used in the Discovery, to correctly notify the user using SubscriptionListener::onSubscriptionMatched();
-    std::vector<RemoteWriterAttributes> matched_writers_;
+    ResourceLimitedVector<RemoteWriterAttributes> matched_writers_;
 };
 
 } /* namespace rtps */

--- a/include/fastrtps/rtps/reader/StatelessReader.h
+++ b/include/fastrtps/rtps/reader/StatelessReader.h
@@ -163,7 +163,7 @@ public:
      * StatelessReader allways return true;
      * @return true
      */
-    bool isInCleanState() const 
+    bool isInCleanState() const override
     { 
         return true; 
     }

--- a/include/fastrtps/rtps/reader/StatelessReader.h
+++ b/include/fastrtps/rtps/reader/StatelessReader.h
@@ -17,8 +17,9 @@
  */
 
 
-#ifndef STATELESSREADER_H_
-#define STATELESSREADER_H_
+#ifndef FASTRTPS_RTPS_READER_STATELESSREADER_H_
+#define FASTRTPS_RTPS_READER_STATELESSREADER_H_
+
 #ifndef DOXYGEN_SHOULD_SKIP_THIS_PUBLIC
 
 #include "RTPSReader.h"
@@ -40,29 +41,37 @@ class StatelessReader: public RTPSReader
 
 public:
     virtual ~StatelessReader();
+
 protected:
-    StatelessReader(RTPSParticipantImpl*,GUID_t& guid,
-            ReaderAttributes& att,ReaderHistory* hist,ReaderListener* listen=nullptr);
+    StatelessReader(
+            RTPSParticipantImpl* pimpl,
+            const GUID_t& guid,
+            const ReaderAttributes& att,
+            ReaderHistory* hist,
+            ReaderListener* listen = nullptr);
+
 public:
+
     /**
      * Add a matched writer represented by a WriterProxyData object.
      * @param wdata Pointer to the WPD object to add.
      * @return True if correctly added.
      */
-    bool matched_writer_add(RemoteWriterAttributes& wdata);
+    bool matched_writer_add(const RemoteWriterAttributes& wdata) override;
+
     /**
      * Remove a WriterProxyData from the matached writers.
      * @param wdata Pointer to the WPD object.
      * @return True if correct.
      */
-    bool matched_writer_remove(const RemoteWriterAttributes& wdata);
+    bool matched_writer_remove(const RemoteWriterAttributes& wdata) override;
 
     /**
      * Tells us if a specific Writer is matched against this reader
      * @param wdata Pointer to the WriterProxyData object
      * @return True if it is matched.
      */
-    bool matched_writer_is_matched(const RemoteWriterAttributes& wdata);
+    bool matched_writer_is_matched(const RemoteWriterAttributes& wdata) const override;
 
     /**
      * Method to indicate the reader that some change has been removed due to HistoryQos requirements.
@@ -70,7 +79,9 @@ public:
      * @param prox Pointer to the WriterProxy.
      * @return True if correctly removed.
      */
-    bool change_removed_by_history(CacheChange_t* change,WriterProxy* prox = nullptr);
+    bool change_removed_by_history(
+            CacheChange_t* change,
+            WriterProxy* prox = nullptr) override;
 
     /**
      * Processes a new DATA message. Previously the message must have been accepted by function acceptMsgDirectedTo.
@@ -78,7 +89,7 @@ public:
      * @param change Pointer to the CacheChange_t.
      * @return true if the reader accepts messages from the.
      */
-    bool processDataMsg(CacheChange_t *change);
+    bool processDataMsg(CacheChange_t *change) override;
 
     /**
      * Processes a new DATA FRAG message. Previously the message must have been accepted by function acceptMsgDirectedTo.
@@ -87,17 +98,28 @@ public:
      * @param fragmentStartingNum fragment number of this particular fragment.
      * @return true if the reader accepts message.
      */
-    bool processDataFragMsg(CacheChange_t *change, uint32_t sampleSize, uint32_t fragmentStartingNum);
+    bool processDataFragMsg(
+            CacheChange_t* change, 
+            uint32_t sampleSize, 
+            uint32_t fragmentStartingNum) override;
 
     /**
      * Processes a new HEARTBEAT message. Previously the message must have been accepted by function acceptMsgDirectedTo.
      *
      * @return true if the reader accepts messages from the.
      */
-    bool processHeartbeatMsg(GUID_t &writerGUID, uint32_t hbCount, SequenceNumber_t &firstSN,
-            SequenceNumber_t &lastSN, bool finalFlag, bool livelinessFlag);
+    bool processHeartbeatMsg(
+            const GUID_t &writerGUID, 
+            uint32_t hbCount, 
+            const SequenceNumber_t& firstSN,
+            const SequenceNumber_t& lastSN, 
+            bool finalFlag, 
+            bool livelinessFlag) override;
 
-    bool processGapMsg(GUID_t &writerGUID, SequenceNumber_t &gapStart, SequenceNumberSet_t &gapList);
+    bool processGapMsg(
+            const GUID_t& writerGUID, 
+            const SequenceNumber_t& gapStart, 
+            const SequenceNumberSet_t& gapList) override;
 
     /**
      * This method is called when a new change is received. This method calls the received_change of the History
@@ -113,43 +135,60 @@ public:
      * @param wpout Pointer to pointer of the matched writer proxy
      * @return True if read.
      */
-    bool nextUnreadCache(CacheChange_t** change,WriterProxy** wpout=nullptr);
+    bool nextUnreadCache(
+            CacheChange_t** change,
+            WriterProxy** wpout = nullptr) override;
     /**
      * Take the next CacheChange_t from the history;
      * @param change Pointer to pointer of CacheChange_t
      * @param wpout Pointer to pointer of the matched writer proxy
      * @return True if read.
      */
-    bool nextUntakenCache(CacheChange_t** change,WriterProxy** wpout=nullptr);
+    bool nextUntakenCache(
+            CacheChange_t** change,
+            WriterProxy** wpout = nullptr) override;
 
     /**
      * Get the number of matched writers
      * @return Number of matched writers
      */
-    inline size_t getMatchedWritersSize() const {return m_matched_writers.size();};
+    inline size_t getMatchedWritersSize() const 
+    {
+        return matched_writers_.size();
+    }
 
     /*!
      * @brief Returns there is a clean state with all Writers.
      * StatelessReader allways return true;
      * @return true
      */
-    bool isInCleanState() const { return true; }
+    bool isInCleanState() const 
+    { 
+        return true; 
+    }
 
-    inline RTPSParticipantImpl* getRTPSParticipant() const {return mp_RTPSParticipant;}
+    inline RTPSParticipantImpl* getRTPSParticipant() const 
+    {
+        return mp_RTPSParticipant;
+    }
 
 private:
 
-    bool acceptMsgFrom(GUID_t& entityId);
+    bool acceptMsgFrom(const GUID_t& entityId);
 
-    bool thereIsUpperRecordOf(GUID_t& guid, SequenceNumber_t& seq);
+    bool thereIsUpperRecordOf(
+            const GUID_t& guid, 
+            const SequenceNumber_t& seq);
 
     //!List of GUID_t os matched writers.
     //!Is only used in the Discovery, to correctly notify the user using SubscriptionListener::onSubscriptionMatched();
-    std::vector<RemoteWriterAttributes> m_matched_writers;
+    std::vector<RemoteWriterAttributes> matched_writers_;
 };
 
-}
 } /* namespace rtps */
+} /* namespace fastrtps */
 } /* namespace eprosima */
+
 #endif
-#endif /* STATELESSREADER_H_ */
+
+#endif /* FASTRTPS_RTPS_READER_STATELESSREADER_H_ */

--- a/include/fastrtps/rtps/reader/WriterProxy.h
+++ b/include/fastrtps/rtps/reader/WriterProxy.h
@@ -16,8 +16,8 @@
  * @file WriterProxy.h
  */
 
-#ifndef WRITERPROXY_H_
-#define WRITERPROXY_H_
+#ifndef FASTRTPS_RTPS_READER_WRITERPROXY_H_
+#define FASTRTPS_RTPS_READER_WRITERPROXY_H_
 #ifndef DOXYGEN_SHOULD_SKIP_THIS_PUBLIC
 
 #include <mutex>
@@ -34,186 +34,220 @@
 #define TEST_FRIENDS
 #endif // TEST_FRIENDS
 
-namespace eprosima
+namespace eprosima {
+namespace fastrtps {
+namespace rtps {
+
+class StatefulReader;
+class HeartbeatResponseDelay;
+class WriterProxyLiveliness;
+class InitialAckNack;
+
+/**
+ * Class WriterProxy that contains the state of each matched writer for a specific reader.
+ * @ingroup READER_MODULE
+ */
+class WriterProxy
 {
-    namespace fastrtps
+    TEST_FRIENDS
+
+public:
+
+    ~WriterProxy();
+
+    /**
+     * Constructor.
+     * @param attributes RemoteWriterAttributes.
+     * @param reader Pointer to the StatefulReader creating this proxy.
+     */
+    WriterProxy(
+            const RemoteWriterAttributes& attributes, 
+            StatefulReader* reader);
+
+    /**
+     * Set initial value for last acked sequence number.
+     * @param[in] seq_num last acked sequence number.
+     */
+    void loaded_from_storage_nts(const SequenceNumber_t& seq_num);
+
+    /**
+     * Get the maximum sequenceNumber received from this Writer.
+     * @return the maximum sequence number.
+     */
+    const SequenceNumber_t available_changes_max() const;
+
+    /**
+     * Update the missing changes up to the provided sequenceNumber.
+     * All changes with status UNKNOWN with seq_num <= input seq_num are marked MISSING.
+     * @param[in] seq_num Pointer to the SequenceNumber.
+     */
+    void missing_changes_update(const SequenceNumber_t& seq_num);
+
+    /**
+     * Update the lost changes up to the provided sequenceNumber.
+     * All changes with status UNKNOWN or MISSING with seq_num < input seq_num are marked LOST.
+     * @param[in] seq_num Pointer to the SequenceNumber.
+     */
+    void lost_changes_update(const SequenceNumber_t& seq_num);
+
+    /**
+     * The provided change is marked as RECEIVED.
+     * @param seq_num Sequence number of the change
+     * @return True if correct.
+     */
+    bool received_change_set(const SequenceNumber_t& seq_num);
+
+    /**
+     * Set a change as RECEIVED and NOT RELEVANT.
+     * @param seq_num Sequence number of the change
+     * @return true on success
+     */
+    bool irrelevant_change_set(const SequenceNumber_t& seq_num);
+
+    /**
+     * Called when a change has been removed from the reader's history.
+     * @param seq_num Sequence number of the removed change.
+     */
+    void change_removed_from_history(const SequenceNumber_t& seq_num);
+
+    /**
+     * Check if this proxy has any missing change.
+     * @return true when there is at least one missing change on this proxy.
+     */
+    bool are_there_missing_changes() const;
+
+    /**
+     * The method returns a vector containing all missing changes.
+     * @return Vector of missing changes..
+     */
+    const std::vector<ChangeFromWriter_t> missing_changes() const;
+
+    /**
+     * Get the number of missing changes up to a certain sequence number.
+     * @param seq_num Sequence number limiting the query. 
+     *                Only changes with a sequence number less than this one will be considered.
+     * @return the number of missing changes with a sequence number less than seq_num.
+     */
+    size_t unknown_missing_changes_up_to(const SequenceNumber_t& seq_num) const;
+
+    //! Pointer to associated StatefulReader.
+    StatefulReader* mp_SFR;
+    //! Parameters of the WriterProxy
+    RemoteWriterAttributes m_att;
+    //! LAst HEartbeatcount.
+    uint32_t m_lastHeartbeatCount;
+    //!Timed event to postpone the heartbeatResponse.
+    HeartbeatResponseDelay* mp_heartbeatResponse;
+    //!TO check the liveliness Status periodically.
+    WriterProxyLiveliness* mp_writerProxyLiveliness;
+    //! Timed event to send initial acknack.
+    InitialAckNack* mp_initialAcknack;
+    //!Indicates if the heartbeat has the final flag set.
+    bool m_heartbeatFinalFlag;
+
+    /**
+     * Check if the writer is alive
+     * @return true if the writer is alive
+     */
+    inline bool is_alive() const
     {
-        namespace rtps
-        {
+        return is_alive_;
+    };
 
-            class StatefulReader;
-            class HeartbeatResponseDelay;
-            class WriterProxyLiveliness;
-            class InitialAckNack;
+    /**
+     * Set the writer as alive
+     */
+    void assert_liveliness();
 
-            /**
-             * Class WriterProxy that contains the state of each matched writer for a specific reader.
-             * @ingroup READER_MODULE
-             */
-            class WriterProxy
-            {
-                TEST_FRIENDS
+    /**
+     * Set the writer as not alive
+     */
+    inline void set_not_alive()
+    {
+        is_alive_ = false;
+    }
+    
+    /**
+     * Get the mutex
+     * @return Associated mutex
+     */
+    inline std::recursive_mutex* get_mutex()
+    {
+        return mutex_;
+    }
 
-                public:
+    /*!
+     * @brief Returns number of ChangeFromWriter_t managed currently by the WriterProxy.
+     * @return Number of ChangeFromWriter_t managed currently by the WriterProxy.
+     */
+    size_t number_of_changes_from_writer() const;
 
-                    ~WriterProxy();
+    /*!
+     * @brief Returns next SequenceNumber_t to be notified.
+     * @return Next SequenceNumber_t to be nofified or invalid SequenceNumber_t
+     * if any SequenceNumber_t to be notified.
+     */
+    SequenceNumber_t next_cache_change_to_be_notified();
 
-                    /**
-                     * Constructor.
-                     * @param watt RemoteWriterAttributes.
-                     * @param SR Pointer to the StatefulReader.
-                     */
-                    WriterProxy(const RemoteWriterAttributes& watt, StatefulReader* SR);
+    /**
+     * Checks whether a cache change was already received from this proxy.
+     * @param[in] seq_num Sequence number of the cache change to check.
+     * @return true if the cache change was received, false otherwise.
+     */
+    bool change_was_received(const SequenceNumber_t& seq_num) const;
 
-                    /**
-                     * Set initial value for last acked sequence number.
-                     * @param[in] seqNum last acked sequence number.
-                     */
-                    void loaded_from_storage_nts(const SequenceNumber_t& seqNum);
+private:
 
-                    /**
-                     * Get the maximum sequenceNumber received from this Writer.
-                     * @return the maximum sequence number.
-                     */
-                    const SequenceNumber_t available_changes_max() const;
+    /*!
+     * @brief Add ChangeFromWriter_t up to the sequenceNumber passed, but not including this.
+     * Ex: If you have seqNums 1,2,3 and you receive seq_num 6, you need to add 4 and 5.
+     * @param sequence_number
+     * @param default_status ChangeFromWriter_t added will be created with this ChangeFromWriterStatus_t.
+     * @return True if sequence_number will be the next after last element in the changes_from_writer_ container.
+     * @remarks No thread-safe.
+     */
+    bool maybe_add_changes_from_writer_up_to(
+            const SequenceNumber_t& sequence_number, 
+            const ChangeFromWriterStatus_t default_status = ChangeFromWriterStatus_t::UNKNOWN);
 
-                    /**
-                     * Update the missing changes up to the provided sequenceNumber.
-                     * All changes with status UNKNOWN with seqNum <= input seqNum are marked MISSING.
-                     * @param[in] seqNum Pointer to the SequenceNumber.
-                     */
-                    void missing_changes_update(const SequenceNumber_t& seqNum);
+    bool received_change_set(
+            const SequenceNumber_t& seq_num, 
+            bool is_relevance);
 
-                    /**
-                     * Update the lost changes up to the provided sequenceNumber.
-                     * All changes with status UNKNOWN or MISSING with seqNum < input seqNum are marked LOST.
-                     * @param[in] seqNum Pointer to the SequenceNumber.
-                     */
-                    void lost_changes_update(const SequenceNumber_t& seqNum);
+    void cleanup();
 
-                    /**
-                     * The provided change is marked as RECEIVED.
-                     * @param seqNum Sequence number of the change
-                     * @return True if correct.
-                     */
-                    bool received_change_set(const SequenceNumber_t& seqNum);
+    //!Is the writer alive
+    bool is_alive_;
+    //Print Method for log purposes
+    void print_changes_fromWriter_test2();
 
-                    /**
-                     * Set a change as RECEIVED and NOT RELEVANT.
-                     * @param seqNum Sequence number of the change
-                     * @return true on success
-                     */
-                    bool irrelevant_change_set(const SequenceNumber_t& seqNum);
+    //!Mutex Pointer
+    std::recursive_mutex* mutex_;
 
-                    void setNotValid(const SequenceNumber_t& seqNum);
+    //!Vector containing the ChangeFromWriter_t objects.
+    std::set<ChangeFromWriter_t, ChangeFromWriterCmp> changes_from_writer_;
+    SequenceNumber_t changes_from_writer_low_mark_;
 
-                    bool areThereMissing();
+    //! Store last ChacheChange_t notified.
+    SequenceNumber_t last_notified_;
 
-                    /**
-                     * The method returns a vector containing all missing changes.
-                     * @return Vector of missing changes..
-                     */
-                    const std::vector<ChangeFromWriter_t>  missing_changes();
+    void for_each_set_status_from(
+            decltype(changes_from_writer_)::iterator first,
+            decltype(changes_from_writer_)::iterator last,
+            ChangeFromWriterStatus_t status,
+            ChangeFromWriterStatus_t new_status);
 
-                    size_t unknown_missing_changes_up_to(const SequenceNumber_t& seqNum);
+    void for_each_set_status_from_and_maybe_remove(
+            decltype(changes_from_writer_)::iterator first,
+            decltype(changes_from_writer_)::iterator last,
+            ChangeFromWriterStatus_t status,
+            ChangeFromWriterStatus_t or_status,
+            ChangeFromWriterStatus_t new_status);
+};
 
-                    //! Pointer to associated StatefulReader.
-                    StatefulReader* mp_SFR;
-                    //! Parameters of the WriterProxy
-                    RemoteWriterAttributes m_att;
-                    //! LAst HEartbeatcount.
-                    uint32_t m_lastHeartbeatCount;
-                    //!Timed event to postpone the heartbeatResponse.
-                    HeartbeatResponseDelay* mp_heartbeatResponse;
-                    //!TO check the liveliness Status periodically.
-                    WriterProxyLiveliness* mp_writerProxyLiveliness;
-                    //! Timed event to send initial acknack.
-                    InitialAckNack* mp_initialAcknack;
-                    //!Indicates if the heartbeat has the final flag set.
-                    bool m_heartbeatFinalFlag;
-
-                    /**
-                     * Check if the writer is alive
-                     * @return true if the writer is alive
-                     */
-                    inline bool isAlive(){return m_isAlive;};
-
-                    /**
-                     * Set the writer as alive
-                     */
-                    void assertLiveliness();
-                    /**
-                     * Set the writer as not alive
-                     * @return
-                     */
-                    inline void setNotAlive(){m_isAlive = false;};
-
-                    /**
-                     * Get the mutex
-                     * @return Associated mutex
-                     */
-                    inline std::recursive_mutex* getMutex(){return mp_mutex;};
-
-                    /*!
-                     * @brief Returns number of ChangeFromWriter_t managed currently by the WriterProxy.
-                     * @return Number of ChangeFromWriter_t managed currently by the WriterProxy.
-                    */
-                    size_t numberOfChangeFromWriter() const;
-
-                    /*!
-                     * @brief Returns next CacheChange_t to be notified.
-                     * @return Next CacheChange_t to be nofified or invalid SequenceNumber_t
-                     * if any CacheChange_t to be notified.
-                     */
-                    SequenceNumber_t nextCacheChangeToBeNotified();
-
-                    bool change_was_received(const SequenceNumber_t& seq_num);
-
-                private:
-
-                    /*!
-                     * @brief Add ChangeFromWriter_t up to the sequenceNumber passed, but not including this.
-                     * Ex: If you have seqNums 1,2,3 and you receive seqNum 6, you need to add 4 and 5.
-                     * @param sequence_number
-                     * @param default_status ChangeFromWriter_t added will be created with this ChangeFromWriterStatus_t.
-                     * @return True if sequence_number will be the next after last element in the m_changesFromW container.
-                     * @remarks No thread-safe.
-                     */
-                    bool maybe_add_changes_from_writer_up_to(const SequenceNumber_t& sequence_number, const ChangeFromWriterStatus_t default_status = ChangeFromWriterStatus_t::UNKNOWN);
-
-                    bool received_change_set(const SequenceNumber_t& seqNum, bool is_relevance);
-
-                    void cleanup();
-
-                    //!Is the writer alive
-                    bool m_isAlive;
-                    //Print Method for log purposes
-                    void print_changes_fromWriter_test2();
-
-                    //!Mutex Pointer
-                    std::recursive_mutex* mp_mutex;
-
-                    //!Vector containing the ChangeFromWriter_t objects.
-                    std::set<ChangeFromWriter_t, ChangeFromWriterCmp> m_changesFromW;
-                    SequenceNumber_t changesFromWLowMark_;
-
-                    //! Store last ChacheChange_t notified.
-                    SequenceNumber_t lastNotified_;
-
-                    void for_each_set_status_from(decltype(m_changesFromW)::iterator first,
-                            decltype(m_changesFromW)::iterator last,
-                            ChangeFromWriterStatus_t status,
-                            ChangeFromWriterStatus_t new_status);
-
-                    void for_each_set_status_from_and_maybe_remove(decltype(m_changesFromW)::iterator first,
-                            decltype(m_changesFromW)::iterator last,
-                            ChangeFromWriterStatus_t status,
-                            ChangeFromWriterStatus_t orstatus,
-                            ChangeFromWriterStatus_t new_status);
-            };
-
-        } /* namespace rtps */
-    } /* namespace fastrtps */
+} /* namespace rtps */
+} /* namespace fastrtps */
 } /* namespace eprosima */
+
 #endif
-#endif /* WRITERPROXY_H_ */
+#endif /* FASTRTPS_RTPS_READER_WRITERPROXY_H_ */

--- a/include/fastrtps/rtps/reader/WriterProxy.h
+++ b/include/fastrtps/rtps/reader/WriterProxy.h
@@ -308,15 +308,17 @@ private:
     //!To fool RTPSMessageGroup when using this proxy as single destination
     ResourceLimitedVector<GUID_t> guid_as_vector_;
 
+    using ChangeIterator = decltype(changes_from_writer_)::iterator;
+
     void for_each_set_status_from(
-            decltype(changes_from_writer_)::iterator first,
-            decltype(changes_from_writer_)::iterator last,
+            ChangeIterator first,
+            ChangeIterator last,
             ChangeFromWriterStatus_t status,
             ChangeFromWriterStatus_t new_status);
 
     void for_each_set_status_from_and_maybe_remove(
-            decltype(changes_from_writer_)::iterator first,
-            decltype(changes_from_writer_)::iterator last,
+            ChangeIterator first,
+            ChangeIterator last,
             ChangeFromWriterStatus_t status,
             ChangeFromWriterStatus_t or_status,
             ChangeFromWriterStatus_t new_status);

--- a/include/fastrtps/rtps/reader/WriterProxy.h
+++ b/include/fastrtps/rtps/reader/WriterProxy.h
@@ -262,10 +262,6 @@ public:
      */
     void update_heartbeat_response_interval(const Duration_t& interval);
 
-    inline void liveliness_expired()
-    {
-    }
-
 private:
 
     /*!

--- a/include/fastrtps/rtps/reader/WriterProxy.h
+++ b/include/fastrtps/rtps/reader/WriterProxy.h
@@ -180,12 +180,6 @@ public:
     }
 
     /**
-     * Get the participant this proxy is part of.
-     * @return pointer to the participant of the StatefulReader that created this proxy.
-     */
-    RTPSParticipantImpl* get_participant() const;
-
-    /**
      * Check if the writer is alive
      * @return true if the writer is alive
      */

--- a/include/fastrtps/rtps/reader/WriterProxy.h
+++ b/include/fastrtps/rtps/reader/WriterProxy.h
@@ -60,12 +60,20 @@ public:
 
     /**
      * Constructor.
-     * @param attributes RemoteWriterAttributes.
      * @param reader Pointer to the StatefulReader creating this proxy.
      */
-    WriterProxy(
-            const RemoteWriterAttributes& attributes, 
-            StatefulReader* reader);
+    WriterProxy(StatefulReader* reader);
+
+    /**
+     * Activate this proxy associating it to a remote writer.
+     * @param attributes RemoteWriterAttributes of the writer for which to keep state.
+     */
+    void start(const RemoteWriterAttributes& attributes);
+
+    /**
+     * Disable this proxy.
+     */
+    void stop();
 
     /**
      * Set initial value for last acked sequence number.
@@ -192,14 +200,6 @@ public:
     void assert_liveliness();
 
     /**
-     * Set the writer as not alive
-     */
-    inline void set_not_alive()
-    {
-        is_alive_ = false;
-    }
-    
-    /**
      * Get the mutex
      * @return Associated mutex
      */
@@ -264,7 +264,6 @@ public:
 
     inline void liveliness_expired()
     {
-        writer_proxy_liveliness_ = nullptr;
     }
 
 private:

--- a/include/fastrtps/rtps/reader/WriterProxy.h
+++ b/include/fastrtps/rtps/reader/WriterProxy.h
@@ -196,6 +196,11 @@ public:
      */
     bool change_was_received(const SequenceNumber_t& seq_num) const;
 
+    inline void liveliness_expired()
+    {
+        mp_writerProxyLiveliness = nullptr;
+    }
+
 private:
 
     /*!

--- a/include/fastrtps/rtps/reader/WriterProxy.h
+++ b/include/fastrtps/rtps/reader/WriterProxy.h
@@ -287,9 +287,6 @@ private:
 
     void cleanup();
 
-    //Print Method for log purposes
-    void print_changes_fromWriter_test2();
-
     //! Pointer to associated StatefulReader.
     StatefulReader* reader_;
     //! Parameters of the WriterProxy

--- a/include/fastrtps/rtps/reader/WriterProxy.h
+++ b/include/fastrtps/rtps/reader/WriterProxy.h
@@ -120,10 +120,10 @@ public:
     bool are_there_missing_changes() const;
 
     /**
-     * The method returns a vector containing all missing changes.
-     * @return Vector of missing changes..
+     * The method returns a SequenceNumberSet_t containing the sequence number of all missing changes.
+     * @return Sequence number set of missing changes.
      */
-    const std::vector<ChangeFromWriter_t> missing_changes() const;
+    SequenceNumberSet_t missing_changes() const;
 
     /**
      * Get the number of missing changes up to a certain sequence number.

--- a/include/fastrtps/rtps/reader/WriterProxy.h
+++ b/include/fastrtps/rtps/reader/WriterProxy.h
@@ -222,6 +222,12 @@ public:
      */
     void perform_initial_ack_nack(RTPSMessageGroup_t& buffer) const;
 
+    /**
+     * Sends the necessary acknac and nackfrag messages to answer the last received heartbeat message.
+     * @param buffer Message buffer to use for serialization.
+     */
+    void perform_heartbeat_response(RTPSMessageGroup_t& buffer) const;
+
     inline void liveliness_expired()
     {
         mp_writerProxyLiveliness = nullptr;

--- a/include/fastrtps/rtps/reader/timedevent/HeartbeatResponseDelay.h
+++ b/include/fastrtps/rtps/reader/timedevent/HeartbeatResponseDelay.h
@@ -19,57 +19,56 @@
 
 #ifndef HEARTBEATRESPONSEDELAY_H_
 #define HEARTBEATRESPONSEDELAY_H_
+
 #ifndef DOXYGEN_SHOULD_SKIP_THIS_PUBLIC
-#include "../../resources/TimedEvent.h"
-#include "../../common/CDRMessage_t.h"
-#include "../../messages/RTPSMessageGroup.h"
+
+#include <fastrtps/rtps/resources/TimedEvent.h>
+#include <fastrtps/rtps/messages/RTPSMessageGroup.h>
 
 namespace eprosima {
 namespace fastrtps{
 namespace rtps {
 
-class StatefulReader;
 class WriterProxy;
 
 /**
  * Class HeartbeatResponseDelay, TimedEvent used to delay the response to a specific HB.
  * @ingroup READER_MODULE
  */
-class HeartbeatResponseDelay:public TimedEvent
-    {
-        public:
-            virtual ~HeartbeatResponseDelay();
+class HeartbeatResponseDelay : public TimedEvent
+{
+    public:
+        
+        virtual ~HeartbeatResponseDelay();
 
-            /**
-             * @param p_WP
-             * @param interval
-             */
-            HeartbeatResponseDelay(
-                    WriterProxy* p_WP,
-                    double interval);
+        /**
+         * Constructs a HeartbeatResponseDelay event object
+         * @param writer_proxy  Pointer to the writer proxy creating this event.
+         * @param interval      Interval in milliseconds of this event.
+         */
+        HeartbeatResponseDelay(
+                WriterProxy* writer_proxy,
+                double interval);
 
-            /**
-             * Method invoked when the event occurs
-             *
-             * @param code Code representing the status of the event
-             * @param msg Message associated to the event
-             */
-            void event(
-                    EventCode code,
-                    const char* msg= nullptr);
+        /**
+         * Method invoked when the event occurs
+         *
+         * @param code Code representing the status of the event
+         * @param msg Message associated to the event
+         */
+        void event(
+                EventCode code,
+                const char* msg= nullptr);
 
-            //!Pointer to the WriterProxy associated with this specific event.
-            WriterProxy* mp_WP;
-            //!CDRMessage_t used in the response.
-            RTPSMessageGroup_t m_cdrmessages;
-            //!List of destination locators
-            LocatorList_t m_destination_locators;
-            //!List of destination endpoints
-            std::vector<GUID_t> m_remote_endpoints;
+        //! Message buffer used in the response.
+        RTPSMessageGroup_t message_buffer_;
+        //! Pointer to the WriterProxy associated with this specific event.
+        WriterProxy* writer_proxy_;
+};
 
-    };
-}
 } /* namespace rtps */
+} /* namespace fastrtps */
 } /* namespace eprosima */
+
 #endif
 #endif /* HEARTBEATRESPONSEDELAY_H_ */

--- a/include/fastrtps/rtps/reader/timedevent/HeartbeatResponseDelay.h
+++ b/include/fastrtps/rtps/reader/timedevent/HeartbeatResponseDelay.h
@@ -30,6 +30,7 @@ namespace fastrtps{
 namespace rtps {
 
 class WriterProxy;
+class RTPSParticipantImpl;
 
 /**
  * Class HeartbeatResponseDelay, TimedEvent used to delay the response to a specific HB.
@@ -43,12 +44,12 @@ class HeartbeatResponseDelay : public TimedEvent
 
         /**
          * Constructs a HeartbeatResponseDelay event object
-         * @param writer_proxy  Pointer to the writer proxy creating this event.
-         * @param interval      Interval in milliseconds of this event.
+         * @param participant   Pointer to the participant creating this event.
+         * @param writer_proxy  Pointer to the writer this event should be associated to.
          */
         HeartbeatResponseDelay(
-                WriterProxy* writer_proxy,
-                double interval);
+                RTPSParticipantImpl* participant,
+                WriterProxy* writer_proxy);
 
         /**
          * Method invoked when the event occurs

--- a/include/fastrtps/rtps/reader/timedevent/InitialAckNack.h
+++ b/include/fastrtps/rtps/reader/timedevent/InitialAckNack.h
@@ -30,6 +30,7 @@ namespace fastrtps {
 namespace rtps {
 
 class WriterProxy;
+class RTPSParticipantImpl;
 
 /**
  * InitialAckNack class, controls the initial send operation of AckNack.
@@ -41,12 +42,12 @@ class InitialAckNack : public TimedEvent
 
         /**
          * Constructs a InitialAckNack event object
-         * @param writer_proxy  Pointer to the writer proxy creating this event.
-         * @param interval      Interval in milliseconds of this event.
+         * @param participant   Pointer to the participant creating this event.
+         * @param writer_proxy  Pointer to the writer this event should be associated to.
          */
         InitialAckNack(
-                WriterProxy* writer_proxy,
-                double interval);
+                RTPSParticipantImpl* participant,
+                WriterProxy* writer_proxy);
 
         virtual ~InitialAckNack();
 

--- a/include/fastrtps/rtps/reader/timedevent/InitialAckNack.h
+++ b/include/fastrtps/rtps/reader/timedevent/InitialAckNack.h
@@ -19,36 +19,33 @@
 
 #ifndef INITIALACKNACK_H_
 #define INITIALACKNACK_H_
+
 #ifndef DOXYGEN_SHOULD_SKIP_THIS_PUBLIC
+
 #include <fastrtps/rtps/resources/TimedEvent.h>
-#include <fastrtps/rtps/common/CDRMessage_t.h>
-#include <fastrtps/rtps/common/Guid.h>
 #include <fastrtps/rtps/messages/RTPSMessageGroup.h>
 
 namespace eprosima {
-namespace fastrtps{
-namespace rtps{
+namespace fastrtps {
+namespace rtps {
 
-class RTPSParticipantImpl;
-class StatefulReader;
 class WriterProxy;
-
 
 /**
  * InitialAckNack class, controls the initial send operation of AckNack.
  * @ingroup WRITER_MODULE
  */
-class InitialAckNack: public TimedEvent
+class InitialAckNack : public TimedEvent
 {
     public:
 
         /**
-         *
-         * @param p_RP
-         * @param interval
+         * Constructs a InitialAckNack event object
+         * @param writer_proxy  Pointer to the writer proxy creating this event.
+         * @param interval      Interval in milliseconds of this event.
          */
         InitialAckNack(
-                WriterProxy* wp,
+                WriterProxy* writer_proxy,
                 double interval);
 
         virtual ~InitialAckNack();
@@ -64,17 +61,14 @@ class InitialAckNack: public TimedEvent
                 const char* msg= nullptr);
 
         //!
-        RTPSMessageGroup_t m_cdrmessages;
+        RTPSMessageGroup_t message_buffer_;
         //!
-        WriterProxy* wp_;
-        //!List of destination locators
-        LocatorList_t m_destination_locators;
-        //!List of destination endpoints
-        std::vector<GUID_t> m_remote_endpoints;
+        WriterProxy* writer_proxy_;
 };
 
-}
-}
+} /* namespace rtps */
+} /* namespace fastrtps */
 } /* namespace eprosima */
+
 #endif
 #endif /* INITIALACKNACK_H_ */

--- a/include/fastrtps/rtps/reader/timedevent/WriterProxyLiveliness.h
+++ b/include/fastrtps/rtps/reader/timedevent/WriterProxyLiveliness.h
@@ -32,22 +32,26 @@ class StatefulReader;
  * Class WriterProxyLiveliness, timed event to check the liveliness of a writer each leaseDuration.
  *  @ingroup READER_MODULE
  */
-class WriterProxyLiveliness: public TimedEvent 
+class WriterProxyLiveliness : public TimedEvent 
 {
 public:
 
 	/**
      * Construct a WriterProxyLiveliness event object.
 	 * @param reader StatefulReader creating this event.
-     * @param writer_guid GUID of the writer proxy for which this event is created.
-	 * @param interval Time in milliseconds to consider the writer as dead.
 	 */
-	WriterProxyLiveliness(
-            StatefulReader* reader,
-            const GUID_t& writer_guid,
-            double interval);
+    WriterProxyLiveliness(StatefulReader* reader);
 
 	virtual ~WriterProxyLiveliness();
+
+    /**
+     * Starts this event for the specified writer.
+     * @param writer_guid GUID of the writer proxy for which the liveliness should be checked.
+     * @param interval Duration of the liveliness period.
+     */
+    void start(
+            const GUID_t& writer_guid,
+            const Duration_t& interval);
 
 	/**
 	 * Method invoked when the event occurs

--- a/include/fastrtps/rtps/reader/timedevent/WriterProxyLiveliness.h
+++ b/include/fastrtps/rtps/reader/timedevent/WriterProxyLiveliness.h
@@ -17,40 +17,59 @@
  *
  */
 
-#ifndef WRITERPROXYLIVELINESS_H_
-#define WRITERPROXYLIVELINESS_H_
+#ifndef FASTRTPS_RTPS_READER_TIMEDEVENT_WRITERPROXYLIVELINESS_H_
+#define FASTRTPS_RTPS_READER_TIMEDEVENT_WRITERPROXYLIVELINESS_H_
 #ifndef DOXYGEN_SHOULD_SKIP_THIS_PUBLIC
 #include "../../resources/TimedEvent.h"
+#include "../../common/Guid.h"
 
 namespace eprosima {
 namespace fastrtps{
 namespace rtps {
 
-class WriterProxy;
+class StatefulReader;
 /**
  * Class WriterProxyLiveliness, timed event to check the liveliness of a writer each leaseDuration.
  *  @ingroup READER_MODULE
  */
-class WriterProxyLiveliness: public TimedEvent {
+class WriterProxyLiveliness: public TimedEvent 
+{
 public:
+
 	/**
-	* @param wp
-	* @param interval
-	*/
-	WriterProxyLiveliness(WriterProxy* wp,double interval);
+     * Construct a WriterProxyLiveliness event object.
+	 * @param reader StatefulReader creating this event.
+     * @param writer_guid GUID of the writer proxy for which this event is created.
+	 * @param interval Time in milliseconds to consider the writer as dead.
+	 */
+	WriterProxyLiveliness(
+            StatefulReader* reader,
+            const GUID_t& writer_guid,
+            double interval);
+
 	virtual ~WriterProxyLiveliness();
+
 	/**
-	* Method invoked when the event occurs
-	*
-	* @param code Code representing the status of the event
-	* @param msg Message associated to the event
-	*/
-	void event(EventCode code, const char* msg= nullptr);
-	//!Pointer to the WriterProxy associated with this specific event.
-	WriterProxy* mp_WP;
+	 * Method invoked when the event occurs
+	 *
+	 * @param code Code representing the status of the event
+	 * @param msg Message associated to the event
+	 */
+	void event(
+            EventCode code, 
+            const char* msg = nullptr);
+
+private:
+
+	//!Pointer to the StatefulReader associated with this specific event.
+    StatefulReader* reader_;
+    //! GUID of the writer proxy associated with this specific event.
+    GUID_t writer_guid_;
 };
-}
+
 } /* namespace rtps */
+} /* namespace fastrtps */
 } /* namespace eprosima */
+
 #endif
-#endif /* WRITERPROXYLIVELINESS_H_ */
+#endif /* FASTRTPS_RTPS_READER_TIMEDEVENT_WRITERPROXYLIVELINESS_H_ */

--- a/include/fastrtps/xmlparser/XMLParserCommon.h
+++ b/include/fastrtps/xmlparser/XMLParserCommon.h
@@ -110,6 +110,7 @@ extern const char* HIST_MEM_POLICY;
 extern const char* USER_DEF_ID;
 extern const char* ENTITY_ID;
 extern const char* MATCHED_SUBSCRIBERS_ALLOCATION;
+extern const char* MATCHED_PUBLISHERS_ALLOCATION;
 
 ///
 extern const char* PROPERTIES;

--- a/resources/xsd/fastRTPS_profiles.xsd
+++ b/resources/xsd/fastRTPS_profiles.xsd
@@ -617,6 +617,7 @@
             <xs:element name="propertiesPolicy" type="propertyPolicyType" minOccurs="0"/>
             <xs:element name="userDefinedID" type="int16Type" minOccurs="0"/>
             <xs:element name="entityID" type="int16Type" minOccurs="0"/>
+            <xs:element name="matchedPublishersAllocation" type="containerAllocationConfigType" minOccurs="0"/>
         </xs:all>
         <xs:attribute name="profile_name" type="stringType" use="required"/>
     </xs:complexType>

--- a/src/cpp/CMakeLists.txt
+++ b/src/cpp/CMakeLists.txt
@@ -288,7 +288,7 @@ elseif(NOT EPROSIMA_INSTALLER)
     endif()
 
     # Link library to external libraries.
-    target_link_libraries(${PROJECT_NAME} ${PRIVACY} fastcdr
+    target_link_libraries(${PROJECT_NAME} ${PRIVACY} fastcdr foonathan_memory
         ${CMAKE_THREAD_LIBS_INIT} ${CMAKE_DL_LIBS}
         ${TINYXML2_LIBRARY}
         $<$<BOOL:${LINK_SSL}>:OpenSSL::SSL$<SEMICOLON>OpenSSL::Crypto>

--- a/src/cpp/participant/ParticipantImpl.cpp
+++ b/src/cpp/participant/ParticipantImpl.cpp
@@ -301,6 +301,7 @@ Subscriber* ParticipantImpl::createSubscriber(
     if(att.getUserDefinedID()>0)
         ratt.endpoint.setUserDefinedID((uint8_t)att.getUserDefinedID());
     ratt.times = att.times;
+    ratt.matched_writers_allocation = att.matched_publisher_allocation;
 
     // TODO(Ricardo) Remove in future
     // Insert topic_name and partitions

--- a/src/cpp/rtps/builtin/discovery/participant/PDPSimple.cpp
+++ b/src/cpp/rtps/builtin/discovery/participant/PDPSimple.cpp
@@ -941,7 +941,7 @@ void PDPSimple::assertRemoteWritersLiveliness(GuidPrefix_t& guidP,LivelinessQosP
                             WriterProxy* WP;
                             if(sfr->matched_writer_lookup((*wit)->guid(), &WP))
                             {
-                                WP->assertLiveliness();
+                                WP->assert_liveliness();
                                 continue;
                             }
                         }

--- a/src/cpp/rtps/messages/RTPSMessageGroup.cpp
+++ b/src/cpp/rtps/messages/RTPSMessageGroup.cpp
@@ -685,7 +685,7 @@ bool RTPSMessageGroup::add_gap(std::set<SequenceNumber_t>& changesSeqNum,
     return true;
 }
 
-bool RTPSMessageGroup::add_acknack(const std::vector<GUID_t>& remote_writers, SequenceNumberSet_t& SNSet,
+bool RTPSMessageGroup::add_acknack(const std::vector<GUID_t>& remote_writers, const SequenceNumberSet_t& SNSet,
         int32_t count, bool finalFlag, const LocatorList_t& locators)
 {
     // A vector is used to avoid dynamic allocations, but only first item is used

--- a/src/cpp/rtps/messages/submessages/AckNackMsg.hpp
+++ b/src/cpp/rtps/messages/submessages/AckNackMsg.hpp
@@ -24,7 +24,7 @@ namespace rtps{
 bool RTPSMessageCreator::addMessageAcknack(CDRMessage_t* msg,const GuidPrefix_t& guidprefix,
         const GuidPrefix_t& remoteGuidPrefix,
         const EntityId_t& readerId,const EntityId_t& writerId,
-        SequenceNumberSet_t& SNSet,int32_t count,bool finalFlag){
+        const SequenceNumberSet_t& SNSet,int32_t count,bool finalFlag){
     try
     {
         RTPSMessageCreator::addHeader(msg,guidprefix);
@@ -42,7 +42,7 @@ bool RTPSMessageCreator::addMessageAcknack(CDRMessage_t* msg,const GuidPrefix_t&
 
 bool RTPSMessageCreator::addSubmessageAcknack(CDRMessage_t* msg,
         const EntityId_t& readerId,const EntityId_t& writerId,
-        SequenceNumberSet_t& SNSet,int32_t count,bool finalFlag)
+        const SequenceNumberSet_t& SNSet,int32_t count,bool finalFlag)
 {
     CDRMessage_t& submsgElem = g_pool_submsg.reserve_CDRMsg();
     CDRMessage::initCDRMsg(&submsgElem);

--- a/src/cpp/rtps/persistence/PersistenceService.h
+++ b/src/cpp/rtps/persistence/PersistenceService.h
@@ -23,8 +23,10 @@
 #include <fastrtps/rtps/common/CacheChange.h>
 #include <fastrtps/rtps/attributes/PropertyPolicy.h>
 
-#include <map>
+#include <foonathan/memory/container.hpp>
+#include <foonathan/memory/memory_pool.hpp>
 
+#include <map>
 
 namespace eprosima {
 namespace fastrtps {
@@ -39,6 +41,9 @@ class CacheChangePool;
 class IPersistenceService
 {
 public:
+    using map_allocator_t = 
+        foonathan::memory::memory_pool<foonathan::memory::node_pool, foonathan::memory::heap_allocator>;
+
     virtual ~IPersistenceService() = default;
 
     /**
@@ -47,28 +52,38 @@ public:
      * @param part_id ID of the RTPSParticipant the writer belongs to.
      * @return True if operation was successful.
      */
-    virtual bool load_writer_from_storage(const std::string& persistence_guid, const GUID_t& writer_guid, std::vector<CacheChange_t*>& changes, CacheChangePool* pool) = 0;
+    virtual bool load_writer_from_storage(
+            const std::string& persistence_guid,
+            const GUID_t& writer_guid,
+            std::vector<CacheChange_t*>& changes,
+            CacheChangePool* pool) = 0;
 
     /**
      * Add a change to storage.
      * @param change The cache change to add.
      * @return True if operation was successful.
      */
-    virtual bool add_writer_change_to_storage(const std::string& persistence_guid, const CacheChange_t& change) = 0;
+    virtual bool add_writer_change_to_storage(
+            const std::string& persistence_guid,
+            const CacheChange_t& change) = 0;
 
     /**
      * Remove a change from storage.
      * @param change The cache change to remove.
      * @return True if operation was successful.
      */
-    virtual bool remove_writer_change_from_storage(const std::string& persistence_guid, const CacheChange_t& change) = 0;
+    virtual bool remove_writer_change_from_storage(
+            const std::string& persistence_guid, 
+            const CacheChange_t& change) = 0;
 
     /**
      * Get all data stored for a reader.
      * @param reader_guid GUID of the reader to load.
      * @return True if operation was successful.
      */
-    virtual bool load_reader_from_storage(const std::string& reader_guid, std::map<GUID_t, SequenceNumber_t>& seq_map) = 0;
+    virtual bool load_reader_from_storage(
+            const std::string& reader_guid, 
+            foonathan::memory::map<GUID_t, SequenceNumber_t, map_allocator_t>& seq_map) = 0;
 
     /**
      * Update the sequence number associated to a writer on a reader.
@@ -77,7 +92,10 @@ public:
      * @param seq_number New sequence number value to set for the associated writer.
      * @return True if operation was successful.
      */
-    virtual bool update_writer_seq_on_storage(const std::string& reader_guid, const GUID_t& writer_guid, const SequenceNumber_t& seq_number) = 0;
+    virtual bool update_writer_seq_on_storage(
+            const std::string& reader_guid,
+            const GUID_t& writer_guid,
+            const SequenceNumber_t& seq_number) = 0;
 
 };
 

--- a/src/cpp/rtps/persistence/SQLite3PersistenceService.cpp
+++ b/src/cpp/rtps/persistence/SQLite3PersistenceService.cpp
@@ -126,7 +126,11 @@ SQLite3PersistenceService::~SQLite3PersistenceService()
 * @param writer_guid GUID of the writer to load.
 * @return True if operation was successful.
 */
-bool SQLite3PersistenceService::load_writer_from_storage(const std::string& persistence_guid, const GUID_t& writer_guid, std::vector<CacheChange_t*>& changes, CacheChangePool* pool)
+bool SQLite3PersistenceService::load_writer_from_storage(
+        const std::string& persistence_guid,
+        const GUID_t& writer_guid,
+        std::vector<CacheChange_t*>& changes,
+        CacheChangePool* pool)
 {
     logInfo(RTPS_PERSISTENCE, "Loading writer " << writer_guid);
 
@@ -165,7 +169,9 @@ bool SQLite3PersistenceService::load_writer_from_storage(const std::string& pers
 * @param change The cache change to add.
 * @return True if operation was successful.
 */
-bool SQLite3PersistenceService::add_writer_change_to_storage(const std::string& persistence_guid, const CacheChange_t& change)
+bool SQLite3PersistenceService::add_writer_change_to_storage(
+        const std::string& persistence_guid,
+        const CacheChange_t& change)
 {
     logInfo(RTPS_PERSISTENCE, "Writer " << change.writerGUID << " storing change for seq " << change.sequenceNumber);
 
@@ -194,7 +200,9 @@ bool SQLite3PersistenceService::add_writer_change_to_storage(const std::string& 
 * @param change The cache change to remove.
 * @return True if operation was successful.
 */
-bool SQLite3PersistenceService::remove_writer_change_from_storage(const std::string& persistence_guid, const CacheChange_t& change)
+bool SQLite3PersistenceService::remove_writer_change_from_storage(
+        const std::string& persistence_guid,
+        const CacheChange_t& change)
 {
     logInfo(RTPS_PERSISTENCE, "Writer " << change.writerGUID << " removing change for seq " << change.sequenceNumber);
 
@@ -214,7 +222,9 @@ bool SQLite3PersistenceService::remove_writer_change_from_storage(const std::str
 * @param reader_guid GUID of the reader to load.
 * @return True if operation was successful.
 */
-bool SQLite3PersistenceService::load_reader_from_storage(const std::string& reader_guid, std::map<GUID_t, SequenceNumber_t>& seq_map)
+bool SQLite3PersistenceService::load_reader_from_storage(
+        const std::string& reader_guid,
+        foonathan::memory::map<GUID_t, SequenceNumber_t, IPersistenceService::map_allocator_t>& seq_map)
 {
     logInfo(RTPS_PERSISTENCE, "Loading reader " << reader_guid);
 
@@ -244,7 +254,10 @@ bool SQLite3PersistenceService::load_reader_from_storage(const std::string& read
 * @param seq_number New sequence number value to set for the associated writer.
 * @return True if operation was successful.
 */
-bool SQLite3PersistenceService::update_writer_seq_on_storage(const std::string& reader_guid, const GUID_t& writer_guid, const SequenceNumber_t& seq_number) 
+bool SQLite3PersistenceService::update_writer_seq_on_storage(
+        const std::string& reader_guid,
+        const GUID_t& writer_guid,
+        const SequenceNumber_t& seq_number) 
 {
     logInfo(RTPS_PERSISTENCE, "Reader " << reader_guid << " setting seq for writer " << writer_guid << " to " << seq_number);
 
@@ -264,5 +277,3 @@ bool SQLite3PersistenceService::update_writer_seq_on_storage(const std::string& 
 } /* namespace rtps */
 } /* namespace fastrtps */
 } /* namespace eprosima */
-
-

--- a/src/cpp/rtps/persistence/SQLite3PersistenceService.h
+++ b/src/cpp/rtps/persistence/SQLite3PersistenceService.h
@@ -48,28 +48,38 @@ public:
      * @param writer_guid GUID of the writer to load.
      * @return True if operation was successful.
      */
-    virtual bool load_writer_from_storage(const std::string& persistence_guid, const GUID_t& writer_guid, std::vector<CacheChange_t*>& changes, CacheChangePool* pool) final;
+    virtual bool load_writer_from_storage(
+            const std::string& persistence_guid,
+            const GUID_t& writer_guid,
+            std::vector<CacheChange_t*>& changes,
+            CacheChangePool* pool) final;
 
     /**
      * Add a change to storage.
      * @param change The cache change to add.
      * @return True if operation was successful.
      */
-    virtual bool add_writer_change_to_storage(const std::string& persistence_guid, const CacheChange_t& change) final;
+    virtual bool add_writer_change_to_storage(
+            const std::string& persistence_guid,
+            const CacheChange_t& change) final;
 
     /**
      * Remove a change from storage.
      * @param change The cache change to remove.
      * @return True if operation was successful.
      */
-    virtual bool remove_writer_change_from_storage(const std::string& persistence_guid, const CacheChange_t& change) final;
+    virtual bool remove_writer_change_from_storage(
+            const std::string& persistence_guid,
+            const CacheChange_t& change) final;
 
     /**
      * Get all data stored for a reader.
      * @param reader_guid GUID of the reader to load.
      * @return True if operation was successful.
      */
-    virtual bool load_reader_from_storage(const std::string& reader_guid, std::map<GUID_t, SequenceNumber_t>& seq_map) final;
+    virtual bool load_reader_from_storage(
+            const std::string& reader_guid,
+            foonathan::memory::map<GUID_t, SequenceNumber_t, map_allocator_t>& seq_map) final;
 
     /**
      * Update the sequence number associated to a writer on a reader.
@@ -78,7 +88,10 @@ public:
      * @param seq_number New sequence number value to set for the associated writer.
      * @return True if operation was successful.
      */
-    virtual bool update_writer_seq_on_storage(const std::string& reader_guid, const GUID_t& writer_guid, const SequenceNumber_t& seq_number) final;
+    virtual bool update_writer_seq_on_storage(
+            const std::string& reader_guid,
+            const GUID_t& writer_guid,
+            const SequenceNumber_t& seq_number) final;
 
 private:
     sqlite3* db_;

--- a/src/cpp/rtps/reader/RTPSReader.cpp
+++ b/src/cpp/rtps/reader/RTPSReader.cpp
@@ -30,21 +30,25 @@ namespace eprosima {
 namespace fastrtps{
 namespace rtps {
 
-RTPSReader::RTPSReader(RTPSParticipantImpl*pimpl,GUID_t& guid,
-        ReaderAttributes& att,ReaderHistory* hist,ReaderListener* rlisten):
-    Endpoint(pimpl,guid,att.endpoint),
-    mp_history(hist),
-    mp_listener(rlisten),
-    m_acceptMessagesToUnknownReaders(true),
-    m_acceptMessagesFromUnkownWriters(true),
-    m_expectsInlineQos(att.expectsInlineQos),
-    fragmentedChangePitStop_(nullptr)
-    {
-        mp_history->mp_reader = this;
-        mp_history->mp_mutex = mp_mutex;
-        fragmentedChangePitStop_ = new FragmentedChangePitStop(this);
-        logInfo(RTPS_READER,"RTPSReader created correctly");
-    }
+RTPSReader::RTPSReader(
+        RTPSParticipantImpl* pimpl,
+        const GUID_t& guid,
+        const ReaderAttributes& att,
+        ReaderHistory* hist,
+        ReaderListener* rlisten)
+    : Endpoint(pimpl,guid,att.endpoint)
+    , mp_history(hist)
+    , mp_listener(rlisten)
+    , m_acceptMessagesToUnknownReaders(true)
+    , m_acceptMessagesFromUnkownWriters(true)
+    , m_expectsInlineQos(att.expectsInlineQos)
+    , fragmentedChangePitStop_(nullptr)
+{
+    mp_history->mp_reader = this;
+    mp_history->mp_mutex = mp_mutex;
+    fragmentedChangePitStop_ = new FragmentedChangePitStop(this);
+    logInfo(RTPS_READER,"RTPSReader created correctly");
+}
 
 RTPSReader::~RTPSReader()
 {
@@ -54,7 +58,7 @@ RTPSReader::~RTPSReader()
     mp_history->mp_mutex = nullptr;
 }
 
-bool RTPSReader::acceptMsgDirectedTo(EntityId_t& entityId)
+bool RTPSReader::acceptMsgDirectedTo(const EntityId_t& entityId) const
 {
     if(entityId == m_guid.entityId)
         return true;
@@ -64,7 +68,9 @@ bool RTPSReader::acceptMsgDirectedTo(EntityId_t& entityId)
         return false;
 }
 
-bool RTPSReader::reserveCache(CacheChange_t** change, uint32_t dataCdrSerializedSize)
+bool RTPSReader::reserveCache(
+        CacheChange_t** change, 
+        uint32_t dataCdrSerializedSize)
 {
     return mp_history->reserve_Cache(change, dataCdrSerializedSize);
 }
@@ -74,7 +80,7 @@ void RTPSReader::releaseCache(CacheChange_t* change)
     return mp_history->release_Cache(change);
 }
 
-ReaderListener* RTPSReader::getListener()
+ReaderListener* RTPSReader::getListener() const
 {
     return mp_listener;
 }
@@ -85,8 +91,9 @@ bool RTPSReader::setListener(ReaderListener *target)
     return true;
 }
 
-CacheChange_t* RTPSReader::findCacheInFragmentedCachePitStop(const SequenceNumber_t& sequence_number,
-        const GUID_t& writer_guid)
+CacheChange_t* RTPSReader::findCacheInFragmentedCachePitStop(
+        const SequenceNumber_t& sequence_number,
+        const GUID_t& writer_guid) const
 {
     return fragmentedChangePitStop_->find(sequence_number, writer_guid);
 }
@@ -112,7 +119,9 @@ void RTPSReader::remove_persistence_guid(const RemoteWriterAttributes& wdata)
     }
 }
 
-SequenceNumber_t RTPSReader::update_last_notified(const GUID_t& guid, const SequenceNumber_t& seq)
+SequenceNumber_t RTPSReader::update_last_notified(
+        const GUID_t& guid, 
+        const SequenceNumber_t& seq)
 {
     SequenceNumber_t ret_val;
     std::lock_guard<std::recursive_mutex> guard(*mp_mutex);
@@ -157,11 +166,13 @@ SequenceNumber_t RTPSReader::get_last_notified(const GUID_t& guid) const
     return ret_val;
 }
 
-void RTPSReader::set_last_notified(const GUID_t& peristence_guid, const SequenceNumber_t& seq)
+void RTPSReader::set_last_notified(
+        const GUID_t& peristence_guid, 
+        const SequenceNumber_t& seq)
 {
     history_record_[peristence_guid] = seq;
 }
 
-}
 } /* namespace rtps */
+} /* namespace fastrtps */
 } /* namespace eprosima */

--- a/src/cpp/rtps/reader/StatefulReader.cpp
+++ b/src/cpp/rtps/reader/StatefulReader.cpp
@@ -699,3 +699,28 @@ bool StatefulReader::isInCleanState() const
 
     return cleanState;
 }
+
+void StatefulReader::send_acknack(
+        const SequenceNumberSet_t& sns,
+        RTPSMessageGroup_t& buffer,
+        const LocatorList_t& locators,
+        const std::vector<GUID_t>& guids,
+        bool is_final)
+{
+
+    Count_t acknackCount = 0;
+
+    {//BEGIN PROTECTION
+        std::lock_guard<std::recursive_mutex> guard_reader(*mp_mutex);
+        m_acknackCount++;
+        acknackCount = m_acknackCount;
+    }
+
+
+    logInfo(RTPS_READER, "Sending ACKNACK: " << sns);
+
+    RTPSMessageGroup group(getRTPSParticipant(), this, RTPSMessageGroup::READER, buffer, locators, guids);
+
+    group.add_acknack(guids, sns, acknackCount, is_final, locators);
+
+}

--- a/src/cpp/rtps/reader/StatefulReader.cpp
+++ b/src/cpp/rtps/reader/StatefulReader.cpp
@@ -83,7 +83,8 @@ bool StatefulReader::matched_writer_add(const RemoteWriterAttributes& wdata)
 
     att.endpoint.unicastLocatorList =
         mp_RTPSParticipant->network_factory().ShrinkLocatorLists({att.endpoint.unicastLocatorList});
-    WriterProxy* wp = new WriterProxy(att, this);
+    WriterProxy* wp = new WriterProxy(this);
+    wp->start(att);
 
     add_persistence_guid(att);
     wp->loaded_from_storage_nts(get_last_notified(att.guid));
@@ -116,6 +117,7 @@ bool StatefulReader::matched_writer_remove(const RemoteWriterAttributes& wdata)
 
     if(wproxy != nullptr)
     {
+        wproxy->stop();
         delete wproxy;
         return true;
     }
@@ -147,6 +149,7 @@ bool StatefulReader::liveliness_expired(const GUID_t& writer_guid)
 			}
 
             wproxy->liveliness_expired();
+            wproxy->stop();
 			delete(wproxy);
             return true;
         }

--- a/src/cpp/rtps/reader/WriterProxy.cpp
+++ b/src/cpp/rtps/reader/WriterProxy.cpp
@@ -186,8 +186,6 @@ void WriterProxy::missing_changes_update(const SequenceNumber_t& seq_num)
                     ChangeFromWriterStatus_t::UNKNOWN, ChangeFromWriterStatus_t::MISSING);
         }
     }
-
-    //print_changes_fromWriter_test2();
 }
 
 bool WriterProxy::maybe_add_changes_from_writer_up_to(
@@ -247,8 +245,6 @@ void WriterProxy::lost_changes_update(const SequenceNumber_t& seq_num)
             cleanup();
         }
     }
-
-    //print_changes_fromWriter_test2();
 }
 
 bool WriterProxy::received_change_set(const SequenceNumber_t& seq_num)
@@ -328,7 +324,6 @@ bool WriterProxy::received_change_set(
         }
     }
 
-    //print_changes_fromWriter_test2();
     return true;
 }
 
@@ -348,8 +343,6 @@ const std::vector<ChangeFromWriter_t> WriterProxy::missing_changes() const
         }
     }
 
-
-    //print_changes_fromWriter_test2();
     return returnedValue;
 }
 
@@ -370,20 +363,6 @@ const SequenceNumber_t WriterProxy::available_changes_max() const
 {
     std::lock_guard<std::recursive_mutex> guard(mutex_);
     return changes_from_writer_low_mark_;
-}
-
-void WriterProxy::print_changes_fromWriter_test2()
-{
-    std::stringstream sstream;
-    sstream << this->attributes_.guid.entityId<<": ";
-
-    for(auto it = changes_from_writer_.begin(); it != changes_from_writer_.end(); ++it)
-    {
-        sstream << it->getSequenceNumber() <<"("<<it->isRelevant()<<","<<it->getStatus()<<")-";
-    }
-
-    std::string auxstr = sstream.str();
-    logInfo(RTPS_READER,auxstr;);
 }
 
 void WriterProxy::assert_liveliness()

--- a/src/cpp/rtps/reader/WriterProxy.cpp
+++ b/src/cpp/rtps/reader/WriterProxy.cpp
@@ -125,7 +125,8 @@ WriterProxy::WriterProxy(
     //Create Events
     mp_writerProxyLiveliness =
         new WriterProxyLiveliness(
-            this,
+            reader,
+            m_att.guid,
             TimeConv::Time_t2MilliSecondsDouble(m_att.livelinessLeaseDuration));
     mp_heartbeatResponse =
         new HeartbeatResponseDelay(

--- a/src/cpp/rtps/reader/WriterProxy.cpp
+++ b/src/cpp/rtps/reader/WriterProxy.cpp
@@ -49,11 +49,8 @@ void WriterProxy::for_each_set_status_from(
     {
         if(it->getStatus() == status)
         {
-            ChangeFromWriter_t newch(*it);
-            newch.setStatus(new_status);
-
-            auto hint = changes_from_writer_.erase(it);
-            it = changes_from_writer_.insert(hint, newch);
+            ChangeFromWriter_t& ch = const_cast<ChangeFromWriter_t&>(*it);
+            ch.setStatus(new_status);
         }
 
         ++it;
@@ -74,11 +71,8 @@ void WriterProxy::for_each_set_status_from_and_maybe_remove(
         {
             if(it != changes_from_writer_.begin())
             {
-                ChangeFromWriter_t newch(*it);
-                newch.setStatus(new_status);
-
-                auto hint = changes_from_writer_.erase(it);
-                it = changes_from_writer_.insert(hint, newch);
+                ChangeFromWriter_t& ch = const_cast<ChangeFromWriter_t&>(*it);
+                ch.setStatus(new_status);
                 ++it;
                 continue;
             }
@@ -303,12 +297,9 @@ bool WriterProxy::received_change_set(
         {
             if(chit->getStatus() != RECEIVED)
             {
-                ChangeFromWriter_t newch(*chit);
-                newch.setStatus(RECEIVED);
-                newch.setRelevance(is_relevance);
-
-                auto hint = changes_from_writer_.erase(chit);
-                changes_from_writer_.insert(hint, newch);
+                ChangeFromWriter_t& ch = const_cast<ChangeFromWriter_t&>(*chit);
+                ch.setStatus(RECEIVED);
+                ch.setRelevance(is_relevance);
             }
             else
             {
@@ -402,11 +393,8 @@ void WriterProxy::change_removed_from_history(const SequenceNumber_t& seq_num)
     // Cannot be in the beginning because process of cleanup
     assert(chit != changes_from_writer_.begin());
 
-    ChangeFromWriter_t newch(*chit);
-    newch.notValid();
-
-    auto hint = changes_from_writer_.erase(chit);
-    changes_from_writer_.insert(hint, newch);
+    ChangeFromWriter_t& ch = const_cast<ChangeFromWriter_t&>(*chit);
+    ch.notValid();
 }
 
 void WriterProxy::cleanup()

--- a/src/cpp/rtps/reader/WriterProxy.cpp
+++ b/src/cpp/rtps/reader/WriterProxy.cpp
@@ -29,13 +29,16 @@
 #include <fastrtps/rtps/reader/timedevent/WriterProxyLiveliness.h>
 #include <fastrtps/rtps/reader/timedevent/InitialAckNack.h>
 
-using namespace eprosima::fastrtps::rtps;
+namespace eprosima {
+namespace fastrtps {
+namespace rtps {
 
 /*!
  * @brief Auxiliary function to change status in a range.
  */
-void WriterProxy::for_each_set_status_from(decltype(WriterProxy::m_changesFromW)::iterator first,
-        decltype(WriterProxy::m_changesFromW)::iterator last,
+void WriterProxy::for_each_set_status_from(
+        decltype(WriterProxy::changes_from_writer_)::iterator first,
+        decltype(WriterProxy::changes_from_writer_)::iterator last,
         ChangeFromWriterStatus_t status,
         ChangeFromWriterStatus_t new_status)
 {
@@ -47,34 +50,33 @@ void WriterProxy::for_each_set_status_from(decltype(WriterProxy::m_changesFromW)
             ChangeFromWriter_t newch(*it);
             newch.setStatus(new_status);
 
-            auto hint = m_changesFromW.erase(it);
-
-            it = m_changesFromW.insert(hint, newch);
+            auto hint = changes_from_writer_.erase(it);
+            it = changes_from_writer_.insert(hint, newch);
         }
 
         ++it;
     }
 }
 
-void WriterProxy::for_each_set_status_from_and_maybe_remove(decltype(WriterProxy::m_changesFromW)::iterator first,
-        decltype(WriterProxy::m_changesFromW)::iterator last,
+void WriterProxy::for_each_set_status_from_and_maybe_remove(
+        decltype(WriterProxy::changes_from_writer_)::iterator first,
+        decltype(WriterProxy::changes_from_writer_)::iterator last,
         ChangeFromWriterStatus_t status,
-        ChangeFromWriterStatus_t orstatus,
+        ChangeFromWriterStatus_t or_status,
         ChangeFromWriterStatus_t new_status)
 {
     auto it = first;
     while(it != last)
     {
-        if(it->getStatus() == status || it->getStatus() == orstatus)
+        if(it->getStatus() == status || it->getStatus() == or_status)
         {
-            if(it != m_changesFromW.begin())
+            if(it != changes_from_writer_.begin())
             {
                 ChangeFromWriter_t newch(*it);
                 newch.setStatus(new_status);
 
-                auto hint = m_changesFromW.erase(it);
-
-                it = m_changesFromW.insert(hint, newch);
+                auto hint = changes_from_writer_.erase(it);
+                it = changes_from_writer_.insert(hint, newch);
                 ++it;
                 continue;
             }
@@ -82,87 +84,100 @@ void WriterProxy::for_each_set_status_from_and_maybe_remove(decltype(WriterProxy
 
         // UNKNOWN or MISSING at the beginning or
         // LOST or RECEIVED at the beginning.
-        if(it == m_changesFromW.begin())
+        if(it == changes_from_writer_.begin())
         {
-            changesFromWLowMark_ = it->getSequenceNumber();
-            it = m_changesFromW.erase(it);
+            changes_from_writer_low_mark_ = it->getSequenceNumber();
+            it = changes_from_writer_.erase(it);
         }
     }
 }
 
-static const int WRITERPROXY_LIVELINESS_PERIOD_MULTIPLIER = 1;
-
-
 WriterProxy::~WriterProxy()
 {
-    if(mp_initialAcknack != nullptr)
+    if (mp_initialAcknack != nullptr)
+    {
         delete(mp_initialAcknack);
-    if(mp_writerProxyLiveliness!=nullptr)
+    }
+    if (mp_writerProxyLiveliness != nullptr)
+    {
         delete(mp_writerProxyLiveliness);
+    }
 
     delete(mp_heartbeatResponse);
-    delete(mp_mutex);
+    delete(mutex_);
 }
 
-WriterProxy::WriterProxy(const RemoteWriterAttributes& watt,
-        StatefulReader* SR) :
-    mp_SFR(SR),
-    m_att(watt),
+WriterProxy::WriterProxy(
+        const RemoteWriterAttributes& attributes,
+        StatefulReader* reader) :
+    mp_SFR(reader),
+    m_att(attributes),
     m_lastHeartbeatCount(0),
     mp_heartbeatResponse(nullptr),
     mp_writerProxyLiveliness(nullptr),
     mp_initialAcknack(nullptr),
     m_heartbeatFinalFlag(false),
-    m_isAlive(true),
-    mp_mutex(new std::recursive_mutex())
+    is_alive_(true),
+    mutex_(new std::recursive_mutex())
 
 {
-    m_changesFromW.clear();
+    changes_from_writer_.clear();
     //Create Events
-    mp_writerProxyLiveliness = new WriterProxyLiveliness(this,TimeConv::Time_t2MilliSecondsDouble(m_att.livelinessLeaseDuration)*WRITERPROXY_LIVELINESS_PERIOD_MULTIPLIER);
-    mp_heartbeatResponse = new HeartbeatResponseDelay(this,TimeConv::Time_t2MilliSecondsDouble(mp_SFR->getTimes().heartbeatResponseDelay));
-    mp_initialAcknack = new InitialAckNack(this, TimeConv::Time_t2MilliSecondsDouble(mp_SFR->getTimes().initialAcknackDelay));
-    if(m_att.livelinessLeaseDuration < c_TimeInfinite)
+    mp_writerProxyLiveliness =
+        new WriterProxyLiveliness(
+            this,
+            TimeConv::Time_t2MilliSecondsDouble(m_att.livelinessLeaseDuration));
+    mp_heartbeatResponse =
+        new HeartbeatResponseDelay(
+            this,
+            TimeConv::Time_t2MilliSecondsDouble(mp_SFR->getTimes().heartbeatResponseDelay));
+    mp_initialAcknack =
+        new InitialAckNack(
+            this,
+            TimeConv::Time_t2MilliSecondsDouble(mp_SFR->getTimes().initialAcknackDelay));
+    if (m_att.livelinessLeaseDuration < c_TimeInfinite)
+    {
         mp_writerProxyLiveliness->restart_timer();
+    }
     logInfo(RTPS_READER,"Writer Proxy created in reader: "<<mp_SFR->getGuid().entityId);
 }
 
-void WriterProxy::loaded_from_storage_nts(const SequenceNumber_t& seqNum)
+void WriterProxy::loaded_from_storage_nts(const SequenceNumber_t& seq_num)
 {
-    lastNotified_ = seqNum;
-    changesFromWLowMark_ = seqNum;
+    last_notified_ = seq_num;
+    changes_from_writer_low_mark_ = seq_num;
 }
 
-void WriterProxy::missing_changes_update(const SequenceNumber_t& seqNum)
+void WriterProxy::missing_changes_update(const SequenceNumber_t& seq_num)
 {
-    logInfo(RTPS_READER,m_att.guid.entityId<<": changes up to seqNum: " << seqNum <<" missing.");
-    std::lock_guard<std::recursive_mutex> guard(*mp_mutex);
+    logInfo(RTPS_READER,m_att.guid.entityId<<": changes up to seq_num: " << seq_num <<" missing.");
+    std::lock_guard<std::recursive_mutex> guard(*mutex_);
 
     // Check was not removed from container.
-    if(seqNum > changesFromWLowMark_)
+    if(seq_num > changes_from_writer_low_mark_)
     {
-        if(m_changesFromW.size() == 0 || m_changesFromW.rbegin()->getSequenceNumber() < seqNum)
+        if(changes_from_writer_.size() == 0 || changes_from_writer_.rbegin()->getSequenceNumber() < seq_num)
         {
             // Set already values in container.
-            for_each_set_status_from(m_changesFromW.begin(), m_changesFromW.end(),
+            for_each_set_status_from(changes_from_writer_.begin(), changes_from_writer_.end(),
                     ChangeFromWriterStatus_t::UNKNOWN, ChangeFromWriterStatus_t::MISSING);
 
             // Changes only already inserted values.
-            bool will_be_the_last = maybe_add_changes_from_writer_up_to(seqNum, ChangeFromWriterStatus_t::MISSING);
+            bool will_be_the_last = maybe_add_changes_from_writer_up_to(seq_num, ChangeFromWriterStatus_t::MISSING);
             (void)will_be_the_last;
             assert(will_be_the_last);
 
             // Add requetes sequence number.
-            ChangeFromWriter_t newch(seqNum);
+            ChangeFromWriter_t newch(seq_num);
             newch.setStatus(ChangeFromWriterStatus_t::MISSING);
-            m_changesFromW.insert(m_changesFromW.end(), newch);
+            changes_from_writer_.insert(changes_from_writer_.end(), newch);
         }
         else
         {
             // Find it. Must be there.
-            auto last_it = m_changesFromW.find(ChangeFromWriter_t(seqNum));
-            assert(last_it != m_changesFromW.end());
-            for_each_set_status_from(m_changesFromW.begin(), ++last_it,
+            auto last_it = changes_from_writer_.find(ChangeFromWriter_t(seq_num));
+            assert(last_it != changes_from_writer_.end());
+            for_each_set_status_from(changes_from_writer_.begin(), ++last_it,
                     ChangeFromWriterStatus_t::UNKNOWN, ChangeFromWriterStatus_t::MISSING);
         }
     }
@@ -170,15 +185,18 @@ void WriterProxy::missing_changes_update(const SequenceNumber_t& seqNum)
     //print_changes_fromWriter_test2();
 }
 
-bool WriterProxy::maybe_add_changes_from_writer_up_to(const SequenceNumber_t& sequence_number,
+bool WriterProxy::maybe_add_changes_from_writer_up_to(
+        const SequenceNumber_t& sequence_number,
         const ChangeFromWriterStatus_t default_status)
 {
     bool returnedValue = false;
     // Check if CacheChange_t is in the container or not.
-    SequenceNumber_t lastSeqNum = changesFromWLowMark_;
+    SequenceNumber_t lastSeqNum = changes_from_writer_low_mark_;
 
-    if(m_changesFromW.size() > 0)
-        lastSeqNum = m_changesFromW.rbegin()->getSequenceNumber();
+    if (changes_from_writer_.size() > 0)
+    {
+        lastSeqNum = changes_from_writer_.rbegin()->getSequenceNumber();
+    }
 
     if(sequence_number > lastSeqNum)
     {
@@ -190,34 +208,34 @@ bool WriterProxy::maybe_add_changes_from_writer_up_to(const SequenceNumber_t& se
         {
             ChangeFromWriter_t newch(lastSeqNum);
             newch.setStatus(default_status);
-            m_changesFromW.insert(m_changesFromW.end(), newch);
+            changes_from_writer_.insert(changes_from_writer_.end(), newch);
         }
     }
 
     return returnedValue;
 }
 
-void WriterProxy::lost_changes_update(const SequenceNumber_t& seqNum)
+void WriterProxy::lost_changes_update(const SequenceNumber_t& seq_num)
 {
-    logInfo(RTPS_READER,m_att.guid.entityId<<": up to seqNum: "<<seqNum);
-    std::lock_guard<std::recursive_mutex> guard(*mp_mutex);
+    logInfo(RTPS_READER,m_att.guid.entityId<<": up to seq_num: "<<seq_num);
+    std::lock_guard<std::recursive_mutex> guard(*mutex_);
 
     // Check was not removed from container.
-    if(seqNum > changesFromWLowMark_)
+    if(seq_num > changes_from_writer_low_mark_)
     {
-        if(m_changesFromW.size() == 0 || m_changesFromW.rbegin()->getSequenceNumber() < seqNum)
+        if(changes_from_writer_.size() == 0 || changes_from_writer_.rbegin()->getSequenceNumber() < seq_num)
         {
             // Remove all because lost or received.
-            m_changesFromW.clear();
+            changes_from_writer_.clear();
             // Any in container, then not insert new lost.
-            changesFromWLowMark_ = seqNum - 1;
+            changes_from_writer_low_mark_ = seq_num - 1;
         }
         else
         {
             // Find it. Must be there.
-            auto last_it = m_changesFromW.find(ChangeFromWriter_t(seqNum));
-            assert(last_it != m_changesFromW.end());
-            for_each_set_status_from_and_maybe_remove(m_changesFromW.begin(), last_it,
+            auto last_it = changes_from_writer_.find(ChangeFromWriter_t(seq_num));
+            assert(last_it != changes_from_writer_.end());
+            for_each_set_status_from_and_maybe_remove(changes_from_writer_.begin(), last_it,
                     ChangeFromWriterStatus_t::UNKNOWN, ChangeFromWriterStatus_t::MISSING,
                     ChangeFromWriterStatus_t::LOST);
             // Next could need to be removed.
@@ -228,55 +246,59 @@ void WriterProxy::lost_changes_update(const SequenceNumber_t& seqNum)
     //print_changes_fromWriter_test2();
 }
 
-bool WriterProxy::received_change_set(const SequenceNumber_t& seqNum)
+bool WriterProxy::received_change_set(const SequenceNumber_t& seq_num)
 {
-    logInfo(RTPS_READER, m_att.guid.entityId << ": seqNum: " << seqNum);
-    return received_change_set(seqNum, true);
+    logInfo(RTPS_READER, m_att.guid.entityId << ": seq_num: " << seq_num);
+    return received_change_set(seq_num, true);
 }
 
-bool WriterProxy::irrelevant_change_set(const SequenceNumber_t& seqNum)
+bool WriterProxy::irrelevant_change_set(const SequenceNumber_t& seq_num)
 {
-    return received_change_set(seqNum, false);
+    return received_change_set(seq_num, false);
 }
 
-bool WriterProxy::received_change_set(const SequenceNumber_t& seqNum, bool is_relevance)
+bool WriterProxy::received_change_set(
+        const SequenceNumber_t& seq_num,
+        bool is_relevance)
 {
-    std::lock_guard<std::recursive_mutex> guard(*mp_mutex);
+    std::lock_guard<std::recursive_mutex> guard(*mutex_);
 
     // Check if CacheChange_t was already and it was already removed from changesFromW container.
-    if(seqNum <= changesFromWLowMark_)
+    if(seq_num <= changes_from_writer_low_mark_)
     {
-        logInfo(RTPS_READER, "Change " << seqNum << " <= than max available sequence number " << changesFromWLowMark_);
+        logInfo(RTPS_READER, "Change " << seq_num << " <= than max available sequence number " << changes_from_writer_low_mark_);
         return false;
     }
 
-    // Maybe create information because it is not in the m_changesFromW container.
-    bool will_be_the_last = maybe_add_changes_from_writer_up_to(seqNum);
+    // Maybe create information because it is not in the changes_from_writer_ container.
+    bool will_be_the_last = maybe_add_changes_from_writer_up_to(seq_num);
 
     // If will be the last element, insert it at the end.
     if(will_be_the_last)
     {
         // There are others.
-        if(m_changesFromW.size() > 0)
+        if(changes_from_writer_.size() > 0)
         {
-            ChangeFromWriter_t chfw(seqNum);
+            ChangeFromWriter_t chfw(seq_num);
             chfw.setStatus(RECEIVED);
             chfw.setRelevance(is_relevance);
-            m_changesFromW.insert(m_changesFromW.end(), chfw);
+            changes_from_writer_.insert(changes_from_writer_.end(), chfw);
         }
         // Else not insert
         else
-            changesFromWLowMark_ = seqNum;
+        {
+            changes_from_writer_low_mark_ = seq_num;
+        }
     }
     // Else it has to be found and change state.
     else
     {
-        auto chit = m_changesFromW.find(ChangeFromWriter_t(seqNum));
+        auto chit = changes_from_writer_.find(ChangeFromWriter_t(seq_num));
 
         // Has to be in the container.
-        assert(chit != m_changesFromW.end());
+        assert(chit != changes_from_writer_.end());
 
-        if(chit != m_changesFromW.begin())
+        if(chit != changes_from_writer_.begin())
         {
             if(chit->getStatus() != RECEIVED)
             {
@@ -284,35 +306,34 @@ bool WriterProxy::received_change_set(const SequenceNumber_t& seqNum, bool is_re
                 newch.setStatus(RECEIVED);
                 newch.setRelevance(is_relevance);
 
-                auto hint = m_changesFromW.erase(chit);
-
-                m_changesFromW.insert(hint, newch);
+                auto hint = changes_from_writer_.erase(chit);
+                changes_from_writer_.insert(hint, newch);
             }
             else
+            {
                 return false;
+            }
         }
         else
         {
             assert(chit->getStatus() != RECEIVED);
-            changesFromWLowMark_ = seqNum;
-            m_changesFromW.erase(chit);
+            changes_from_writer_low_mark_ = seq_num;
+            changes_from_writer_.erase(chit);
             cleanup();
         }
-
     }
 
     //print_changes_fromWriter_test2();
-
     return true;
 }
 
 
-const std::vector<ChangeFromWriter_t> WriterProxy::missing_changes()
+const std::vector<ChangeFromWriter_t> WriterProxy::missing_changes() const
 {
     std::vector<ChangeFromWriter_t> returnedValue;
-    std::lock_guard<std::recursive_mutex> guard(*mp_mutex);
+    std::lock_guard<std::recursive_mutex> guard(*mutex_);
 
-    for(auto ch : m_changesFromW)
+    for(auto ch : changes_from_writer_)
     {
         if(ch.getStatus() == MISSING)
         {
@@ -324,29 +345,26 @@ const std::vector<ChangeFromWriter_t> WriterProxy::missing_changes()
 
 
     //print_changes_fromWriter_test2();
-
     return returnedValue;
 }
 
-bool WriterProxy::change_was_received(const SequenceNumber_t& seq_num)
+bool WriterProxy::change_was_received(const SequenceNumber_t& seq_num) const
 {
-    std::lock_guard<std::recursive_mutex> guard(*mp_mutex);
+    std::lock_guard<std::recursive_mutex> guard(*mutex_);
 
-    if(seq_num <= changesFromWLowMark_)
+    if (seq_num <= changes_from_writer_low_mark_)
+    {
         return true;
+    }
 
-    auto chit = m_changesFromW.find(ChangeFromWriter_t(seq_num));
-
-    if(chit != m_changesFromW.end() && chit->getStatus() == RECEIVED)
-        return true;
-
-    return false;
+    auto chit = changes_from_writer_.find(ChangeFromWriter_t(seq_num));
+    return (chit != changes_from_writer_.end() && chit->getStatus() == RECEIVED);
 }
 
 const SequenceNumber_t WriterProxy::available_changes_max() const
 {
-    std::lock_guard<std::recursive_mutex> guard(*mp_mutex);
-    return changesFromWLowMark_;
+    std::lock_guard<std::recursive_mutex> guard(*mutex_);
+    return changes_from_writer_low_mark_;
 }
 
 void WriterProxy::print_changes_fromWriter_test2()
@@ -354,7 +372,7 @@ void WriterProxy::print_changes_fromWriter_test2()
     std::stringstream sstream;
     sstream << this->m_att.guid.entityId<<": ";
 
-    for(auto it = m_changesFromW.begin(); it != m_changesFromW.end(); ++it)
+    for(auto it = changes_from_writer_.begin(); it != changes_from_writer_.end(); ++it)
     {
         sstream << it->getSequenceNumber() <<"("<<it->isRelevant()<<","<<it->getStatus()<<")-";
     }
@@ -363,108 +381,111 @@ void WriterProxy::print_changes_fromWriter_test2()
     logInfo(RTPS_READER,auxstr;);
 }
 
-void WriterProxy::assertLiveliness()
+void WriterProxy::assert_liveliness()
 {
-
     logInfo(RTPS_READER,this->m_att.guid.entityId << " Liveliness asserted");
 
-    //std::lock_guard<std::recursive_mutex> guard(*mp_mutex);
+    //std::lock_guard<std::recursive_mutex> guard(*mutex_);
 
-    m_isAlive=true;
-
+    is_alive_ = true;
     this->mp_writerProxyLiveliness->cancel_timer();
     this->mp_writerProxyLiveliness->restart_timer();
 }
 
-void WriterProxy::setNotValid(const SequenceNumber_t& seqNum)
+void WriterProxy::change_removed_from_history(const SequenceNumber_t& seq_num)
 {
-    std::lock_guard<std::recursive_mutex> guard(*mp_mutex);
+    std::lock_guard<std::recursive_mutex> guard(*mutex_);
 
     // Check sequence number is in the container, because it was not clean up.
-    if(seqNum <= changesFromWLowMark_)
+    if (seq_num <= changes_from_writer_low_mark_)
+    {
         return;
+    }
 
-    auto chit = m_changesFromW.find(ChangeFromWriter_t(seqNum));
+    auto chit = changes_from_writer_.find(ChangeFromWriter_t(seq_num));
 
     // Element must be in the container. In other case, bug.
-    assert(chit != m_changesFromW.end());
+    assert(chit != changes_from_writer_.end());
     // If the element will be set not valid, element must be received.
     // In other case, bug.
     assert(chit->getStatus() == RECEIVED);
 
     // Cannot be in the beginning because process of cleanup
-    assert(chit != m_changesFromW.begin());
+    assert(chit != changes_from_writer_.begin());
 
     ChangeFromWriter_t newch(*chit);
     newch.notValid();
 
-    auto hint = m_changesFromW.erase(chit);
-
-    m_changesFromW.insert(hint, newch);
+    auto hint = changes_from_writer_.erase(chit);
+    changes_from_writer_.insert(hint, newch);
 }
 
 void WriterProxy::cleanup()
 {
-    auto chit = m_changesFromW.begin();
+    auto chit = changes_from_writer_.begin();
 
-    while(chit != m_changesFromW.end() &&
+    while(chit != changes_from_writer_.end() &&
             (chit->getStatus() == RECEIVED || chit->getStatus() == LOST))
     {
-        changesFromWLowMark_ = chit->getSequenceNumber();
-        chit = m_changesFromW.erase(chit);
+        changes_from_writer_low_mark_ = chit->getSequenceNumber();
+        chit = changes_from_writer_.erase(chit);
     }
 }
 
-bool WriterProxy::areThereMissing()
+bool WriterProxy::are_there_missing_changes() const
 {
-    bool returnedValue = false;
-    std::lock_guard<std::recursive_mutex> guard(*mp_mutex);
+    std::lock_guard<std::recursive_mutex> guard(*mutex_);
 
-    for(auto ch : m_changesFromW)
+    for(const ChangeFromWriter_t& ch : changes_from_writer_)
     {
         if(ch.getStatus() == ChangeFromWriterStatus_t::MISSING)
         {
-            returnedValue = true;
-            break;
+            return true;
         }
     }
 
-    return returnedValue;
+    return false;
 }
 
-size_t WriterProxy::unknown_missing_changes_up_to(const SequenceNumber_t& seqNum)
+size_t WriterProxy::unknown_missing_changes_up_to(const SequenceNumber_t& seq_num) const
 {
     size_t returnedValue = 0;
-    std::lock_guard<std::recursive_mutex> guard(*mp_mutex);
+    std::lock_guard<std::recursive_mutex> guard(*mutex_);
 
-    if(seqNum > changesFromWLowMark_)
+    if(seq_num > changes_from_writer_low_mark_)
     {
-        for(auto ch = m_changesFromW.begin(); ch != m_changesFromW.end() && ch->getSequenceNumber() < seqNum; ++ch)
+        for(auto ch = changes_from_writer_.begin(); ch != changes_from_writer_.end() && ch->getSequenceNumber() < seq_num; ++ch)
         {
-            if(ch->getStatus() == ChangeFromWriterStatus_t::UNKNOWN ||
-                    ch->getStatus() == ChangeFromWriterStatus_t::MISSING)
+            if (ch->getStatus() == ChangeFromWriterStatus_t::UNKNOWN ||
+                ch->getStatus() == ChangeFromWriterStatus_t::MISSING)
+            {
                 ++returnedValue;
+            }
         }
     }
 
     return returnedValue;
 }
 
-size_t WriterProxy::numberOfChangeFromWriter() const
+size_t WriterProxy::number_of_changes_from_writer() const
 {
-    std::lock_guard<std::recursive_mutex> guard(*mp_mutex);
-    return m_changesFromW.size();
+    std::lock_guard<std::recursive_mutex> guard(*mutex_);
+    return changes_from_writer_.size();
 }
 
-SequenceNumber_t WriterProxy::nextCacheChangeToBeNotified()
+SequenceNumber_t WriterProxy::next_cache_change_to_be_notified()
 {
-    std::lock_guard<std::recursive_mutex> guard(*mp_mutex);
+    std::lock_guard<std::recursive_mutex> guard(*mutex_);
 
-    if(lastNotified_ < changesFromWLowMark_)
+    if(last_notified_ < changes_from_writer_low_mark_)
     {
-        ++lastNotified_;
-        return lastNotified_;
+        ++last_notified_;
+        return last_notified_;
     }
 
     return SequenceNumber_t::unknown();
 }
+
+} /* namespace rtps */
+} /* namespace fastrtps */
+} /* namespace eprosima */

--- a/src/cpp/rtps/reader/WriterProxy.cpp
+++ b/src/cpp/rtps/reader/WriterProxy.cpp
@@ -107,14 +107,11 @@ WriterProxy::WriterProxy(StatefulReader* reader)
 {
     //Create Events
     writer_proxy_liveliness_ = new WriterProxyLiveliness(reader);
-    heartbeat_response_ =
-        new HeartbeatResponseDelay(
-            this,
-            TimeConv::Time_t2MilliSecondsDouble(reader_->getTimes().heartbeatResponseDelay));
-    initial_acknack_ =
-        new InitialAckNack(
-            this,
-            TimeConv::Time_t2MilliSecondsDouble(reader_->getTimes().initialAcknackDelay));
+    heartbeat_response_ = new HeartbeatResponseDelay(reader_->getRTPSParticipant(), this);
+    initial_acknack_ = new InitialAckNack(reader_->getRTPSParticipant(), this);
+
+    heartbeat_response_->update_interval(reader_->getTimes().heartbeatResponseDelay);
+    initial_acknack_->update_interval(reader_->getTimes().initialAcknackDelay);
 
     stop();
     logInfo(RTPS_READER, "Writer Proxy created in reader: " << reader_->getGuid().entityId);
@@ -526,11 +523,6 @@ bool WriterProxy::process_heartbeat(
 void WriterProxy::update_heartbeat_response_interval(const Duration_t& interval)
 {
     heartbeat_response_->update_interval(interval);
-}
-
-RTPSParticipantImpl* WriterProxy::get_participant() const
-{
-    return reader_->getRTPSParticipant();
 }
 
 } /* namespace rtps */

--- a/src/cpp/rtps/reader/WriterProxy.cpp
+++ b/src/cpp/rtps/reader/WriterProxy.cpp
@@ -497,6 +497,11 @@ void WriterProxy::perform_initial_ack_nack(RTPSMessageGroup_t& buffer) const
     mp_SFR->send_acknack(sns, buffer, remote_locators_shrinked(), guid_as_vector_, false);
 }
 
+void WriterProxy::perform_heartbeat_response(RTPSMessageGroup_t& buffer) const
+{
+    mp_SFR->send_acknack(this, buffer, remote_locators_shrinked(), guid_as_vector_, m_heartbeatFinalFlag);
+}
+
 RTPSParticipantImpl* WriterProxy::get_participant() const
 {
     return mp_SFR->getRTPSParticipant();

--- a/src/cpp/rtps/reader/timedevent/HeartbeatResponseDelay.cpp
+++ b/src/cpp/rtps/reader/timedevent/HeartbeatResponseDelay.cpp
@@ -41,21 +41,17 @@ HeartbeatResponseDelay::~HeartbeatResponseDelay()
 }
 
 HeartbeatResponseDelay::HeartbeatResponseDelay(
-        WriterProxy* p_WP,
+        WriterProxy* writer_proxy,
         double interval)
-    : TimedEvent(p_WP->mp_SFR->getRTPSParticipant()->getEventResource().getIOService(),
-            p_WP->mp_SFR->getRTPSParticipant()->getEventResource().getThread(), interval)
-    , mp_WP(p_WP)
-    , m_cdrmessages(p_WP->mp_SFR->getRTPSParticipant()->getMaxMessageSize(),
-            p_WP->mp_SFR->getRTPSParticipant()->getGuid().guidPrefix)
-    , m_destination_locators(mp_WP->mp_SFR->getRTPSParticipant()->network_factory().
-            ShrinkLocatorLists({p_WP->m_att.endpoint.unicastLocatorList}))
-    , m_remote_endpoints(1, p_WP->m_att.guid)
+    : TimedEvent(
+            writer_proxy->get_participant()->getEventResource().getIOService(),
+            writer_proxy->get_participant()->getEventResource().getThread(),
+            interval)
+    , message_buffer_(
+            writer_proxy->get_participant()->getMaxMessageSize(),
+            writer_proxy->get_participant()->getGuid().guidPrefix)
+    , writer_proxy_(writer_proxy)
 {
-    if(m_destination_locators.empty())
-    {
-        m_destination_locators.push_back(p_WP->m_att.endpoint.multicastLocatorList);
-    }
 }
 
 void HeartbeatResponseDelay::event(
@@ -68,89 +64,7 @@ void HeartbeatResponseDelay::event(
 
     if(code == EVENT_SUCCESS)
     {
-        logInfo(RTPS_READER,"");
-
-        // Protect reader
-        std::lock_guard<std::recursive_mutex> guard(*mp_WP->mp_SFR->getMutex());
-
-        const std::vector<ChangeFromWriter_t> missing_changes = mp_WP->missing_changes();
-        // Stores missing changes but there is some fragments received.
-        std::vector<CacheChange_t*> uncompleted_changes;
-
-        RTPSMessageGroup group(mp_WP->mp_SFR->getRTPSParticipant(), mp_WP->mp_SFR, RTPSMessageGroup::READER,
-                m_cdrmessages, m_destination_locators, m_remote_endpoints);
-
-        if(!missing_changes.empty() || !mp_WP->m_heartbeatFinalFlag)
-        {
-            SequenceNumberSet_t sns(mp_WP->available_changes_max() + 1);
-
-            for(auto ch : missing_changes)
-            {
-                // Check if the CacheChange_t is uncompleted.
-                CacheChange_t* uncomplete_change = mp_WP->mp_SFR->findCacheInFragmentedCachePitStop(ch.getSequenceNumber(), mp_WP->m_att.guid);
-
-                if(uncomplete_change == nullptr)
-                {
-                    if(!sns.add(ch.getSequenceNumber()))
-                    {
-                        logInfo(RTPS_READER,"Sequence number " << ch.getSequenceNumber()
-                                << " exceeded bitmap limit of AckNack. SeqNumSet Base: " << sns.base());
-                    }
-                }
-                else
-                {
-                    uncompleted_changes.push_back(uncomplete_change);
-                }
-            }
-
-            // TODO Protect
-            mp_WP->mp_SFR->m_acknackCount++;
-            logInfo(RTPS_READER,"Sending ACKNACK: "<< sns;);
-
-            bool final = sns.empty();
-            group.add_acknack(m_remote_endpoints, sns, mp_WP->mp_SFR->m_acknackCount, final, m_destination_locators);
-        }
-
-        // Now generage NACK_FRAGS
-        if(!uncompleted_changes.empty())
-        {
-            for(auto cit : uncompleted_changes)
-            {
-                FragmentNumberSet_t frag_sns;
-
-                //  Search first fragment not present.
-                uint32_t frag_num = 0;
-                auto fit = cit->getDataFragments()->begin();
-                for(; fit != cit->getDataFragments()->end(); ++fit)
-                {
-                    ++frag_num;
-                    if(*fit == ChangeFragmentStatus_t::NOT_PRESENT)
-                        break;
-                }
-
-                // Never should happend.
-                assert(frag_num != 0);
-                assert(fit != cit->getDataFragments()->end());
-
-                // Store FragmentNumberSet_t base.
-                frag_sns.base(frag_num);
-
-                // Fill the FragmentNumberSet_t bitmap.
-                for(; fit != cit->getDataFragments()->end(); ++fit)
-                {
-                    if(*fit == ChangeFragmentStatus_t::NOT_PRESENT)
-                        frag_sns.add(frag_num);
-
-                    ++frag_num;
-                }
-
-                ++mp_WP->mp_SFR->m_nackfragCount;
-                logInfo(RTPS_READER,"Sending NACKFRAG for sample" << cit->sequenceNumber << ": "<< frag_sns;);
-
-                group.add_nackfrag(m_remote_endpoints, cit->sequenceNumber, frag_sns, mp_WP->mp_SFR->m_nackfragCount,
-                        m_destination_locators);
-            }
-        }
+        writer_proxy_->perform_heartbeat_response(message_buffer_);
     }
     else if(code == EVENT_ABORT)
     {
@@ -162,6 +76,6 @@ void HeartbeatResponseDelay::event(
     }
 }
 
-}
 } /* namespace rtps */
+} /* namespace fastrtps */
 } /* namespace eprosima */

--- a/src/cpp/rtps/reader/timedevent/HeartbeatResponseDelay.cpp
+++ b/src/cpp/rtps/reader/timedevent/HeartbeatResponseDelay.cpp
@@ -41,15 +41,15 @@ HeartbeatResponseDelay::~HeartbeatResponseDelay()
 }
 
 HeartbeatResponseDelay::HeartbeatResponseDelay(
-        WriterProxy* writer_proxy,
-        double interval)
+        RTPSParticipantImpl* participant,
+        WriterProxy* writer_proxy)
     : TimedEvent(
-            writer_proxy->get_participant()->getEventResource().getIOService(),
-            writer_proxy->get_participant()->getEventResource().getThread(),
-            interval)
+            participant->getEventResource().getIOService(),
+            participant->getEventResource().getThread(),
+            0)
     , message_buffer_(
-            writer_proxy->get_participant()->getMaxMessageSize(),
-            writer_proxy->get_participant()->getGuid().guidPrefix)
+            participant->getMaxMessageSize(),
+            participant->getGuid().guidPrefix)
     , writer_proxy_(writer_proxy)
 {
 }

--- a/src/cpp/rtps/reader/timedevent/InitialAckNack.cpp
+++ b/src/cpp/rtps/reader/timedevent/InitialAckNack.cpp
@@ -42,15 +42,15 @@ InitialAckNack::~InitialAckNack()
 }
 
 InitialAckNack::InitialAckNack(
-        WriterProxy* writer_proxy,
-        double interval)
+        RTPSParticipantImpl* participant,
+        WriterProxy* writer_proxy)
     : TimedEvent(
-            writer_proxy->get_participant()->getEventResource().getIOService(),
-            writer_proxy->get_participant()->getEventResource().getThread(),
-            interval)
+            participant->getEventResource().getIOService(),
+            participant->getEventResource().getThread(),
+            0)
     , message_buffer_(
-            writer_proxy->get_participant()->getMaxMessageSize(),
-            writer_proxy->get_participant()->getGuid().guidPrefix)
+            participant->getMaxMessageSize(),
+            participant->getGuid().guidPrefix)
     , writer_proxy_(writer_proxy)
 {
 }

--- a/src/cpp/rtps/reader/timedevent/WriterProxyLiveliness.cpp
+++ b/src/cpp/rtps/reader/timedevent/WriterProxyLiveliness.cpp
@@ -35,22 +35,28 @@ namespace fastrtps{
 namespace rtps {
 
 
-WriterProxyLiveliness::WriterProxyLiveliness(
-        StatefulReader* reader,
-        const GUID_t& writer_guid,
-        double interval)
+WriterProxyLiveliness::WriterProxyLiveliness(StatefulReader* reader)
     : TimedEvent(
         reader->getRTPSParticipant()->getEventResource().getIOService(),
-        reader->getRTPSParticipant()->getEventResource().getThread(),
-        interval, TimedEvent::ON_SUCCESS)
+        reader->getRTPSParticipant()->getEventResource().getThread(), 0)
     , reader_(reader)
-    , writer_guid_(writer_guid)
+    , writer_guid_()
 {
 }
 
 WriterProxyLiveliness::~WriterProxyLiveliness()
 {
     destroy();
+}
+
+void WriterProxyLiveliness::start(
+        const GUID_t& writer_guid,
+        const Duration_t& interval)
+{
+    writer_guid_ = writer_guid;
+    update_interval(interval);
+    cancel_timer();
+    restart_timer();
 }
 
 void WriterProxyLiveliness::event(

--- a/src/cpp/rtps/reader/timedevent/WriterProxyLiveliness.cpp
+++ b/src/cpp/rtps/reader/timedevent/WriterProxyLiveliness.cpp
@@ -58,7 +58,7 @@ void WriterProxyLiveliness::event(EventCode code, const char* msg)
 	{
 	
 		logInfo(RTPS_LIVELINESS,"Deleting Writer: "<<mp_WP->m_att.guid);
-//		if(!mp_WP->isAlive())
+//		if(!mp_WP->is_alive())
 //		{
 			//logWarning(RTPS_LIVELINESS,"Liveliness failed, leaseDuration was "<< this->getIntervalMilliSec()<< " ms");
 			if(mp_WP->mp_SFR->matched_writer_remove(mp_WP->m_att,false))
@@ -73,7 +73,7 @@ void WriterProxyLiveliness::event(EventCode code, const char* msg)
 			mp_WP->mp_writerProxyLiveliness = nullptr;
 			delete(mp_WP);
 //		}
-//		mp_WP->setNotAlive();
+//		mp_WP->set_not_alive();
 //		this->restart_timer();
 	}
 	else if(code == EVENT_ABORT)

--- a/src/cpp/subscriber/SubscriberHistory.cpp
+++ b/src/cpp/subscriber/SubscriberHistory.cpp
@@ -306,7 +306,7 @@ bool SubscriberHistory::readNextBuffer(SerializedPayload_t* data, SampleInfo_t* 
             info->sourceTimestamp = change->sourceTimestamp;
             if (this->mp_subImpl->getAttributes().qos.m_ownership.kind == EXCLUSIVE_OWNERSHIP_QOS)
             {
-                info->ownershipStrength = wp->m_att.ownershipStrength;
+                info->ownershipStrength = wp->ownership_strength();
             }
             if (this->mp_subImpl->getAttributes().topic.topicKind == WITH_KEY &&
                 change->instanceHandle == c_InstanceHandle_Unknown && change->kind == ALIVE)
@@ -353,7 +353,7 @@ bool SubscriberHistory::takeNextBuffer(SerializedPayload_t* data, SampleInfo_t* 
             info->sourceTimestamp = change->sourceTimestamp;
             if (this->mp_subImpl->getAttributes().qos.m_ownership.kind == EXCLUSIVE_OWNERSHIP_QOS)
             {
-                info->ownershipStrength = wp->m_att.ownershipStrength;
+                info->ownershipStrength = wp->ownership_strength();
             }
             if (this->mp_subImpl->getAttributes().topic.topicKind == WITH_KEY &&
                 change->instanceHandle == c_InstanceHandle_Unknown && change->kind == ALIVE)
@@ -399,7 +399,7 @@ bool SubscriberHistory::readNextData(void* data, SampleInfo_t* info)
             info->sourceTimestamp = change->sourceTimestamp;
             if (this->mp_subImpl->getAttributes().qos.m_ownership.kind == EXCLUSIVE_OWNERSHIP_QOS)
             {
-                info->ownershipStrength = wp->m_att.ownershipStrength;
+                info->ownershipStrength = wp->ownership_strength();
             }
             if (this->mp_subImpl->getAttributes().topic.topicKind == WITH_KEY &&
                 change->instanceHandle == c_InstanceHandle_Unknown && change->kind == ALIVE)
@@ -451,7 +451,7 @@ bool SubscriberHistory::takeNextData(void* data, SampleInfo_t* info)
             info->sourceTimestamp = change->sourceTimestamp;
             if (this->mp_subImpl->getAttributes().qos.m_ownership.kind == EXCLUSIVE_OWNERSHIP_QOS)
             {
-                info->ownershipStrength = wp->m_att.ownershipStrength;
+                info->ownershipStrength = wp->ownership_strength();
             }
             if (this->mp_subImpl->getAttributes().topic.topicKind == WITH_KEY &&
                 change->instanceHandle == c_InstanceHandle_Unknown && change->kind == ALIVE)

--- a/src/cpp/xmlparser/XMLParser.cpp
+++ b/src/cpp/xmlparser/XMLParser.cpp
@@ -2603,6 +2603,12 @@ XMLP_ret XMLParser::fillDataNode(tinyxml2::XMLElement* p_profile, DataNode<Subsc
                 return XMLP_ret::XML_ERROR;
             subscriber_node.get()->setEntityID(static_cast<uint8_t>(i));
         }
+        else if (strcmp(name, MATCHED_PUBLISHERS_ALLOCATION) == 0)
+        {
+            // matchedPublishersAllocation - containerAllocationConfigType
+            if (XMLP_ret::XML_OK != getXMLContainerAllocationConfig(p_aux0, subscriber_node.get()->matched_publisher_allocation, ident))
+                return XMLP_ret::XML_ERROR;
+        }
         else
         {
             logError(XMLPARSER, "Invalid element found into 'subscriberProfileType'. Name: " << name);

--- a/src/cpp/xmlparser/XMLParserCommon.cpp
+++ b/src/cpp/xmlparser/XMLParserCommon.cpp
@@ -93,6 +93,7 @@ const char* HIST_MEM_POLICY = "historyMemoryPolicy";
 const char* USER_DEF_ID = "userDefinedID";
 const char* ENTITY_ID = "entityID";
 const char* MATCHED_SUBSCRIBERS_ALLOCATION = "matchedSubscribersAllocation";
+const char* MATCHED_PUBLISHERS_ALLOCATION = "matchedPublishersAllocation";
 
 ///
 const char* PROPERTIES = "properties";

--- a/test/blackbox/BlackboxTestsRealtimeAllocations.cpp
+++ b/test/blackbox/BlackboxTestsRealtimeAllocations.cpp
@@ -231,4 +231,238 @@ BLACKBOXTEST(BlackBox, AsyncPubSubBestEffortWithLimitedSubscribers)
     ASSERT_EQ(reader2.getReceivedCount(), 0u);
 }
 
+BLACKBOXTEST(BlackBox, PubSubReliableWithLimitedPublishers)
+{
+    PubSubReader<FixedSizedType> reader(TEST_TOPIC_NAME);
+    PubSubWriter<FixedSizedType> writer(TEST_TOPIC_NAME);
+    PubSubWriter<FixedSizedType> writer2(TEST_TOPIC_NAME);
+
+    reader
+        .history_depth(10)
+        .resource_limits_max_samples(10).resource_limits_allocated_samples(10)
+        .matched_writers_allocation(1u, 1u)
+        .expect_no_allocs()
+        .reliability(eprosima::fastrtps::RELIABLE_RELIABILITY_QOS)
+        .init();
+
+    ASSERT_TRUE(reader.isInitialized());
+
+    writer
+        .history_depth(10)
+        .resource_limits_max_samples(10).resource_limits_allocated_samples(10)
+        .init();
+
+    ASSERT_TRUE(writer.isInitialized());
+
+    // Wait for discovery.
+    writer.wait_discovery();
+    reader.wait_discovery();
+
+    // Initialize second writer and wait until it discovers the reader
+    writer2
+        .history_depth(10)
+        .resource_limits_max_samples(10).resource_limits_allocated_samples(10)
+        .init();
+    ASSERT_TRUE(writer2.isInitialized());
+    writer2.wait_discovery();
+
+    // Send data from first writer
+    auto data = default_fixed_sized_data_generator();
+    reader.startReception(data);
+    writer.send(data);
+    // In this test all data should be sent.
+    ASSERT_TRUE(data.empty());
+    // Block reader until reception finished or timeout.
+    reader.block_for_all();
+
+    // Send data from second writer
+    data = default_fixed_sized_data_generator();
+    reader.startReception(data);
+    writer2.send(data);
+    // In this test all data should be sent.
+    ASSERT_TRUE(data.empty());
+
+    reader.block_for_all(std::chrono::seconds(2));
+
+    // Reader should not receive data
+    ASSERT_EQ(reader.getReceivedCount(), 0u);
+}
+
+BLACKBOXTEST(BlackBox, AsyncPubSubReliableWithLimitedPublishers)
+{
+    PubSubReader<FixedSizedType> reader(TEST_TOPIC_NAME);
+    PubSubWriter<FixedSizedType> writer(TEST_TOPIC_NAME);
+    PubSubWriter<FixedSizedType> writer2(TEST_TOPIC_NAME);
+
+    reader
+        .history_depth(10)
+        .resource_limits_max_samples(10).resource_limits_allocated_samples(10)
+        .matched_writers_allocation(1u, 1u)
+        .expect_no_allocs()
+        .reliability(eprosima::fastrtps::RELIABLE_RELIABILITY_QOS)
+        .init();
+
+    ASSERT_TRUE(reader.isInitialized());
+
+    writer
+        .asynchronously(eprosima::fastrtps::ASYNCHRONOUS_PUBLISH_MODE)
+        .history_depth(10)
+        .resource_limits_max_samples(10).resource_limits_allocated_samples(10)
+        .init();
+
+    ASSERT_TRUE(writer.isInitialized());
+
+    // Wait for discovery.
+    writer.wait_discovery();
+    reader.wait_discovery();
+
+    // Initialize second writer and wait until it discovers the reader
+    writer2
+        .asynchronously(eprosima::fastrtps::ASYNCHRONOUS_PUBLISH_MODE)
+        .history_depth(10)
+        .resource_limits_max_samples(10).resource_limits_allocated_samples(10)
+        .init();
+    ASSERT_TRUE(writer2.isInitialized());
+    writer2.wait_discovery();
+
+    // Send data from first writer
+    auto data = default_fixed_sized_data_generator();
+    reader.startReception(data);
+    writer.send(data);
+    // In this test all data should be sent.
+    ASSERT_TRUE(data.empty());
+    // Block reader until reception finished or timeout.
+    reader.block_for_all();
+
+    // Send data from second writer
+    data = default_fixed_sized_data_generator();
+    reader.startReception(data);
+    writer2.send(data);
+    // In this test all data should be sent.
+    ASSERT_TRUE(data.empty());
+
+    reader.block_for_all(std::chrono::seconds(2));
+
+    // Reader should not receive data
+    ASSERT_EQ(reader.getReceivedCount(), 0u);
+}
+
+BLACKBOXTEST(BlackBox, PubSubBestEffortWithLimitedPublishers)
+{
+    PubSubReader<FixedSizedType> reader(TEST_TOPIC_NAME);
+    PubSubWriter<FixedSizedType> writer(TEST_TOPIC_NAME);
+    PubSubWriter<FixedSizedType> writer2(TEST_TOPIC_NAME);
+
+    reader
+        .history_depth(10)
+        .resource_limits_max_samples(10).resource_limits_allocated_samples(10)
+        .matched_writers_allocation(1u, 1u)
+        .expect_no_allocs()
+        .init();
+
+    ASSERT_TRUE(reader.isInitialized());
+
+    writer
+        .reliability(eprosima::fastrtps::BEST_EFFORT_RELIABILITY_QOS)
+        .history_depth(10)
+        .resource_limits_max_samples(10).resource_limits_allocated_samples(10)
+        .init();
+
+    ASSERT_TRUE(writer.isInitialized());
+
+    // Wait for discovery.
+    writer.wait_discovery();
+    reader.wait_discovery();
+
+    // Initialize second writer and wait until it discovers the reader
+    writer2
+        .reliability(eprosima::fastrtps::BEST_EFFORT_RELIABILITY_QOS)
+        .history_depth(10)
+        .resource_limits_max_samples(10).resource_limits_allocated_samples(10)
+        .init();
+    ASSERT_TRUE(writer2.isInitialized());
+    writer2.wait_discovery();
+
+    // Send data from first writer
+    auto data = default_fixed_sized_data_generator();
+    reader.startReception(data);
+    writer.send(data);
+    // In this test all data should be sent.
+    ASSERT_TRUE(data.empty());
+    // Block reader until reception finished or timeout.
+    reader.block_for_all();
+
+    // Send data from second writer
+    data = default_fixed_sized_data_generator();
+    reader.startReception(data);
+    writer2.send(data);
+    // In this test all data should be sent.
+    ASSERT_TRUE(data.empty());
+
+    reader.block_for_all(std::chrono::seconds(2));
+
+    // Reader should not receive data
+    ASSERT_EQ(reader.getReceivedCount(), 0u);
+}
+
+BLACKBOXTEST(BlackBox, AsyncPubSubBestEffortWithLimitedPublishers)
+{
+    PubSubReader<FixedSizedType> reader(TEST_TOPIC_NAME);
+    PubSubWriter<FixedSizedType> writer(TEST_TOPIC_NAME);
+    PubSubWriter<FixedSizedType> writer2(TEST_TOPIC_NAME);
+
+    reader
+        .history_depth(10)
+        .resource_limits_max_samples(10).resource_limits_allocated_samples(10)
+        .matched_writers_allocation(1u, 1u)
+        .expect_no_allocs()
+        .init();
+
+    ASSERT_TRUE(reader.isInitialized());
+
+    writer
+        .reliability(eprosima::fastrtps::BEST_EFFORT_RELIABILITY_QOS)
+        .asynchronously(eprosima::fastrtps::ASYNCHRONOUS_PUBLISH_MODE)
+        .history_depth(10)
+        .resource_limits_max_samples(10).resource_limits_allocated_samples(10)
+        .init();
+
+    ASSERT_TRUE(writer.isInitialized());
+
+    // Wait for discovery.
+    writer.wait_discovery();
+    reader.wait_discovery();
+
+    // Initialize second writer and wait until it discovers the reader
+    writer2
+        .reliability(eprosima::fastrtps::BEST_EFFORT_RELIABILITY_QOS)
+        .asynchronously(eprosima::fastrtps::ASYNCHRONOUS_PUBLISH_MODE)
+        .history_depth(10)
+        .resource_limits_max_samples(10).resource_limits_allocated_samples(10)
+        .init();
+    ASSERT_TRUE(writer2.isInitialized());
+    writer2.wait_discovery();
+
+    // Send data from first writer
+    auto data = default_fixed_sized_data_generator();
+    reader.startReception(data);
+    writer.send(data);
+    // In this test all data should be sent.
+    ASSERT_TRUE(data.empty());
+    // Block reader until reception finished or timeout.
+    reader.block_for_all();
+
+    // Send data from second writer
+    data = default_fixed_sized_data_generator();
+    reader.startReception(data);
+    writer2.send(data);
+    // In this test all data should be sent.
+    ASSERT_TRUE(data.empty());
+
+    reader.block_for_all(std::chrono::seconds(2));
+
+    // Reader should not receive data
+    ASSERT_EQ(reader.getReceivedCount(), 0u);
+}
+
 #endif

--- a/test/blackbox/CMakeLists.txt
+++ b/test/blackbox/CMakeLists.txt
@@ -139,7 +139,7 @@ if(NOT ((MSVC OR MSVC_IDE) AND EPROSIMA_INSTALLER) AND fastcdr_FOUND)
         target_compile_definitions(BlackboxTests_PreallocMem PRIVATE
             PREALLOCATED_MEMORY_MODE_TEST)
         target_include_directories(BlackboxTests_PreallocMem PRIVATE ${GTEST_INCLUDE_DIRS})
-        target_link_libraries(BlackboxTests_PreallocMem fastrtps fastcdr ${GTEST_LIBRARIES})
+        target_link_libraries(BlackboxTests_PreallocMem fastrtps fastcdr foonathan_memory ${GTEST_LIBRARIES})
         add_blackbox_gtest(BlackboxTests_PreallocMem PreallocMem SOURCES ${BLACKBOXTESTS_TEST_SOURCE}
             ENVIRONMENTS "CERTS_PATH=${PROJECT_SOURCE_DIR}/test/certs"
             "TOPIC_RANDOM_NUMBER=${TOPIC_RANDOM_NUMBER}"
@@ -152,7 +152,7 @@ if(NOT ((MSVC OR MSVC_IDE) AND EPROSIMA_INSTALLER) AND fastcdr_FOUND)
         target_compile_definitions(BlackboxTests_ReallocMem PRIVATE
             PREALLOCATED_WITH_REALLOC_MEMORY_MODE_TEST)
         target_include_directories(BlackboxTests_ReallocMem PRIVATE ${GTEST_INCLUDE_DIRS})
-        target_link_libraries(BlackboxTests_ReallocMem fastrtps fastcdr ${GTEST_LIBRARIES})
+        target_link_libraries(BlackboxTests_ReallocMem fastrtps fastcdr foonathan_memory ${GTEST_LIBRARIES})
         add_blackbox_gtest(BlackboxTests_ReallocMem ReallocMem SOURCES ${BLACKBOXTESTS_TEST_SOURCE}
             ENVIRONMENTS "CERTS_PATH=${PROJECT_SOURCE_DIR}/test/certs"
             "TOPIC_RANDOM_NUMBER=${TOPIC_RANDOM_NUMBER}"
@@ -165,7 +165,7 @@ if(NOT ((MSVC OR MSVC_IDE) AND EPROSIMA_INSTALLER) AND fastcdr_FOUND)
         target_compile_definitions(BlackboxTests_DynMem PRIVATE
             DYNAMIC_RESERVE_MEMORY_MODE_TEST)
         target_include_directories(BlackboxTests_DynMem PRIVATE ${GTEST_INCLUDE_DIRS})
-        target_link_libraries(BlackboxTests_DynMem fastrtps fastcdr ${GTEST_LIBRARIES})
+        target_link_libraries(BlackboxTests_DynMem fastrtps fastcdr foonathan_memory ${GTEST_LIBRARIES})
         add_blackbox_gtest(BlackboxTests_DynMem DynMem SOURCES ${BLACKBOXTESTS_TEST_SOURCE}
             ENVIRONMENTS "CERTS_PATH=${PROJECT_SOURCE_DIR}/test/certs"
             "TOPIC_RANDOM_NUMBER=${TOPIC_RANDOM_NUMBER}"

--- a/test/blackbox/PubSubReader.hpp
+++ b/test/blackbox/PubSubReader.hpp
@@ -390,6 +390,19 @@ class PubSubReader
             return *this;
         }
 
+        PubSubReader& matched_writers_allocation(size_t initial, size_t maximum)
+        {
+            subscriber_attr_.matched_publisher_allocation.initial = initial;
+            subscriber_attr_.matched_publisher_allocation.maximum = maximum;
+            return *this;
+        }
+
+        PubSubReader& expect_no_allocs()
+        {
+            // TODO(Mcc): Add no allocations check code when feature is completely ready
+            return *this;
+        }
+
         PubSubReader& heartbeatResponseDelay(const int32_t secs, const int32_t frac)
         {
             subscriber_attr_.times.heartbeatResponseDelay.seconds = secs;

--- a/test/communication/CMakeLists.txt
+++ b/test/communication/CMakeLists.txt
@@ -34,14 +34,14 @@ if(NOT ((MSVC OR MSVC_IDE) AND EPROSIMA_INSTALLER) AND fastcdr_FOUND)
         )
     add_executable(SimpleCommunicationPublisher ${PUBLISHER_SOURCE})
     target_include_directories(SimpleCommunicationPublisher PRIVATE ${PROJECT_SOURCE_DIR}/test/blackbox)
-    target_link_libraries(SimpleCommunicationPublisher fastrtps fastcdr ${CMAKE_DL_LIBS})
+    target_link_libraries(SimpleCommunicationPublisher fastrtps fastcdr foonathan_memory ${CMAKE_DL_LIBS})
 
     set(SUBSCRIBER_SOURCE ${COMMON_SOURCE}
         Subscriber.cpp
         )
     add_executable(SimpleCommunicationSubscriber ${SUBSCRIBER_SOURCE})
     target_include_directories(SimpleCommunicationSubscriber PRIVATE ${PROJECT_SOURCE_DIR}/test/blackbox)
-    target_link_libraries(SimpleCommunicationSubscriber fastrtps fastcdr ${CMAKE_DL_LIBS})
+    target_link_libraries(SimpleCommunicationSubscriber fastrtps fastcdr foonathan_memory ${CMAKE_DL_LIBS})
 
     ###############################################################################
     # Necessary files

--- a/test/mock/rtps/HeartbeatResponseDelay/fastrtps/rtps/reader/timedevent/HeartbeatResponseDelay.h
+++ b/test/mock/rtps/HeartbeatResponseDelay/fastrtps/rtps/reader/timedevent/HeartbeatResponseDelay.h
@@ -25,12 +25,13 @@ namespace rtps {
 
 // Forward declarations
 class WriterProxy;
+class RTPSParticipantImpl;
 
 class HeartbeatResponseDelay
 {
     public:
                             
-        HeartbeatResponseDelay(WriterProxy* /*wp*/,double /*interval*/) { }
+        HeartbeatResponseDelay(RTPSParticipantImpl* /*participant*/, WriterProxy* /*wp*/) { }
 
         MOCK_METHOD0(restart_timer, void());
         MOCK_METHOD0(cancel_timer, void());

--- a/test/mock/rtps/HeartbeatResponseDelay/fastrtps/rtps/reader/timedevent/HeartbeatResponseDelay.h
+++ b/test/mock/rtps/HeartbeatResponseDelay/fastrtps/rtps/reader/timedevent/HeartbeatResponseDelay.h
@@ -15,24 +15,30 @@
 #ifndef _RTPS_READER_TIMEDEVENT_HEARTBEATRESPONSEDELAY_H_
 #define _RTPS_READER_TIMEDEVENT_HEARTBEATRESPONSEDELAY_H_
 
-namespace eprosima
+#include <gmock/gmock.h>
+
+#include <fastrtps/rtps/common/Time_t.h>
+
+namespace eprosima {
+namespace fastrtps {
+namespace rtps {
+
+// Forward declarations
+class WriterProxy;
+
+class HeartbeatResponseDelay
 {
-    namespace fastrtps
-    {
-        namespace rtps
-        {
-            // Forward declarations
-            class WriterProxy;
+    public:
+                            
+        HeartbeatResponseDelay(WriterProxy* /*wp*/,double /*interval*/) { }
 
-            class HeartbeatResponseDelay
-            {
-                public:
+        MOCK_METHOD0(restart_timer, void());
+        MOCK_METHOD0(cancel_timer, void());
+        MOCK_METHOD1(update_interval, void(const Duration_t&));
+};
 
-                    HeartbeatResponseDelay(WriterProxy* /*wp*/,double /*interval*/)
-                    {
-                    }
-            };
-        } // namespace rtps
-    } // namespace fastrtps
+} // namespace rtps
+} // namespace fastrtps
 } // namespace eprosima
+
 #endif // _RTPS_READER_TIMEDEVENT_HEARTBEATRESPONSEDELAY_H_

--- a/test/mock/rtps/InitialAckNack/fastrtps/rtps/reader/timedevent/InitialAckNack.h
+++ b/test/mock/rtps/InitialAckNack/fastrtps/rtps/reader/timedevent/InitialAckNack.h
@@ -15,24 +15,27 @@
 #ifndef _RTPS_READER_TIMEDEVENT_INITIALACKNACK_H_
 #define _RTPS_READER_TIMEDEVENT_INITIALACKNACK_H_
 
-namespace eprosima
+#include <gmock/gmock.h>
+
+namespace eprosima {
+namespace fastrtps {
+namespace rtps {
+
+// Forward declarations
+class WriterProxy;
+
+class InitialAckNack
 {
-    namespace fastrtps
-    {
-        namespace rtps
-        {
-            // Forward declarations
-            class WriterProxy;
+    public:
 
-            class InitialAckNack
-            {
-                public:
+        InitialAckNack(WriterProxy* /*wp*/,double /*interval*/) { }
 
-                    InitialAckNack(WriterProxy* /*wp*/,double /*interval*/)
-                    {
-                    }
-            };
-        } // namespace rtps
-    } // namespace fastrtps
+        MOCK_METHOD0(restart_timer, void());
+        MOCK_METHOD0(cancel_timer, void());
+};
+
+} // namespace rtps
+} // namespace fastrtps
 } // namespace eprosima
+
 #endif // _RTPS_READER_TIMEDEVENT_INITIALACKNACK_H_

--- a/test/mock/rtps/InitialAckNack/fastrtps/rtps/reader/timedevent/InitialAckNack.h
+++ b/test/mock/rtps/InitialAckNack/fastrtps/rtps/reader/timedevent/InitialAckNack.h
@@ -23,13 +23,15 @@ namespace rtps {
 
 // Forward declarations
 class WriterProxy;
+class RTPSParticipantImpl;
 
 class InitialAckNack
 {
     public:
 
-        InitialAckNack(WriterProxy* /*wp*/,double /*interval*/) { }
+        InitialAckNack(RTPSParticipantImpl* /*participant*/, WriterProxy* /*wp*/) { }
 
+        MOCK_METHOD1(update_interval, void(const Duration_t&));
         MOCK_METHOD0(restart_timer, void());
         MOCK_METHOD0(cancel_timer, void());
 };

--- a/test/mock/rtps/StatefulReader/fastrtps/rtps/reader/StatefulReader.h
+++ b/test/mock/rtps/StatefulReader/fastrtps/rtps/reader/StatefulReader.h
@@ -24,6 +24,7 @@ namespace fastrtps {
 namespace rtps {
 
 class RTPSMessageGroup_t;
+class WriterProxy;
 
 class StatefulReader : public RTPSReader
     {
@@ -46,6 +47,14 @@ class StatefulReader : public RTPSReader
                     const LocatorList_t& /*locators*/,
                     const std::vector<GUID_t>& /*guids*/,
                     bool /*is_final*/) 
+            {}
+
+            void send_acknack(
+                    const WriterProxy* /*writer*/,
+                    RTPSMessageGroup_t& /*buffer*/,
+                    const LocatorList_t& /*locators*/,
+                    const std::vector<GUID_t>& /*guids*/,
+                    bool /*heartbeat_was_final*/) 
             {}
 
             RTPSParticipantImpl* getRTPSParticipant() const { return nullptr; }

--- a/test/mock/rtps/StatefulReader/fastrtps/rtps/reader/StatefulReader.h
+++ b/test/mock/rtps/StatefulReader/fastrtps/rtps/reader/StatefulReader.h
@@ -21,7 +21,9 @@
 
 namespace eprosima {
 namespace fastrtps {
-namespace rtps{
+namespace rtps {
+
+class RTPSMessageGroup_t;
 
 class StatefulReader : public RTPSReader
     {
@@ -38,7 +40,17 @@ class StatefulReader : public RTPSReader
 
             inline ReaderTimes& getTimes(){return times_;};
 
-        private:
+            void send_acknack(
+                    const SequenceNumberSet_t& /*sns*/,
+                    RTPSMessageGroup_t& /*buffer*/,
+                    const LocatorList_t& /*locators*/,
+                    const std::vector<GUID_t>& /*guids*/,
+                    bool /*is_final*/) 
+            {}
+
+            RTPSParticipantImpl* getRTPSParticipant() const { return nullptr; }
+
+    private:
 
             GUID_t guid_;
 

--- a/test/mock/rtps/WriterProxyLiveliness/fastrtps/rtps/reader/timedevent/WriterProxyLiveliness.h
+++ b/test/mock/rtps/WriterProxyLiveliness/fastrtps/rtps/reader/timedevent/WriterProxyLiveliness.h
@@ -29,13 +29,11 @@ class WriterProxyLiveliness
 {
     public:
 
-        WriterProxyLiveliness(
-                StatefulReader* /*reader*/,
-                const GUID_t& /*guid*/,
-                double /*interval*/)
+        WriterProxyLiveliness(StatefulReader* /*reader*/)
         {
         }
 
+        MOCK_METHOD2(start, void(const GUID_t&, const Duration_t&));
         MOCK_METHOD0(restart_timer, void());
         MOCK_METHOD0(cancel_timer, void());
 };

--- a/test/mock/rtps/WriterProxyLiveliness/fastrtps/rtps/reader/timedevent/WriterProxyLiveliness.h
+++ b/test/mock/rtps/WriterProxyLiveliness/fastrtps/rtps/reader/timedevent/WriterProxyLiveliness.h
@@ -24,13 +24,17 @@ namespace eprosima
         namespace rtps
         {
             // Forward declarations
-            class WriterProxy;
+            class StatefulReader;
+            struct GUID_t;
 
             class WriterProxyLiveliness
             {
                 public:
 
-                    WriterProxyLiveliness(WriterProxy* /*wp*/, double /*interval*/)
+                    WriterProxyLiveliness(
+                            StatefulReader* /*reader*/,
+                            const GUID_t& /*guid*/,
+                            double /*interval*/)
                     {
                     }
 

--- a/test/mock/rtps/WriterProxyLiveliness/fastrtps/rtps/reader/timedevent/WriterProxyLiveliness.h
+++ b/test/mock/rtps/WriterProxyLiveliness/fastrtps/rtps/reader/timedevent/WriterProxyLiveliness.h
@@ -17,33 +17,31 @@
 
 #include <gmock/gmock.h>
 
-namespace eprosima
+namespace eprosima {
+namespace fastrtps {
+namespace rtps {
+
+// Forward declarations
+class StatefulReader;
+struct GUID_t;
+
+class WriterProxyLiveliness
 {
-    namespace fastrtps
-    {
-        namespace rtps
+    public:
+
+        WriterProxyLiveliness(
+                StatefulReader* /*reader*/,
+                const GUID_t& /*guid*/,
+                double /*interval*/)
         {
-            // Forward declarations
-            class StatefulReader;
-            struct GUID_t;
+        }
 
-            class WriterProxyLiveliness
-            {
-                public:
+        MOCK_METHOD0(restart_timer, void());
+        MOCK_METHOD0(cancel_timer, void());
+};
 
-                    WriterProxyLiveliness(
-                            StatefulReader* /*reader*/,
-                            const GUID_t& /*guid*/,
-                            double /*interval*/)
-                    {
-                    }
-
-                    MOCK_METHOD0(restart_timer, void());
-
-                    MOCK_METHOD0(cancel_timer, void());
-            };
-        } //namespace rtps
-    } //namespace fastrtps
+} //namespace rtps
+} //namespace fastrtps
 } //namespace eprosima
 
 #endif // _RTPS_READER_TIMEDEVENT_WRITERPROXYLIVELINESS_H_

--- a/test/performance/CMakeLists.txt
+++ b/test/performance/CMakeLists.txt
@@ -39,7 +39,7 @@ if(NOT ((MSVC OR MSVC_IDE) AND EPROSIMA_INSTALLER) AND fastcdr_FOUND)
         main_LatencyTest.cpp
         )
     add_executable(LatencyTest ${LATENCYTEST_SOURCE})
-    target_link_libraries(LatencyTest fastrtps ${CMAKE_THREAD_LIBS_INIT} ${CMAKE_DL_LIBS})
+    target_link_libraries(LatencyTest fastrtps foonathan_memory ${CMAKE_THREAD_LIBS_INIT} ${CMAKE_DL_LIBS})
 
     set(THROUGHPUTTEST_SOURCE ThroughputPublisher.cpp
         ThroughputSubscriber.cpp
@@ -48,7 +48,7 @@ if(NOT ((MSVC OR MSVC_IDE) AND EPROSIMA_INSTALLER) AND fastcdr_FOUND)
         )
     add_executable(ThroughputTest ${THROUGHPUTTEST_SOURCE})
     target_include_directories(ThroughputTest PRIVATE)
-    target_link_libraries(ThroughputTest fastrtps ${CMAKE_THREAD_LIBS_INIT} ${CMAKE_DL_LIBS})
+    target_link_libraries(ThroughputTest fastrtps foonathan_memory ${CMAKE_THREAD_LIBS_INIT} ${CMAKE_DL_LIBS})
 
     if(WIN32)
         if (EXISTS $ENV{GSTREAMER_1_0_ROOT_X86_64})
@@ -104,7 +104,7 @@ if(NOT ((MSVC OR MSVC_IDE) AND EPROSIMA_INSTALLER) AND fastcdr_FOUND)
         endif()
 
         if (WIN32)
-            target_link_libraries(VideoTest fastrtps
+            target_link_libraries(VideoTest fastrtps foonathan_memory
                 ${CMAKE_THREAD_LIBS_INIT}
                 ${CMAKE_DL_LIBS}
                 ${GST_LIBRARIES}
@@ -114,7 +114,7 @@ if(NOT ((MSVC OR MSVC_IDE) AND EPROSIMA_INSTALLER) AND fastcdr_FOUND)
                 $ENV{GSTREAMER_1_0_ROOT_X86_64}/lib/gobject-2.0.lib
                 $ENV{GSTREAMER_1_0_ROOT_X86_64}/lib/glib-2.0.lib)
         else()
-            target_link_libraries(VideoTest fastrtps
+            target_link_libraries(VideoTest fastrtps foonathan_memory
                 ${CMAKE_THREAD_LIBS_INIT}
                 ${CMAKE_DL_LIBS}
                 ${GST_LIBRARIES}

--- a/test/profiling/CMakeLists.txt
+++ b/test/profiling/CMakeLists.txt
@@ -38,7 +38,7 @@ if(NOT ((MSVC OR MSVC_IDE) AND EPROSIMA_INSTALLER))
         main_MemoryTest.cpp
         )
     add_executable(MemoryTest ${MEMORYTEST_SOURCE})
-    target_link_libraries(MemoryTest fastrtps ${CMAKE_THREAD_LIBS_INIT} ${CMAKE_DL_LIBS})
+    target_link_libraries(MemoryTest fastrtps foonathan_memory ${CMAKE_THREAD_LIBS_INIT} ${CMAKE_DL_LIBS})
 
     configure_file("cycles_tests.py" "cycles_tests.py")
     configure_file("memory_tests.py" "memory_tests.py")

--- a/test/profiling/allocations/CMakeLists.txt
+++ b/test/profiling/allocations/CMakeLists.txt
@@ -40,7 +40,7 @@ file(COPY ${CMAKE_CURRENT_SOURCE_DIR}/test.sh
     )
 
 add_executable(AllocationTest ${ALLOCTEST_EXAMPLE_SOURCES_CXX} ${ALLOCTEST_EXAMPLE_SOURCES_CPP})
-target_link_libraries(AllocationTest fastrtps fastcdr osrf_testing_tools_cpp::memory_tools)
+target_link_libraries(AllocationTest fastrtps fastcdr foonathan_memory osrf_testing_tools_cpp::memory_tools)
 install(TARGETS AllocationTest
     RUNTIME DESTINATION test/profiling/allocations/${BIN_INSTALL_DIR})
 

--- a/test/profiling/allocations/test_xml_profiles.xml
+++ b/test/profiling/allocations/test_xml_profiles.xml
@@ -164,6 +164,11 @@
                     <kind>BEST_EFFORT</kind>
                 </reliability>
             </qos>
+            <matchedPublishersAllocation>
+                <initial>1</initial>
+                <maximum>1</maximum>
+                <increment>0</increment>
+            </matchedPublishersAllocation>
         </subscriber>
 
         <subscriber profile_name="test_subscriber_profile_tl_re">
@@ -189,6 +194,11 @@
                     <kind>RELIABLE</kind>
                 </reliability>
             </qos>
+            <matchedPublishersAllocation>
+                <initial>1</initial>
+                <maximum>1</maximum>
+                <increment>0</increment>
+            </matchedPublishersAllocation>
         </subscriber>
 
         <subscriber profile_name="test_subscriber_profile_vo_be">
@@ -214,6 +224,11 @@
                     <kind>BEST_EFFORT</kind>
                 </reliability>
             </qos>
+            <matchedPublishersAllocation>
+                <initial>1</initial>
+                <maximum>1</maximum>
+                <increment>0</increment>
+            </matchedPublishersAllocation>
         </subscriber>
 
         <subscriber profile_name="test_subscriber_profile_vo_re">
@@ -239,6 +254,11 @@
                     <kind>RELIABLE</kind>
                 </reliability>
             </qos>
+            <matchedPublishersAllocation>
+                <initial>1</initial>
+                <maximum>1</maximum>
+                <increment>0</increment>
+            </matchedPublishersAllocation>
         </subscriber>
 
     </profiles>

--- a/test/unittest/rtps/network/CMakeLists.txt
+++ b/test/unittest/rtps/network/CMakeLists.txt
@@ -40,7 +40,8 @@ if(NOT ((MSVC OR MSVC_IDE) AND EPROSIMA_INSTALLER))
             ${PROJECT_SOURCE_DIR}/include ${PROJECT_BINARY_DIR}/include
             ${PROJECT_SOURCE_DIR}/src/cpp
             )
-        target_link_libraries(NetworkFactoryTests ${GTEST_LIBRARIES} ${MOCKS} ${CMAKE_THREAD_LIBS_INIT} ${CMAKE_DL_LIBS})
+        target_link_libraries(NetworkFactoryTests foonathan_memory
+            ${GTEST_LIBRARIES} ${MOCKS} ${CMAKE_THREAD_LIBS_INIT} ${CMAKE_DL_LIBS})
 
         if(WIN32)
             add_definitions(-D_WIN32_WINNT=0x0601)

--- a/test/unittest/rtps/persistence/CMakeLists.txt
+++ b/test/unittest/rtps/persistence/CMakeLists.txt
@@ -33,7 +33,7 @@ if(NOT ((MSVC OR MSVC_IDE) AND EPROSIMA_INSTALLER))
             ${PROJECT_SOURCE_DIR}/include ${PROJECT_BINARY_DIR}/include
             ${PROJECT_SOURCE_DIR}/src/cpp
             )
-        target_link_libraries(PersistenceTests ${GTEST_LIBRARIES} ${CMAKE_DL_LIBS})
+        target_link_libraries(PersistenceTests foonathan_memory ${GTEST_LIBRARIES} ${CMAKE_DL_LIBS})
         if(MSVC OR MSVC_IDE)
             target_link_libraries(PersistenceTests ${PRIVACY}
                 iphlpapi Shlwapi

--- a/test/unittest/rtps/persistence/PersistenceTests.cpp
+++ b/test/unittest/rtps/persistence/PersistenceTests.cpp
@@ -127,8 +127,9 @@ TEST_F(PersistenceTest, Reader)
     service = PersistenceFactory::create_persistence_service(policy);
     ASSERT_NE(service, nullptr);
 
-    std::map<GUID_t, SequenceNumber_t> seq_map;
-    std::map<GUID_t, SequenceNumber_t> seq_map_loaded;
+    IPersistenceService::map_allocator_t pool(128, 1024);
+    foonathan::memory::map<GUID_t, SequenceNumber_t, IPersistenceService::map_allocator_t> seq_map(pool);
+    foonathan::memory::map<GUID_t, SequenceNumber_t, IPersistenceService::map_allocator_t> seq_map_loaded(pool);
     GUID_t guid_1(GuidPrefix_t::unknown(), 1U);
     SequenceNumber_t seq_1(0, 1);
     GUID_t guid_2(GuidPrefix_t::unknown(), 2U);

--- a/test/unittest/rtps/reader/CMakeLists.txt
+++ b/test/unittest/rtps/reader/CMakeLists.txt
@@ -41,7 +41,7 @@ if(NOT ((MSVC OR MSVC_IDE) AND EPROSIMA_INSTALLER))
             ${PROJECT_SOURCE_DIR}/test/mock/rtps/WriterProxyLiveliness
             ${PROJECT_SOURCE_DIR}/test/mock/rtps/InitialAckNack
             ${PROJECT_SOURCE_DIR}/include ${PROJECT_BINARY_DIR}/include)
-        target_link_libraries(WriterProxyTests
+        target_link_libraries(WriterProxyTests foonathan_memory
             ${GTEST_LIBRARIES} ${GMOCK_LIBRARIES}
             ${CMAKE_THREAD_LIBS_INIT} ${CMAKE_DL_LIBS})
         add_gtest(WriterProxyTests SOURCES ${WRITERPROXYTESTS_SOURCE})

--- a/test/unittest/rtps/reader/WriterProxyTests.cpp
+++ b/test/unittest/rtps/reader/WriterProxyTests.cpp
@@ -36,7 +36,8 @@ namespace eprosima
             {
                 RemoteWriterAttributes wattr;
                 StatefulReader readerMock;
-                WriterProxy wproxy(wattr, &readerMock);
+                WriterProxy wproxy(&readerMock);
+                wproxy.start(wattr);
 
                 // Update MISSING changes util sequence number 3.
                 wproxy.missing_changes_update(SequenceNumber_t(0, 3));
@@ -106,7 +107,8 @@ namespace eprosima
             {
                 RemoteWriterAttributes wattr;
                 StatefulReader readerMock;
-                WriterProxy wproxy(wattr, &readerMock);
+                WriterProxy wproxy(&readerMock);
+                wproxy.start(wattr);
 
                 // Update LOST changes util sequence number 3.
                 wproxy.lost_changes_update(SequenceNumber_t(0, 3));
@@ -154,7 +156,8 @@ namespace eprosima
             {
                 RemoteWriterAttributes wattr;
                 StatefulReader readerMock;
-                WriterProxy wproxy(wattr, &readerMock);
+                WriterProxy wproxy(&readerMock);
+                wproxy.start(wattr);
 
                 // Set received change with sequence number 3.
                 wproxy.received_change_set(SequenceNumber_t(0, 3));
@@ -236,7 +239,8 @@ namespace eprosima
             {
                 RemoteWriterAttributes wattr;
                 StatefulReader readerMock;
-                WriterProxy wproxy(wattr, &readerMock);
+                WriterProxy wproxy(&readerMock);
+                wproxy.start(wattr);
 
                 // Set irrelevant change with sequence number 3.
                 wproxy.irrelevant_change_set(SequenceNumber_t(0, 3));

--- a/test/unittest/rtps/reader/WriterProxyTests.cpp
+++ b/test/unittest/rtps/reader/WriterProxyTests.cpp
@@ -40,25 +40,25 @@ namespace eprosima
 
                 // Update MISSING changes util sequence number 3.
                 wproxy.missing_changes_update(SequenceNumber_t(0, 3));
-                ASSERT_EQ(wproxy.changesFromWLowMark_, SequenceNumber_t(0, 0));
-                ASSERT_EQ(wproxy.m_changesFromW.size(), 3u);
-                ASSERT_EQ(wproxy.m_changesFromW.find(SequenceNumber_t(0, 1))->getStatus(), ChangeFromWriterStatus_t::MISSING);
-                ASSERT_EQ(wproxy.m_changesFromW.find(SequenceNumber_t(0, 2))->getStatus(), ChangeFromWriterStatus_t::MISSING);
-                ASSERT_EQ(wproxy.m_changesFromW.find(SequenceNumber_t(0, 3))->getStatus(), ChangeFromWriterStatus_t::MISSING);
+                ASSERT_EQ(wproxy.changes_from_writer_low_mark_, SequenceNumber_t(0, 0));
+                ASSERT_EQ(wproxy.changes_from_writer_.size(), 3u);
+                ASSERT_EQ(wproxy.changes_from_writer_.find(SequenceNumber_t(0, 1))->getStatus(), ChangeFromWriterStatus_t::MISSING);
+                ASSERT_EQ(wproxy.changes_from_writer_.find(SequenceNumber_t(0, 2))->getStatus(), ChangeFromWriterStatus_t::MISSING);
+                ASSERT_EQ(wproxy.changes_from_writer_.find(SequenceNumber_t(0, 3))->getStatus(), ChangeFromWriterStatus_t::MISSING);
 
                 // Add two UNKNOWN with sequence numberes 4 and 5.
-                wproxy.m_changesFromW.insert(ChangeFromWriter_t(SequenceNumber_t(0,4)));
-                wproxy.m_changesFromW.insert(ChangeFromWriter_t(SequenceNumber_t(0,5)));
+                wproxy.changes_from_writer_.insert(ChangeFromWriter_t(SequenceNumber_t(0,4)));
+                wproxy.changes_from_writer_.insert(ChangeFromWriter_t(SequenceNumber_t(0,5)));
 
                 // Update MISSING changes util sequence number 5.
                 wproxy.missing_changes_update(SequenceNumber_t(0,5));
-                ASSERT_EQ(wproxy.changesFromWLowMark_, SequenceNumber_t(0, 0));
-                ASSERT_EQ(wproxy.m_changesFromW.size(), 5u);
-                ASSERT_EQ(wproxy.m_changesFromW.find(SequenceNumber_t(0, 1))->getStatus(), ChangeFromWriterStatus_t::MISSING);
-                ASSERT_EQ(wproxy.m_changesFromW.find(SequenceNumber_t(0, 2))->getStatus(), ChangeFromWriterStatus_t::MISSING);
-                ASSERT_EQ(wproxy.m_changesFromW.find(SequenceNumber_t(0, 3))->getStatus(), ChangeFromWriterStatus_t::MISSING);
-                ASSERT_EQ(wproxy.m_changesFromW.find(SequenceNumber_t(0, 4))->getStatus(), ChangeFromWriterStatus_t::MISSING);
-                ASSERT_EQ(wproxy.m_changesFromW.find(SequenceNumber_t(0, 5))->getStatus(), ChangeFromWriterStatus_t::MISSING);
+                ASSERT_EQ(wproxy.changes_from_writer_low_mark_, SequenceNumber_t(0, 0));
+                ASSERT_EQ(wproxy.changes_from_writer_.size(), 5u);
+                ASSERT_EQ(wproxy.changes_from_writer_.find(SequenceNumber_t(0, 1))->getStatus(), ChangeFromWriterStatus_t::MISSING);
+                ASSERT_EQ(wproxy.changes_from_writer_.find(SequenceNumber_t(0, 2))->getStatus(), ChangeFromWriterStatus_t::MISSING);
+                ASSERT_EQ(wproxy.changes_from_writer_.find(SequenceNumber_t(0, 3))->getStatus(), ChangeFromWriterStatus_t::MISSING);
+                ASSERT_EQ(wproxy.changes_from_writer_.find(SequenceNumber_t(0, 4))->getStatus(), ChangeFromWriterStatus_t::MISSING);
+                ASSERT_EQ(wproxy.changes_from_writer_.find(SequenceNumber_t(0, 5))->getStatus(), ChangeFromWriterStatus_t::MISSING);
 
                 // Set all as received.
                 wproxy.received_change_set(SequenceNumber_t(0, 1));
@@ -66,40 +66,40 @@ namespace eprosima
                 wproxy.received_change_set(SequenceNumber_t(0, 3));
                 wproxy.received_change_set(SequenceNumber_t(0, 4));
                 wproxy.received_change_set(SequenceNumber_t(0, 5));
-                ASSERT_EQ(wproxy.changesFromWLowMark_, SequenceNumber_t(0, 5));
-                ASSERT_EQ(wproxy.m_changesFromW.size(), 0u);
+                ASSERT_EQ(wproxy.changes_from_writer_low_mark_, SequenceNumber_t(0, 5));
+                ASSERT_EQ(wproxy.changes_from_writer_.size(), 0u);
 
                 // Try to update MISSING changes util sequence number 4.
                 wproxy.missing_changes_update(SequenceNumber_t(0, 4));
-                ASSERT_EQ(wproxy.changesFromWLowMark_, SequenceNumber_t(0, 5));
-                ASSERT_EQ(wproxy.m_changesFromW.size(), 0u);
+                ASSERT_EQ(wproxy.changes_from_writer_low_mark_, SequenceNumber_t(0, 5));
+                ASSERT_EQ(wproxy.changes_from_writer_.size(), 0u);
 
                 // Add three UNKNOWN changes with sequence number 6, 7 and 9.
                 // Add one RECEIVED change with sequence number 8.
-                wproxy.m_changesFromW.insert(ChangeFromWriter_t(SequenceNumber_t(0, 6)));
-                wproxy.m_changesFromW.insert(ChangeFromWriter_t(SequenceNumber_t(0, 7)));
-                wproxy.m_changesFromW.insert(ChangeFromWriter_t(SequenceNumber_t(0, 8)));
+                wproxy.changes_from_writer_.insert(ChangeFromWriter_t(SequenceNumber_t(0, 6)));
+                wproxy.changes_from_writer_.insert(ChangeFromWriter_t(SequenceNumber_t(0, 7)));
+                wproxy.changes_from_writer_.insert(ChangeFromWriter_t(SequenceNumber_t(0, 8)));
                 wproxy.received_change_set(SequenceNumber_t(0, 8));
-                wproxy.m_changesFromW.insert(ChangeFromWriter_t(SequenceNumber_t(0, 9)));
+                wproxy.changes_from_writer_.insert(ChangeFromWriter_t(SequenceNumber_t(0, 9)));
 
                 // Update MISSING changes util sequence number 8.
                 wproxy.missing_changes_update(SequenceNumber_t(0, 8));
-                ASSERT_EQ(wproxy.changesFromWLowMark_, SequenceNumber_t(0, 5));
-                ASSERT_EQ(wproxy.m_changesFromW.size(), 4u);
-                ASSERT_EQ(wproxy.m_changesFromW.find(SequenceNumber_t(0, 6))->getStatus(), ChangeFromWriterStatus_t::MISSING);
-                ASSERT_EQ(wproxy.m_changesFromW.find(SequenceNumber_t(0, 7))->getStatus(), ChangeFromWriterStatus_t::MISSING);
-                ASSERT_EQ(wproxy.m_changesFromW.find(SequenceNumber_t(0, 8))->getStatus(), ChangeFromWriterStatus_t::RECEIVED);
-                ASSERT_EQ(wproxy.m_changesFromW.find(SequenceNumber_t(0, 9))->getStatus(), ChangeFromWriterStatus_t::UNKNOWN);
+                ASSERT_EQ(wproxy.changes_from_writer_low_mark_, SequenceNumber_t(0, 5));
+                ASSERT_EQ(wproxy.changes_from_writer_.size(), 4u);
+                ASSERT_EQ(wproxy.changes_from_writer_.find(SequenceNumber_t(0, 6))->getStatus(), ChangeFromWriterStatus_t::MISSING);
+                ASSERT_EQ(wproxy.changes_from_writer_.find(SequenceNumber_t(0, 7))->getStatus(), ChangeFromWriterStatus_t::MISSING);
+                ASSERT_EQ(wproxy.changes_from_writer_.find(SequenceNumber_t(0, 8))->getStatus(), ChangeFromWriterStatus_t::RECEIVED);
+                ASSERT_EQ(wproxy.changes_from_writer_.find(SequenceNumber_t(0, 9))->getStatus(), ChangeFromWriterStatus_t::UNKNOWN);
 
                 // Update MISSING changes util sequence number 10.
                 wproxy.missing_changes_update(SequenceNumber_t(0, 10));
-                ASSERT_EQ(wproxy.changesFromWLowMark_, SequenceNumber_t(0, 5));
-                ASSERT_EQ(wproxy.m_changesFromW.size(), 5u);
-                ASSERT_EQ(wproxy.m_changesFromW.find(SequenceNumber_t(0, 6))->getStatus(), ChangeFromWriterStatus_t::MISSING);
-                ASSERT_EQ(wproxy.m_changesFromW.find(SequenceNumber_t(0, 7))->getStatus(), ChangeFromWriterStatus_t::MISSING);
-                ASSERT_EQ(wproxy.m_changesFromW.find(SequenceNumber_t(0, 8))->getStatus(), ChangeFromWriterStatus_t::RECEIVED);
-                ASSERT_EQ(wproxy.m_changesFromW.find(SequenceNumber_t(0, 9))->getStatus(), ChangeFromWriterStatus_t::MISSING);
-                ASSERT_EQ(wproxy.m_changesFromW.find(SequenceNumber_t(0, 10))->getStatus(), ChangeFromWriterStatus_t::MISSING);
+                ASSERT_EQ(wproxy.changes_from_writer_low_mark_, SequenceNumber_t(0, 5));
+                ASSERT_EQ(wproxy.changes_from_writer_.size(), 5u);
+                ASSERT_EQ(wproxy.changes_from_writer_.find(SequenceNumber_t(0, 6))->getStatus(), ChangeFromWriterStatus_t::MISSING);
+                ASSERT_EQ(wproxy.changes_from_writer_.find(SequenceNumber_t(0, 7))->getStatus(), ChangeFromWriterStatus_t::MISSING);
+                ASSERT_EQ(wproxy.changes_from_writer_.find(SequenceNumber_t(0, 8))->getStatus(), ChangeFromWriterStatus_t::RECEIVED);
+                ASSERT_EQ(wproxy.changes_from_writer_.find(SequenceNumber_t(0, 9))->getStatus(), ChangeFromWriterStatus_t::MISSING);
+                ASSERT_EQ(wproxy.changes_from_writer_.find(SequenceNumber_t(0, 10))->getStatus(), ChangeFromWriterStatus_t::MISSING);
             }
 
             TEST(WriterProxyTests, LostChangesUpdate)
@@ -110,44 +110,44 @@ namespace eprosima
 
                 // Update LOST changes util sequence number 3.
                 wproxy.lost_changes_update(SequenceNumber_t(0, 3));
-                ASSERT_EQ(wproxy.changesFromWLowMark_, SequenceNumber_t(0, 2));
-                ASSERT_EQ(wproxy.m_changesFromW.size(), 0u);
+                ASSERT_EQ(wproxy.changes_from_writer_low_mark_, SequenceNumber_t(0, 2));
+                ASSERT_EQ(wproxy.changes_from_writer_.size(), 0u);
 
                 // Add two UNKNOWN with sequence numberes 3 and 4.
-                wproxy.m_changesFromW.insert(ChangeFromWriter_t(SequenceNumber_t(0,3)));
-                wproxy.m_changesFromW.insert(ChangeFromWriter_t(SequenceNumber_t(0,4)));
+                wproxy.changes_from_writer_.insert(ChangeFromWriter_t(SequenceNumber_t(0,3)));
+                wproxy.changes_from_writer_.insert(ChangeFromWriter_t(SequenceNumber_t(0,4)));
 
                 // Update LOST changes util sequence number 5.
                 wproxy.lost_changes_update(SequenceNumber_t(0, 5));
-                ASSERT_EQ(wproxy.changesFromWLowMark_, SequenceNumber_t(0, 4));
-                ASSERT_EQ(wproxy.m_changesFromW.size(), 0u);
+                ASSERT_EQ(wproxy.changes_from_writer_low_mark_, SequenceNumber_t(0, 4));
+                ASSERT_EQ(wproxy.changes_from_writer_.size(), 0u);
 
                 // Try to update LOST changes util sequence number 4.
                 wproxy.lost_changes_update(SequenceNumber_t(0, 3));
-                ASSERT_EQ(wproxy.changesFromWLowMark_, SequenceNumber_t(0, 4));
-                ASSERT_EQ(wproxy.m_changesFromW.size(), 0u);
+                ASSERT_EQ(wproxy.changes_from_writer_low_mark_, SequenceNumber_t(0, 4));
+                ASSERT_EQ(wproxy.changes_from_writer_.size(), 0u);
 
                 // Add two UNKNOWN changes with sequence number 5 and 8.
                 // Add one MISSING change with sequence number 6.
                 // Add one RECEIVED change with sequence number 7.
-                wproxy.m_changesFromW.insert(ChangeFromWriter_t(SequenceNumber_t(0, 5)));
+                wproxy.changes_from_writer_.insert(ChangeFromWriter_t(SequenceNumber_t(0, 5)));
                 ChangeFromWriter_t missing_aux_change_from_w(SequenceNumber_t(0, 6));
                 missing_aux_change_from_w.setStatus(ChangeFromWriterStatus_t::MISSING);
-                wproxy.m_changesFromW.insert(missing_aux_change_from_w);
-                wproxy.m_changesFromW.insert(ChangeFromWriter_t(SequenceNumber_t(0, 7)));
+                wproxy.changes_from_writer_.insert(missing_aux_change_from_w);
+                wproxy.changes_from_writer_.insert(ChangeFromWriter_t(SequenceNumber_t(0, 7)));
                 wproxy.received_change_set(SequenceNumber_t(0, 7));
-                wproxy.m_changesFromW.insert(ChangeFromWriter_t(SequenceNumber_t(0, 8)));
+                wproxy.changes_from_writer_.insert(ChangeFromWriter_t(SequenceNumber_t(0, 8)));
 
                 // Update LOST changes util sequence number 8.
                 wproxy.lost_changes_update(SequenceNumber_t(0, 8));
-                ASSERT_EQ(wproxy.changesFromWLowMark_, SequenceNumber_t(0, 7));
-                ASSERT_EQ(wproxy.m_changesFromW.size(), 1u);
-                ASSERT_EQ(wproxy.m_changesFromW.find(SequenceNumber_t(0, 8))->getStatus(), ChangeFromWriterStatus_t::UNKNOWN);
+                ASSERT_EQ(wproxy.changes_from_writer_low_mark_, SequenceNumber_t(0, 7));
+                ASSERT_EQ(wproxy.changes_from_writer_.size(), 1u);
+                ASSERT_EQ(wproxy.changes_from_writer_.find(SequenceNumber_t(0, 8))->getStatus(), ChangeFromWriterStatus_t::UNKNOWN);
 
                 // Update LOST changes util sequence number 10.
                 wproxy.lost_changes_update(SequenceNumber_t(0, 10));
-                ASSERT_EQ(wproxy.changesFromWLowMark_, SequenceNumber_t(0, 9));
-                ASSERT_EQ(wproxy.m_changesFromW.size(), 0u);
+                ASSERT_EQ(wproxy.changes_from_writer_low_mark_, SequenceNumber_t(0, 9));
+                ASSERT_EQ(wproxy.changes_from_writer_.size(), 0u);
             }
 
             TEST(WriterProxyTests, ReceivedChangeSet)
@@ -158,78 +158,78 @@ namespace eprosima
 
                 // Set received change with sequence number 3.
                 wproxy.received_change_set(SequenceNumber_t(0, 3));
-                ASSERT_EQ(wproxy.changesFromWLowMark_, SequenceNumber_t(0, 0));
-                ASSERT_EQ(wproxy.m_changesFromW.size(), 3u);
-                ASSERT_EQ(wproxy.m_changesFromW.find(SequenceNumber_t(0, 1))->getStatus(), ChangeFromWriterStatus_t::UNKNOWN);
-                ASSERT_EQ(wproxy.m_changesFromW.find(SequenceNumber_t(0, 2))->getStatus(), ChangeFromWriterStatus_t::UNKNOWN);
-                ASSERT_EQ(wproxy.m_changesFromW.find(SequenceNumber_t(0, 3))->getStatus(), ChangeFromWriterStatus_t::RECEIVED);
+                ASSERT_EQ(wproxy.changes_from_writer_low_mark_, SequenceNumber_t(0, 0));
+                ASSERT_EQ(wproxy.changes_from_writer_.size(), 3u);
+                ASSERT_EQ(wproxy.changes_from_writer_.find(SequenceNumber_t(0, 1))->getStatus(), ChangeFromWriterStatus_t::UNKNOWN);
+                ASSERT_EQ(wproxy.changes_from_writer_.find(SequenceNumber_t(0, 2))->getStatus(), ChangeFromWriterStatus_t::UNKNOWN);
+                ASSERT_EQ(wproxy.changes_from_writer_.find(SequenceNumber_t(0, 3))->getStatus(), ChangeFromWriterStatus_t::RECEIVED);
 
                 // Add two UNKNOWN with sequence numberes 4 and 5.
-                wproxy.m_changesFromW.insert(ChangeFromWriter_t(SequenceNumber_t(0,4)));
-                wproxy.m_changesFromW.insert(ChangeFromWriter_t(SequenceNumber_t(0,5)));
+                wproxy.changes_from_writer_.insert(ChangeFromWriter_t(SequenceNumber_t(0,4)));
+                wproxy.changes_from_writer_.insert(ChangeFromWriter_t(SequenceNumber_t(0,5)));
 
                 // Set received change with sequence number 2
                 wproxy.received_change_set(SequenceNumber_t(0, 2));
-                ASSERT_EQ(wproxy.changesFromWLowMark_, SequenceNumber_t(0, 0));
-                ASSERT_EQ(wproxy.m_changesFromW.size(), 5u);
-                ASSERT_EQ(wproxy.m_changesFromW.find(SequenceNumber_t(0, 1))->getStatus(), ChangeFromWriterStatus_t::UNKNOWN);
-                ASSERT_EQ(wproxy.m_changesFromW.find(SequenceNumber_t(0, 2))->getStatus(), ChangeFromWriterStatus_t::RECEIVED);
-                ASSERT_EQ(wproxy.m_changesFromW.find(SequenceNumber_t(0, 3))->getStatus(), ChangeFromWriterStatus_t::RECEIVED);
-                ASSERT_EQ(wproxy.m_changesFromW.find(SequenceNumber_t(0, 4))->getStatus(), ChangeFromWriterStatus_t::UNKNOWN);
-                ASSERT_EQ(wproxy.m_changesFromW.find(SequenceNumber_t(0, 5))->getStatus(), ChangeFromWriterStatus_t::UNKNOWN);
+                ASSERT_EQ(wproxy.changes_from_writer_low_mark_, SequenceNumber_t(0, 0));
+                ASSERT_EQ(wproxy.changes_from_writer_.size(), 5u);
+                ASSERT_EQ(wproxy.changes_from_writer_.find(SequenceNumber_t(0, 1))->getStatus(), ChangeFromWriterStatus_t::UNKNOWN);
+                ASSERT_EQ(wproxy.changes_from_writer_.find(SequenceNumber_t(0, 2))->getStatus(), ChangeFromWriterStatus_t::RECEIVED);
+                ASSERT_EQ(wproxy.changes_from_writer_.find(SequenceNumber_t(0, 3))->getStatus(), ChangeFromWriterStatus_t::RECEIVED);
+                ASSERT_EQ(wproxy.changes_from_writer_.find(SequenceNumber_t(0, 4))->getStatus(), ChangeFromWriterStatus_t::UNKNOWN);
+                ASSERT_EQ(wproxy.changes_from_writer_.find(SequenceNumber_t(0, 5))->getStatus(), ChangeFromWriterStatus_t::UNKNOWN);
 
                 // Set received change with sequence number 1
                 wproxy.received_change_set(SequenceNumber_t(0, 1));
-                ASSERT_EQ(wproxy.changesFromWLowMark_, SequenceNumber_t(0, 3));
-                ASSERT_EQ(wproxy.m_changesFromW.size(), 2u);
-                ASSERT_EQ(wproxy.m_changesFromW.find(SequenceNumber_t(0, 4))->getStatus(), ChangeFromWriterStatus_t::UNKNOWN);
-                ASSERT_EQ(wproxy.m_changesFromW.find(SequenceNumber_t(0, 5))->getStatus(), ChangeFromWriterStatus_t::UNKNOWN);
+                ASSERT_EQ(wproxy.changes_from_writer_low_mark_, SequenceNumber_t(0, 3));
+                ASSERT_EQ(wproxy.changes_from_writer_.size(), 2u);
+                ASSERT_EQ(wproxy.changes_from_writer_.find(SequenceNumber_t(0, 4))->getStatus(), ChangeFromWriterStatus_t::UNKNOWN);
+                ASSERT_EQ(wproxy.changes_from_writer_.find(SequenceNumber_t(0, 5))->getStatus(), ChangeFromWriterStatus_t::UNKNOWN);
 
                 // Try to update LOST changes util sequence number 3.
                 wproxy.received_change_set(SequenceNumber_t(0, 3));
-                ASSERT_EQ(wproxy.changesFromWLowMark_, SequenceNumber_t(0, 3));
-                ASSERT_EQ(wproxy.m_changesFromW.size(), 2u);
-                ASSERT_EQ(wproxy.m_changesFromW.find(SequenceNumber_t(0, 4))->getStatus(), ChangeFromWriterStatus_t::UNKNOWN);
-                ASSERT_EQ(wproxy.m_changesFromW.find(SequenceNumber_t(0, 5))->getStatus(), ChangeFromWriterStatus_t::UNKNOWN);
+                ASSERT_EQ(wproxy.changes_from_writer_low_mark_, SequenceNumber_t(0, 3));
+                ASSERT_EQ(wproxy.changes_from_writer_.size(), 2u);
+                ASSERT_EQ(wproxy.changes_from_writer_.find(SequenceNumber_t(0, 4))->getStatus(), ChangeFromWriterStatus_t::UNKNOWN);
+                ASSERT_EQ(wproxy.changes_from_writer_.find(SequenceNumber_t(0, 5))->getStatus(), ChangeFromWriterStatus_t::UNKNOWN);
 
                 // Add received change with sequence number 6
                 wproxy.received_change_set(SequenceNumber_t(0, 6));
-                ASSERT_EQ(wproxy.changesFromWLowMark_, SequenceNumber_t(0, 3));
-                ASSERT_EQ(wproxy.m_changesFromW.size(), 3u);
-                ASSERT_EQ(wproxy.m_changesFromW.find(SequenceNumber_t(0, 4))->getStatus(), ChangeFromWriterStatus_t::UNKNOWN);
-                ASSERT_EQ(wproxy.m_changesFromW.find(SequenceNumber_t(0, 5))->getStatus(), ChangeFromWriterStatus_t::UNKNOWN);
-                ASSERT_EQ(wproxy.m_changesFromW.find(SequenceNumber_t(0, 6))->getStatus(), ChangeFromWriterStatus_t::RECEIVED);
+                ASSERT_EQ(wproxy.changes_from_writer_low_mark_, SequenceNumber_t(0, 3));
+                ASSERT_EQ(wproxy.changes_from_writer_.size(), 3u);
+                ASSERT_EQ(wproxy.changes_from_writer_.find(SequenceNumber_t(0, 4))->getStatus(), ChangeFromWriterStatus_t::UNKNOWN);
+                ASSERT_EQ(wproxy.changes_from_writer_.find(SequenceNumber_t(0, 5))->getStatus(), ChangeFromWriterStatus_t::UNKNOWN);
+                ASSERT_EQ(wproxy.changes_from_writer_.find(SequenceNumber_t(0, 6))->getStatus(), ChangeFromWriterStatus_t::RECEIVED);
 
                 // Add received change with sequence number 8
                 wproxy.received_change_set(SequenceNumber_t(0, 8));
-                ASSERT_EQ(wproxy.changesFromWLowMark_, SequenceNumber_t(0, 3));
-                ASSERT_EQ(wproxy.m_changesFromW.size(), 5u);
-                ASSERT_EQ(wproxy.m_changesFromW.find(SequenceNumber_t(0, 4))->getStatus(), ChangeFromWriterStatus_t::UNKNOWN);
-                ASSERT_EQ(wproxy.m_changesFromW.find(SequenceNumber_t(0, 5))->getStatus(), ChangeFromWriterStatus_t::UNKNOWN);
-                ASSERT_EQ(wproxy.m_changesFromW.find(SequenceNumber_t(0, 6))->getStatus(), ChangeFromWriterStatus_t::RECEIVED);
-                ASSERT_EQ(wproxy.m_changesFromW.find(SequenceNumber_t(0, 7))->getStatus(), ChangeFromWriterStatus_t::UNKNOWN);
-                ASSERT_EQ(wproxy.m_changesFromW.find(SequenceNumber_t(0, 8))->getStatus(), ChangeFromWriterStatus_t::RECEIVED);
+                ASSERT_EQ(wproxy.changes_from_writer_low_mark_, SequenceNumber_t(0, 3));
+                ASSERT_EQ(wproxy.changes_from_writer_.size(), 5u);
+                ASSERT_EQ(wproxy.changes_from_writer_.find(SequenceNumber_t(0, 4))->getStatus(), ChangeFromWriterStatus_t::UNKNOWN);
+                ASSERT_EQ(wproxy.changes_from_writer_.find(SequenceNumber_t(0, 5))->getStatus(), ChangeFromWriterStatus_t::UNKNOWN);
+                ASSERT_EQ(wproxy.changes_from_writer_.find(SequenceNumber_t(0, 6))->getStatus(), ChangeFromWriterStatus_t::RECEIVED);
+                ASSERT_EQ(wproxy.changes_from_writer_.find(SequenceNumber_t(0, 7))->getStatus(), ChangeFromWriterStatus_t::UNKNOWN);
+                ASSERT_EQ(wproxy.changes_from_writer_.find(SequenceNumber_t(0, 8))->getStatus(), ChangeFromWriterStatus_t::RECEIVED);
 
                 // Add received change with sequence number 4
                 wproxy.received_change_set(SequenceNumber_t(0, 4));
-                ASSERT_EQ(wproxy.changesFromWLowMark_, SequenceNumber_t(0, 4));
-                ASSERT_EQ(wproxy.m_changesFromW.size(), 4u);
-                ASSERT_EQ(wproxy.m_changesFromW.find(SequenceNumber_t(0, 5))->getStatus(), ChangeFromWriterStatus_t::UNKNOWN);
-                ASSERT_EQ(wproxy.m_changesFromW.find(SequenceNumber_t(0, 6))->getStatus(), ChangeFromWriterStatus_t::RECEIVED);
-                ASSERT_EQ(wproxy.m_changesFromW.find(SequenceNumber_t(0, 7))->getStatus(), ChangeFromWriterStatus_t::UNKNOWN);
-                ASSERT_EQ(wproxy.m_changesFromW.find(SequenceNumber_t(0, 8))->getStatus(), ChangeFromWriterStatus_t::RECEIVED);
+                ASSERT_EQ(wproxy.changes_from_writer_low_mark_, SequenceNumber_t(0, 4));
+                ASSERT_EQ(wproxy.changes_from_writer_.size(), 4u);
+                ASSERT_EQ(wproxy.changes_from_writer_.find(SequenceNumber_t(0, 5))->getStatus(), ChangeFromWriterStatus_t::UNKNOWN);
+                ASSERT_EQ(wproxy.changes_from_writer_.find(SequenceNumber_t(0, 6))->getStatus(), ChangeFromWriterStatus_t::RECEIVED);
+                ASSERT_EQ(wproxy.changes_from_writer_.find(SequenceNumber_t(0, 7))->getStatus(), ChangeFromWriterStatus_t::UNKNOWN);
+                ASSERT_EQ(wproxy.changes_from_writer_.find(SequenceNumber_t(0, 8))->getStatus(), ChangeFromWriterStatus_t::RECEIVED);
 
                 // Add received change with sequence number 5
                 wproxy.received_change_set(SequenceNumber_t(0, 5));
-                ASSERT_EQ(wproxy.changesFromWLowMark_, SequenceNumber_t(0, 6));
-                ASSERT_EQ(wproxy.m_changesFromW.size(), 2u);
-                ASSERT_EQ(wproxy.m_changesFromW.find(SequenceNumber_t(0, 7))->getStatus(), ChangeFromWriterStatus_t::UNKNOWN);
-                ASSERT_EQ(wproxy.m_changesFromW.find(SequenceNumber_t(0, 8))->getStatus(), ChangeFromWriterStatus_t::RECEIVED);
+                ASSERT_EQ(wproxy.changes_from_writer_low_mark_, SequenceNumber_t(0, 6));
+                ASSERT_EQ(wproxy.changes_from_writer_.size(), 2u);
+                ASSERT_EQ(wproxy.changes_from_writer_.find(SequenceNumber_t(0, 7))->getStatus(), ChangeFromWriterStatus_t::UNKNOWN);
+                ASSERT_EQ(wproxy.changes_from_writer_.find(SequenceNumber_t(0, 8))->getStatus(), ChangeFromWriterStatus_t::RECEIVED);
 
                 // Add received change with sequence number 7
                 wproxy.received_change_set(SequenceNumber_t(0, 7));
-                ASSERT_EQ(wproxy.changesFromWLowMark_, SequenceNumber_t(0, 8));
-                ASSERT_EQ(wproxy.m_changesFromW.size(), 0u);
+                ASSERT_EQ(wproxy.changes_from_writer_low_mark_, SequenceNumber_t(0, 8));
+                ASSERT_EQ(wproxy.changes_from_writer_.size(), 0u);
             }
 
             TEST(WriterProxyTests, IrrelevantChangeSet)
@@ -240,87 +240,87 @@ namespace eprosima
 
                 // Set irrelevant change with sequence number 3.
                 wproxy.irrelevant_change_set(SequenceNumber_t(0, 3));
-                ASSERT_EQ(wproxy.changesFromWLowMark_, SequenceNumber_t(0, 0));
-                ASSERT_EQ(wproxy.m_changesFromW.size(), 3u);
-                ASSERT_EQ(wproxy.m_changesFromW.find(SequenceNumber_t(0, 1))->getStatus(), ChangeFromWriterStatus_t::UNKNOWN);
-                ASSERT_EQ(wproxy.m_changesFromW.find(SequenceNumber_t(0, 2))->getStatus(), ChangeFromWriterStatus_t::UNKNOWN);
-                ASSERT_EQ(wproxy.m_changesFromW.find(SequenceNumber_t(0, 3))->getStatus(), ChangeFromWriterStatus_t::RECEIVED);
-                ASSERT_EQ(wproxy.m_changesFromW.find(SequenceNumber_t(0, 3))->isRelevant(), false);
+                ASSERT_EQ(wproxy.changes_from_writer_low_mark_, SequenceNumber_t(0, 0));
+                ASSERT_EQ(wproxy.changes_from_writer_.size(), 3u);
+                ASSERT_EQ(wproxy.changes_from_writer_.find(SequenceNumber_t(0, 1))->getStatus(), ChangeFromWriterStatus_t::UNKNOWN);
+                ASSERT_EQ(wproxy.changes_from_writer_.find(SequenceNumber_t(0, 2))->getStatus(), ChangeFromWriterStatus_t::UNKNOWN);
+                ASSERT_EQ(wproxy.changes_from_writer_.find(SequenceNumber_t(0, 3))->getStatus(), ChangeFromWriterStatus_t::RECEIVED);
+                ASSERT_EQ(wproxy.changes_from_writer_.find(SequenceNumber_t(0, 3))->isRelevant(), false);
 
                 // Add two UNKNOWN with sequence numberes 4 and 5.
-                wproxy.m_changesFromW.insert(ChangeFromWriter_t(SequenceNumber_t(0,4)));
-                wproxy.m_changesFromW.insert(ChangeFromWriter_t(SequenceNumber_t(0,5)));
+                wproxy.changes_from_writer_.insert(ChangeFromWriter_t(SequenceNumber_t(0,4)));
+                wproxy.changes_from_writer_.insert(ChangeFromWriter_t(SequenceNumber_t(0,5)));
 
                 // Set irrelevant change with sequence number 2
                 wproxy.irrelevant_change_set(SequenceNumber_t(0, 2));
-                ASSERT_EQ(wproxy.changesFromWLowMark_, SequenceNumber_t(0, 0));
-                ASSERT_EQ(wproxy.m_changesFromW.size(), 5u);
-                ASSERT_EQ(wproxy.m_changesFromW.find(SequenceNumber_t(0, 1))->getStatus(), ChangeFromWriterStatus_t::UNKNOWN);
-                ASSERT_EQ(wproxy.m_changesFromW.find(SequenceNumber_t(0, 2))->getStatus(), ChangeFromWriterStatus_t::RECEIVED);
-                ASSERT_EQ(wproxy.m_changesFromW.find(SequenceNumber_t(0, 2))->isRelevant(), false);
-                ASSERT_EQ(wproxy.m_changesFromW.find(SequenceNumber_t(0, 3))->getStatus(), ChangeFromWriterStatus_t::RECEIVED);
-                ASSERT_EQ(wproxy.m_changesFromW.find(SequenceNumber_t(0, 3))->isRelevant(), false);
-                ASSERT_EQ(wproxy.m_changesFromW.find(SequenceNumber_t(0, 4))->getStatus(), ChangeFromWriterStatus_t::UNKNOWN);
-                ASSERT_EQ(wproxy.m_changesFromW.find(SequenceNumber_t(0, 5))->getStatus(), ChangeFromWriterStatus_t::UNKNOWN);
+                ASSERT_EQ(wproxy.changes_from_writer_low_mark_, SequenceNumber_t(0, 0));
+                ASSERT_EQ(wproxy.changes_from_writer_.size(), 5u);
+                ASSERT_EQ(wproxy.changes_from_writer_.find(SequenceNumber_t(0, 1))->getStatus(), ChangeFromWriterStatus_t::UNKNOWN);
+                ASSERT_EQ(wproxy.changes_from_writer_.find(SequenceNumber_t(0, 2))->getStatus(), ChangeFromWriterStatus_t::RECEIVED);
+                ASSERT_EQ(wproxy.changes_from_writer_.find(SequenceNumber_t(0, 2))->isRelevant(), false);
+                ASSERT_EQ(wproxy.changes_from_writer_.find(SequenceNumber_t(0, 3))->getStatus(), ChangeFromWriterStatus_t::RECEIVED);
+                ASSERT_EQ(wproxy.changes_from_writer_.find(SequenceNumber_t(0, 3))->isRelevant(), false);
+                ASSERT_EQ(wproxy.changes_from_writer_.find(SequenceNumber_t(0, 4))->getStatus(), ChangeFromWriterStatus_t::UNKNOWN);
+                ASSERT_EQ(wproxy.changes_from_writer_.find(SequenceNumber_t(0, 5))->getStatus(), ChangeFromWriterStatus_t::UNKNOWN);
 
                 // Set irrelevant change with sequence number 1
                 wproxy.irrelevant_change_set(SequenceNumber_t(0, 1));
-                ASSERT_EQ(wproxy.changesFromWLowMark_, SequenceNumber_t(0, 3));
-                ASSERT_EQ(wproxy.m_changesFromW.size(), 2u);
-                ASSERT_EQ(wproxy.m_changesFromW.find(SequenceNumber_t(0, 4))->getStatus(), ChangeFromWriterStatus_t::UNKNOWN);
-                ASSERT_EQ(wproxy.m_changesFromW.find(SequenceNumber_t(0, 5))->getStatus(), ChangeFromWriterStatus_t::UNKNOWN);
+                ASSERT_EQ(wproxy.changes_from_writer_low_mark_, SequenceNumber_t(0, 3));
+                ASSERT_EQ(wproxy.changes_from_writer_.size(), 2u);
+                ASSERT_EQ(wproxy.changes_from_writer_.find(SequenceNumber_t(0, 4))->getStatus(), ChangeFromWriterStatus_t::UNKNOWN);
+                ASSERT_EQ(wproxy.changes_from_writer_.find(SequenceNumber_t(0, 5))->getStatus(), ChangeFromWriterStatus_t::UNKNOWN);
 
                 // Try to update LOST changes util sequence number 3.
                 wproxy.irrelevant_change_set(SequenceNumber_t(0, 3));
-                ASSERT_EQ(wproxy.changesFromWLowMark_, SequenceNumber_t(0, 3));
-                ASSERT_EQ(wproxy.m_changesFromW.size(), 2u);
-                ASSERT_EQ(wproxy.m_changesFromW.find(SequenceNumber_t(0, 4))->getStatus(), ChangeFromWriterStatus_t::UNKNOWN);
-                ASSERT_EQ(wproxy.m_changesFromW.find(SequenceNumber_t(0, 5))->getStatus(), ChangeFromWriterStatus_t::UNKNOWN);
+                ASSERT_EQ(wproxy.changes_from_writer_low_mark_, SequenceNumber_t(0, 3));
+                ASSERT_EQ(wproxy.changes_from_writer_.size(), 2u);
+                ASSERT_EQ(wproxy.changes_from_writer_.find(SequenceNumber_t(0, 4))->getStatus(), ChangeFromWriterStatus_t::UNKNOWN);
+                ASSERT_EQ(wproxy.changes_from_writer_.find(SequenceNumber_t(0, 5))->getStatus(), ChangeFromWriterStatus_t::UNKNOWN);
 
                 // Add irrelevant change with sequence number 6
                 wproxy.irrelevant_change_set(SequenceNumber_t(0, 6));
-                ASSERT_EQ(wproxy.changesFromWLowMark_, SequenceNumber_t(0, 3));
-                ASSERT_EQ(wproxy.m_changesFromW.size(), 3u);
-                ASSERT_EQ(wproxy.m_changesFromW.find(SequenceNumber_t(0, 4))->getStatus(), ChangeFromWriterStatus_t::UNKNOWN);
-                ASSERT_EQ(wproxy.m_changesFromW.find(SequenceNumber_t(0, 5))->getStatus(), ChangeFromWriterStatus_t::UNKNOWN);
-                ASSERT_EQ(wproxy.m_changesFromW.find(SequenceNumber_t(0, 6))->getStatus(), ChangeFromWriterStatus_t::RECEIVED);
-                ASSERT_EQ(wproxy.m_changesFromW.find(SequenceNumber_t(0, 6))->isRelevant(), false);
+                ASSERT_EQ(wproxy.changes_from_writer_low_mark_, SequenceNumber_t(0, 3));
+                ASSERT_EQ(wproxy.changes_from_writer_.size(), 3u);
+                ASSERT_EQ(wproxy.changes_from_writer_.find(SequenceNumber_t(0, 4))->getStatus(), ChangeFromWriterStatus_t::UNKNOWN);
+                ASSERT_EQ(wproxy.changes_from_writer_.find(SequenceNumber_t(0, 5))->getStatus(), ChangeFromWriterStatus_t::UNKNOWN);
+                ASSERT_EQ(wproxy.changes_from_writer_.find(SequenceNumber_t(0, 6))->getStatus(), ChangeFromWriterStatus_t::RECEIVED);
+                ASSERT_EQ(wproxy.changes_from_writer_.find(SequenceNumber_t(0, 6))->isRelevant(), false);
 
                 // Add irrelevant change with sequence number 8
                 wproxy.irrelevant_change_set(SequenceNumber_t(0, 8));
-                ASSERT_EQ(wproxy.changesFromWLowMark_, SequenceNumber_t(0, 3));
-                ASSERT_EQ(wproxy.m_changesFromW.size(), 5u);
-                ASSERT_EQ(wproxy.m_changesFromW.find(SequenceNumber_t(0, 4))->getStatus(), ChangeFromWriterStatus_t::UNKNOWN);
-                ASSERT_EQ(wproxy.m_changesFromW.find(SequenceNumber_t(0, 5))->getStatus(), ChangeFromWriterStatus_t::UNKNOWN);
-                ASSERT_EQ(wproxy.m_changesFromW.find(SequenceNumber_t(0, 6))->getStatus(), ChangeFromWriterStatus_t::RECEIVED);
-                ASSERT_EQ(wproxy.m_changesFromW.find(SequenceNumber_t(0, 6))->isRelevant(), false);
-                ASSERT_EQ(wproxy.m_changesFromW.find(SequenceNumber_t(0, 7))->getStatus(), ChangeFromWriterStatus_t::UNKNOWN);
-                ASSERT_EQ(wproxy.m_changesFromW.find(SequenceNumber_t(0, 8))->getStatus(), ChangeFromWriterStatus_t::RECEIVED);
-                ASSERT_EQ(wproxy.m_changesFromW.find(SequenceNumber_t(0, 8))->isRelevant(), false);
+                ASSERT_EQ(wproxy.changes_from_writer_low_mark_, SequenceNumber_t(0, 3));
+                ASSERT_EQ(wproxy.changes_from_writer_.size(), 5u);
+                ASSERT_EQ(wproxy.changes_from_writer_.find(SequenceNumber_t(0, 4))->getStatus(), ChangeFromWriterStatus_t::UNKNOWN);
+                ASSERT_EQ(wproxy.changes_from_writer_.find(SequenceNumber_t(0, 5))->getStatus(), ChangeFromWriterStatus_t::UNKNOWN);
+                ASSERT_EQ(wproxy.changes_from_writer_.find(SequenceNumber_t(0, 6))->getStatus(), ChangeFromWriterStatus_t::RECEIVED);
+                ASSERT_EQ(wproxy.changes_from_writer_.find(SequenceNumber_t(0, 6))->isRelevant(), false);
+                ASSERT_EQ(wproxy.changes_from_writer_.find(SequenceNumber_t(0, 7))->getStatus(), ChangeFromWriterStatus_t::UNKNOWN);
+                ASSERT_EQ(wproxy.changes_from_writer_.find(SequenceNumber_t(0, 8))->getStatus(), ChangeFromWriterStatus_t::RECEIVED);
+                ASSERT_EQ(wproxy.changes_from_writer_.find(SequenceNumber_t(0, 8))->isRelevant(), false);
 
                 // Add irrelevant change with sequence number 4
                 wproxy.irrelevant_change_set(SequenceNumber_t(0, 4));
-                ASSERT_EQ(wproxy.changesFromWLowMark_, SequenceNumber_t(0, 4));
-                ASSERT_EQ(wproxy.m_changesFromW.size(), 4u);
-                ASSERT_EQ(wproxy.m_changesFromW.find(SequenceNumber_t(0, 5))->getStatus(), ChangeFromWriterStatus_t::UNKNOWN);
-                ASSERT_EQ(wproxy.m_changesFromW.find(SequenceNumber_t(0, 6))->getStatus(), ChangeFromWriterStatus_t::RECEIVED);
-                ASSERT_EQ(wproxy.m_changesFromW.find(SequenceNumber_t(0, 6))->isRelevant(), false);
-                ASSERT_EQ(wproxy.m_changesFromW.find(SequenceNumber_t(0, 7))->getStatus(), ChangeFromWriterStatus_t::UNKNOWN);
-                ASSERT_EQ(wproxy.m_changesFromW.find(SequenceNumber_t(0, 8))->getStatus(), ChangeFromWriterStatus_t::RECEIVED);
-                ASSERT_EQ(wproxy.m_changesFromW.find(SequenceNumber_t(0, 8))->isRelevant(), false);
+                ASSERT_EQ(wproxy.changes_from_writer_low_mark_, SequenceNumber_t(0, 4));
+                ASSERT_EQ(wproxy.changes_from_writer_.size(), 4u);
+                ASSERT_EQ(wproxy.changes_from_writer_.find(SequenceNumber_t(0, 5))->getStatus(), ChangeFromWriterStatus_t::UNKNOWN);
+                ASSERT_EQ(wproxy.changes_from_writer_.find(SequenceNumber_t(0, 6))->getStatus(), ChangeFromWriterStatus_t::RECEIVED);
+                ASSERT_EQ(wproxy.changes_from_writer_.find(SequenceNumber_t(0, 6))->isRelevant(), false);
+                ASSERT_EQ(wproxy.changes_from_writer_.find(SequenceNumber_t(0, 7))->getStatus(), ChangeFromWriterStatus_t::UNKNOWN);
+                ASSERT_EQ(wproxy.changes_from_writer_.find(SequenceNumber_t(0, 8))->getStatus(), ChangeFromWriterStatus_t::RECEIVED);
+                ASSERT_EQ(wproxy.changes_from_writer_.find(SequenceNumber_t(0, 8))->isRelevant(), false);
 
                 // Add irrelevant change with sequence number 5
                 wproxy.irrelevant_change_set(SequenceNumber_t(0, 5));
-                ASSERT_EQ(wproxy.changesFromWLowMark_, SequenceNumber_t(0, 6));
-                ASSERT_EQ(wproxy.m_changesFromW.size(), 2u);
-                ASSERT_EQ(wproxy.m_changesFromW.find(SequenceNumber_t(0, 7))->getStatus(), ChangeFromWriterStatus_t::UNKNOWN);
-                ASSERT_EQ(wproxy.m_changesFromW.find(SequenceNumber_t(0, 8))->getStatus(), ChangeFromWriterStatus_t::RECEIVED);
-                ASSERT_EQ(wproxy.m_changesFromW.find(SequenceNumber_t(0, 8))->isRelevant(), false);
+                ASSERT_EQ(wproxy.changes_from_writer_low_mark_, SequenceNumber_t(0, 6));
+                ASSERT_EQ(wproxy.changes_from_writer_.size(), 2u);
+                ASSERT_EQ(wproxy.changes_from_writer_.find(SequenceNumber_t(0, 7))->getStatus(), ChangeFromWriterStatus_t::UNKNOWN);
+                ASSERT_EQ(wproxy.changes_from_writer_.find(SequenceNumber_t(0, 8))->getStatus(), ChangeFromWriterStatus_t::RECEIVED);
+                ASSERT_EQ(wproxy.changes_from_writer_.find(SequenceNumber_t(0, 8))->isRelevant(), false);
 
                 // Add irrelevant change with sequence number 7
                 wproxy.irrelevant_change_set(SequenceNumber_t(0, 7));
-                ASSERT_EQ(wproxy.changesFromWLowMark_, SequenceNumber_t(0, 8));
-                ASSERT_EQ(wproxy.m_changesFromW.size(), 0u);
+                ASSERT_EQ(wproxy.changes_from_writer_low_mark_, SequenceNumber_t(0, 8));
+                ASSERT_EQ(wproxy.changes_from_writer_.size(), 0u);
             }
 
         } // namespace rtps

--- a/test/unittest/rtps/reader/WriterProxyTests.cpp
+++ b/test/unittest/rtps/reader/WriterProxyTests.cpp
@@ -36,7 +36,7 @@ namespace eprosima
             {
                 RemoteWriterAttributes wattr;
                 StatefulReader readerMock;
-                WriterProxy wproxy(&readerMock);
+                WriterProxy wproxy(&readerMock, ResourceLimitedContainerConfig());
                 wproxy.start(wattr);
 
                 // Update MISSING changes util sequence number 3.
@@ -107,7 +107,7 @@ namespace eprosima
             {
                 RemoteWriterAttributes wattr;
                 StatefulReader readerMock;
-                WriterProxy wproxy(&readerMock);
+                WriterProxy wproxy(&readerMock, ResourceLimitedContainerConfig());
                 wproxy.start(wattr);
 
                 // Update LOST changes util sequence number 3.
@@ -156,7 +156,7 @@ namespace eprosima
             {
                 RemoteWriterAttributes wattr;
                 StatefulReader readerMock;
-                WriterProxy wproxy(&readerMock);
+                WriterProxy wproxy(&readerMock, ResourceLimitedContainerConfig());
                 wproxy.start(wattr);
 
                 // Set received change with sequence number 3.
@@ -239,7 +239,7 @@ namespace eprosima
             {
                 RemoteWriterAttributes wattr;
                 StatefulReader readerMock;
-                WriterProxy wproxy(&readerMock);
+                WriterProxy wproxy(&readerMock, ResourceLimitedContainerConfig());
                 wproxy.start(wattr);
 
                 // Set irrelevant change with sequence number 3.

--- a/test/unittest/transport/CMakeLists.txt
+++ b/test/unittest/transport/CMakeLists.txt
@@ -192,7 +192,7 @@ if(NOT ((MSVC OR MSVC_IDE) AND EPROSIMA_INSTALLER))
             ${PROJECT_SOURCE_DIR}/test/mock/rtps/MessageReceiver
             ${PROJECT_SOURCE_DIR}/test/mock/rtps/ReceiverResource
             ${PROJECT_SOURCE_DIR}/include ${PROJECT_BINARY_DIR}/include)
-        target_link_libraries(UDPv4Tests ${GTEST_LIBRARIES} ${MOCKS})
+        target_link_libraries(UDPv4Tests foonathan_memory ${GTEST_LIBRARIES} ${MOCKS})
         if(MSVC OR MSVC_IDE)
             target_link_libraries(UDPv4Tests ${PRIVACY} iphlpapi Shlwapi )
         endif()
@@ -208,7 +208,7 @@ if(NOT ((MSVC OR MSVC_IDE) AND EPROSIMA_INSTALLER))
                 ${PROJECT_SOURCE_DIR}/test/mock/rtps/MessageReceiver
                 ${PROJECT_SOURCE_DIR}/test/mock/rtps/ReceiverResource
                 ${PROJECT_SOURCE_DIR}/include ${PROJECT_BINARY_DIR}/include)
-            target_link_libraries(UDPv6Tests ${GTEST_LIBRARIES} ${MOCKS})
+            target_link_libraries(UDPv6Tests foonathan_memory ${GTEST_LIBRARIES} ${MOCKS})
             if(MSVC OR MSVC_IDE)
                 target_link_libraries(UDPv6Tests ${PRIVACY} iphlpapi Shlwapi )
             endif()
@@ -223,7 +223,7 @@ if(NOT ((MSVC OR MSVC_IDE) AND EPROSIMA_INSTALLER))
                 ${PROJECT_SOURCE_DIR}/test/mock/rtps/MessageReceiver
                 ${PROJECT_SOURCE_DIR}/test/mock/rtps/ReceiverResource
                 ${PROJECT_SOURCE_DIR}/include ${PROJECT_BINARY_DIR}/include)
-            target_link_libraries(TCPv6Tests ${GTEST_LIBRARIES} ${MOCKS}
+            target_link_libraries(TCPv6Tests foonathan_memory ${GTEST_LIBRARIES} ${MOCKS}
                 $<$<BOOL:${TLS_FOUND}>:OpenSSL::SSL$<SEMICOLON>OpenSSL::Crypto>)
             if(MSVC OR MSVC_IDE)
                 target_link_libraries(TCPv6Tests ${PRIVACY} fastcdr iphlpapi Shlwapi)
@@ -242,7 +242,7 @@ if(NOT ((MSVC OR MSVC_IDE) AND EPROSIMA_INSTALLER))
             ${PROJECT_SOURCE_DIR}/test/mock/rtps/MessageReceiver
             ${PROJECT_SOURCE_DIR}/test/mock/rtps/ReceiverResource
             ${PROJECT_SOURCE_DIR}/include ${PROJECT_BINARY_DIR}/include)
-        target_link_libraries(test_UDPv4Tests ${GTEST_LIBRARIES} ${MOCKS})
+        target_link_libraries(test_UDPv4Tests foonathan_memory ${GTEST_LIBRARIES} ${MOCKS})
         if(MSVC OR MSVC_IDE)
             target_link_libraries(test_UDPv4Tests ${PRIVACY} iphlpapi Shlwapi)
         else()
@@ -259,7 +259,7 @@ if(NOT ((MSVC OR MSVC_IDE) AND EPROSIMA_INSTALLER))
             ${PROJECT_SOURCE_DIR}/test/mock/rtps/MessageReceiver
             ${PROJECT_SOURCE_DIR}/test/mock/rtps/ReceiverResource
             ${PROJECT_SOURCE_DIR}/include ${PROJECT_BINARY_DIR}/include)
-        target_link_libraries(TCPv4Tests ${GTEST_LIBRARIES} ${MOCKS}
+        target_link_libraries(TCPv4Tests foonathan_memory ${GTEST_LIBRARIES} ${MOCKS}
             $<$<BOOL:${TLS_FOUND}>:OpenSSL::SSL$<SEMICOLON>OpenSSL::Crypto>)
         if(MSVC OR MSVC_IDE)
             target_link_libraries(TCPv4Tests ${PRIVACY} fastcdr iphlpapi Shlwapi)

--- a/test/unittest/xmlparser/XMLProfileParserTests.cpp
+++ b/test/unittest/xmlparser/XMLProfileParserTests.cpp
@@ -408,6 +408,7 @@ TEST_F(XMLProfileParserTests, XMLParserSubscriber)
     EXPECT_EQ(subscriber_atts.historyMemoryPolicy, PREALLOCATED_WITH_REALLOC_MEMORY_MODE);
     EXPECT_EQ(subscriber_atts.getUserDefinedID(), 13);
     EXPECT_EQ(subscriber_atts.getEntityID(), 31);
+    EXPECT_EQ(subscriber_atts.matched_publisher_allocation, ResourceLimitedContainerConfig::fixed_size_configuration(10u));
 }
 
 TEST_F(XMLProfileParserTests, XMLParserDefaultSubscriberProfile)
@@ -472,6 +473,7 @@ TEST_F(XMLProfileParserTests, XMLParserDefaultSubscriberProfile)
     EXPECT_EQ(subscriber_atts.historyMemoryPolicy, PREALLOCATED_WITH_REALLOC_MEMORY_MODE);
     EXPECT_EQ(subscriber_atts.getUserDefinedID(), 13);
     EXPECT_EQ(subscriber_atts.getEntityID(), 31);
+    EXPECT_EQ(subscriber_atts.matched_publisher_allocation, ResourceLimitedContainerConfig::fixed_size_configuration(10u));
 }
 
 #if HAVE_SECURITY

--- a/test/unittest/xmlparser/test_xml_profiles.xml
+++ b/test/unittest/xmlparser/test_xml_profiles.xml
@@ -297,6 +297,11 @@
         <historyMemoryPolicy>PREALLOCATED_WITH_REALLOC</historyMemoryPolicy>
         <userDefinedID>13</userDefinedID>
         <entityID>31</entityID>
+        <matchedPublishersAllocation>
+            <initial>10</initial>
+            <maximum>10</maximum>
+            <increment>0</increment>
+        </matchedPublishersAllocation>
     </subscriber>
 
 </profiles>

--- a/test/unittest/xmlparser/test_xml_profiles_rooted.xml
+++ b/test/unittest/xmlparser/test_xml_profiles_rooted.xml
@@ -295,6 +295,11 @@
             <historyMemoryPolicy>PREALLOCATED_WITH_REALLOC</historyMemoryPolicy>
             <userDefinedID>13</userDefinedID>
             <entityID>31</entityID>
+            <matchedPublishersAllocation>
+                <initial>10</initial>
+                <maximum>20</maximum>
+                <increment>2</increment>
+            </matchedPublishersAllocation>
         </subscriber>
 
     </profiles>


### PR DESCRIPTION
This PR:
* Adds `matched_publisher_allocation` to `SubscriberAttributes`
* Adds `matched_writers_allocation` to `ReaderAttributes`
* Adds a dependency on [foonathan_memory](https://github.com/foonathan/memory)
* Refactors the collections on `RTPSReader`, `StatelessReader` and `StatefulReader` that depend on the number of matched writers to be resouce limited by `matched_writers_allocation`.
* Refactors `WriterProxy` to allow for its reuse and having a pool on `StatefulReader`
* Refactors the collections on `WriterProxy` that depend on the resource limits of the writer's history to be resource limited.