### PR TITLE
[Windows] No need to expose linked libs when the target is a shared lib

### DIFF
--- a/src/cpp/CMakeLists.txt
+++ b/src/cpp/CMakeLists.txt
@@ -278,10 +278,7 @@ elseif(NOT EPROSIMA_INSTALLER)
     endif()
 
     # Link library to external libraries.
-    target_link_directories(${PROJECT_NAME} ${PRIVACY}
-        ${TINYXML2_LIBRARY_DIRS}
-        )
-    target_link_libraries(${PROJECT_NAME} ${PRIVACY} fastcdr
+    target_link_libraries(${PROJECT_NAME} PRIVATE fastcdr
         ${CMAKE_THREAD_LIBS_INIT} ${CMAKE_DL_LIBS}
         ${TINYXML2_LIBRARY}
         $<$<BOOL:${SECURITY}>:OpenSSL::SSL$<SEMICOLON>OpenSSL::Crypto>

--- a/src/cpp/CMakeLists.txt
+++ b/src/cpp/CMakeLists.txt
@@ -278,6 +278,9 @@ elseif(NOT EPROSIMA_INSTALLER)
     endif()
 
     # Link library to external libraries.
+    target_link_directories(${PROJECT_NAME}
+        ${TINYXML2_LIBRARY_DIRS}
+        )
     target_link_libraries(${PROJECT_NAME} ${PRIVACY} fastcdr
         ${CMAKE_THREAD_LIBS_INIT} ${CMAKE_DL_LIBS}
         ${TINYXML2_LIBRARY}

--- a/src/cpp/CMakeLists.txt
+++ b/src/cpp/CMakeLists.txt
@@ -277,8 +277,13 @@ elseif(NOT EPROSIMA_INSTALLER)
         set(PRIVACY "PRIVATE")
     endif()
 
+    # No need to expose linked libs when shared library is built.
+    if(BUILD_SHARED_LIBS)
+        set(PRIVACY "PRIVATE")
+    endif()
+
     # Link library to external libraries.
-    target_link_libraries(${PROJECT_NAME} PRIVATE fastcdr
+    target_link_libraries(${PROJECT_NAME} ${PRIVACY} fastcdr
         ${CMAKE_THREAD_LIBS_INIT} ${CMAKE_DL_LIBS}
         ${TINYXML2_LIBRARY}
         $<$<BOOL:${SECURITY}>:OpenSSL::SSL$<SEMICOLON>OpenSSL::Crypto>

--- a/src/cpp/CMakeLists.txt
+++ b/src/cpp/CMakeLists.txt
@@ -277,8 +277,8 @@ elseif(NOT EPROSIMA_INSTALLER)
         set(PRIVACY "PRIVATE")
     endif()
 
-    # No need to expose linked libs when shared library is built.
-    if(BUILD_SHARED_LIBS)
+    # No need to expose linked libs when target is a shared library on MSVC.
+    if(BUILD_SHARED_LIBS AND MSVC)
         set(PRIVACY "PRIVATE")
     endif()
 

--- a/src/cpp/CMakeLists.txt
+++ b/src/cpp/CMakeLists.txt
@@ -278,7 +278,7 @@ elseif(NOT EPROSIMA_INSTALLER)
     endif()
 
     # Link library to external libraries.
-    target_link_directories(${PROJECT_NAME}
+    target_link_directories(${PROJECT_NAME} ${PRIVACY}
         ${TINYXML2_LIBRARY_DIRS}
         )
     target_link_libraries(${PROJECT_NAME} ${PRIVACY} fastcdr


### PR DESCRIPTION
This problem manifests when I am building ROS2 build on Windows. When building `rmw_fastrtps_shared_cpp.dll`, it doesn't need to link with `tinyxml2.lib` but which is included in linker command. It's because `fastrtps` exposes the linked libs, and it is eventually propagating to `fastrtps-targets.cmake`. After making those linked libs for `fastrtps` to be `PRIVATE`, I am able to pass and build the rest of packages.

Here is the code snippet from `fastrtps-targets.cmake`:
```
set_target_properties(fastrtps PROPERTIES
  INTERFACE_COMPILE_DEFINITIONS "FASTRTPS_DYN_LINK"
  INTERFACE_INCLUDE_DIRECTORIES "${_IMPORT_PREFIX}/include"
  INTERFACE_LINK_LIBRARIES "fastcdr;tinyxml2;\$<\$<BOOL:OFF>:OpenSSL::SSL\$<SEMICOLON>OpenSSL::Crypto>;\$<\$<BOOL:1>:iphlpapi\$<SEMICOLON>Shlwapi>"
)
```

Here is the log showing `tinyxml2.lib` included:
```
Link:
  C:\Program Files (x86)\Microsoft Visual Studio\2017\Enterprise\VC\Tools\MSVC\14.16.27023\bin\HostX86\x64\link.exe /ERRORREPORT:QUEUE /OUT:"C:\opt\ros2\build\rmw_fastrtps_shared_cpp\Release\rmw_fastrtps_shared_cpp.dll" /INCREMENTAL:NO /NOLOGO "C:\opt\ros\crystal\x64\lib\fastrtps-1.7.lib" C:\opt\ros\crystal\x64\Lib\rcutils.lib C:\opt\ros\crystal\x64\Lib\rosidl_generator_c.lib C:\opt\ros\crystal\x64\Lib\rmw.lib "C:\opt\ros\crystal\x64\lib\fastcdr-1.0.lib" tinyxml2.lib iphlpapi.lib Shlwapi.lib kernel32.lib user32.lib gdi32.lib winspool.lib shell32.lib ole32.lib oleaut32.lib uuid.lib comdlg32.lib advapi32.lib /MANIFEST /MANIFESTUAC:"level='asInvoker' uiAccess='false'" /manifest:embed /PDB:"C:/opt/ros2/build/rmw_fastrtps_shared_cpp/Release/rmw_fastrtps_shared_cpp.pdb" /SUBSYSTEM:CONSOLE /TLBID:1 /DYNAMICBASE /NXCOMPAT /IMPLIB:"C:/opt/ros2/build/rmw_fastrtps_shared_cpp/Release/rmw_fastrtps_shared_cpp.lib" /MACHINE:X64  /machine:x64 /DLL rmw_fastrtps_shared_cpp.dir\Release\demangle.obj
  rmw_fastrtps_shared_cpp.dir\Release\namespace_prefix.obj
  rmw_fastrtps_shared_cpp.dir\Release\qos.obj
  rmw_fastrtps_shared_cpp.dir\Release\rmw_client.obj
  rmw_fastrtps_shared_cpp.dir\Release\rmw_compare_gids_equal.obj
  rmw_fastrtps_shared_cpp.dir\Release\rmw_count.obj
  rmw_fastrtps_shared_cpp.dir\Release\rmw_get_gid_for_publisher.obj
  rmw_fastrtps_shared_cpp.dir\Release\rmw_guard_condition.obj
  rmw_fastrtps_shared_cpp.dir\Release\rmw_logging.obj
  rmw_fastrtps_shared_cpp.dir\Release\rmw_node.obj
  rmw_fastrtps_shared_cpp.dir\Release\rmw_node_info_and_types.obj
  rmw_fastrtps_shared_cpp.dir\Release\rmw_node_names.obj
  rmw_fastrtps_shared_cpp.dir\Release\rmw_publish.obj
  rmw_fastrtps_shared_cpp.dir\Release\rmw_publisher.obj
  rmw_fastrtps_shared_cpp.dir\Release\rmw_request.obj
  rmw_fastrtps_shared_cpp.dir\Release\rmw_response.obj
  rmw_fastrtps_shared_cpp.dir\Release\rmw_service.obj
  rmw_fastrtps_shared_cpp.dir\Release\rmw_service_names_and_types.obj
  rmw_fastrtps_shared_cpp.dir\Release\rmw_service_server_is_available.obj
  rmw_fastrtps_shared_cpp.dir\Release\rmw_subscription.obj
  rmw_fastrtps_shared_cpp.dir\Release\rmw_take.obj
  rmw_fastrtps_shared_cpp.dir\Release\rmw_topic_names_and_types.obj
  rmw_fastrtps_shared_cpp.dir\Release\rmw_trigger_guard_condition.obj
  rmw_fastrtps_shared_cpp.dir\Release\rmw_wait.obj
  rmw_fastrtps_shared_cpp.dir\Release\rmw_wait_set.obj
  rmw_fastrtps_shared_cpp.dir\Release\TypeSupport_impl.obj
LINK : fatal error LNK1181: cannot open input file 'tinyxml2.lib' [C:\opt\ros2\build\rmw_fastrtps_shared_cpp\rmw_fastrtps_shared_cpp.vcxproj]
Done Building Project "C:\opt\ros2\build\rmw_fastrtps_shared_cpp\rmw_fastrtps_shared_cpp.vcxproj" (default targets) -- FAILED.
Done Building Project "C:\opt\ros2\build\rmw_fastrtps_shared_cpp\ALL_BUILD.vcxproj" (default targets) -- FAILED.

Build FAILED.

"C:\opt\ros2\build\rmw_fastrtps_shared_cpp\ALL_BUILD.vcxproj" (default target) (1) ->
"C:\opt\ros2\build\rmw_fastrtps_shared_cpp\rmw_fastrtps_shared_cpp.vcxproj" (default target) (3) ->
(Link target) -> 
  LINK : fatal error LNK1181: cannot open input file 'tinyxml2.lib' [C:\opt\ros2\build\rmw_fastrtps_shared_cpp\rmw_fastrtps_shared_cpp.vcxproj]

    0 Warning(s)
    1 Error(s)

Time Elapsed 00:00:31.56
---
Failed   <<< rmw_fastrtps_shared_cpp	[ Exited with code 1 ]
```