### PR TITLE
ReaderProxy history reloaded incorrectly missing GAP message [4962]

### DIFF
--- a/src/cpp/rtps/writer/StatefulWriter.cpp
+++ b/src/cpp/rtps/writer/StatefulWriter.cpp
@@ -617,8 +617,16 @@ bool StatefulWriter::matched_reader_add(RemoteReaderAttributes& rdata)
             rp->add_change(changeForReader, false);
             ++current_seq;
         }
-
-        assert(last_seq + 1 == current_seq);
+        // This is to cover the case where the last change has been removed from the history
+        while(current_seq < next_sequence_number())
+        {
+            ChangeForReader_t changeForReader(current_seq);
+            changeForReader.setRelevance(false);
+            not_relevant_changes.insert(current_seq);
+            changeForReader.setStatus(UNACKNOWLEDGED);
+            rp->add_change(changeForReader, false);
+            ++current_seq;
+        }
 
         try
         {


### PR DESCRIPTION
The problem is invalid changes at the end of the stateful writer history don't get added to a newly connected reader proxy cache causing the reader proxy to miss a lot of invalid changed and not generate the proper GAP message.

The fix is to make sure the missing changes are loaded into the reader proxy history so that the GAP message is properly generated.

should fix #452