### PR TITLE
Maximum Domain ID limitation [5151]

### DIFF
--- a/include/fastrtps/rtps/attributes/RTPSParticipantAttributes.h
+++ b/include/fastrtps/rtps/attributes/RTPSParticipantAttributes.h
@@ -106,19 +106,28 @@ class BuiltinAttributes{
          * DomainId to be used by the RTPSParticipant (80 by default).
          */
         uint32_t domainId;
-        //!Lease Duration of the RTPSParticipant, indicating how much time remote RTPSParticipants should consider this RTPSParticipant alive.
+
+        /**
+         * Lease Duration of the RTPSParticipant,
+         * indicating how much time remote RTPSParticipants should consider this RTPSParticipant alive.
+         */
         Duration_t leaseDuration;
+
         /**
          * The period for the RTPSParticipant to send its Discovery Message to all other discovered RTPSParticipants
          * as well as to all Multicast ports.
          */
         Duration_t leaseDuration_announcementperiod;
+
         //!Attributes of the SimpleEDP protocol
         SimpleEDPAttributes m_simpleEDP;
+
         //!Metatraffic Unicast Locator List
         LocatorList_t metatrafficUnicastLocatorList;
+
         //!Metatraffic Multicast Locator List.
         LocatorList_t metatrafficMulticastLocatorList;
+
         //! Initial peers.
         LocatorList_t initialPeersList;
 

--- a/include/fastrtps/rtps/common/PortParameters.h
+++ b/include/fastrtps/rtps/common/PortParameters.h
@@ -20,6 +20,7 @@
 #define _PORT_PARAMETERS_H_
 
 #include "Types.h"
+#include <fastrtps/log/Log.h>
 
 namespace eprosima {
 namespace fastrtps{
@@ -63,7 +64,16 @@ public:
      */
     inline uint32_t getMulticastPort(uint32_t domainId) const
     {
-        return portBase+ domainIDGain * domainId+ offsetd0;
+        uint32_t port = portBase + domainIDGain * domainId + offsetd0;
+
+        if (port > 65535)
+        {
+            logError(RTPS, "Calculated port number is too high. Probably the domainId is over 232 "
+                << "or portBase is too high.");
+            exit(EXIT_FAILURE);
+        }
+
+        return port;
     }
     /**
      * Get a unicast port baes on the domain ID and the participant ID.
@@ -74,7 +84,16 @@ public:
      */
     inline uint32_t getUnicastPort(uint32_t domainId,uint32_t RTPSParticipantID) const
     {
-        return portBase+ domainIDGain * domainId + offsetd1	+ participantIDGain * RTPSParticipantID;
+        uint32_t port = portBase + domainIDGain * domainId + offsetd1	+ participantIDGain * RTPSParticipantID;
+
+        if (port > 65535)
+        {
+            logError(RTPS, "Calculated port number is too high. Probably the domainId is over 232, there are "
+                << "too much participants created or portBase is too high.");
+            exit(EXIT_FAILURE);
+        }
+
+        return port;
     }
 
 public:

--- a/include/fastrtps/rtps/common/PortParameters.h
+++ b/include/fastrtps/rtps/common/PortParameters.h
@@ -70,6 +70,9 @@ public:
         {
             logError(RTPS, "Calculated port number is too high. Probably the domainId is over 232 "
                 << "or portBase is too high.");
+            std::cout << "Calculated port number is too high. Probably the domainId is over 232 "
+                << "or portBase is too high." << std::endl;
+            std::cout.flush();
             exit(EXIT_FAILURE);
         }
 
@@ -90,6 +93,9 @@ public:
         {
             logError(RTPS, "Calculated port number is too high. Probably the domainId is over 232, there are "
                 << "too much participants created or portBase is too high.");
+            std::cout << "Calculated port number is too high. Probably the domainId is over 232, there are "
+                << "too much participants created or portBase is too high." << std::endl;
+            std::cout.flush();
             exit(EXIT_FAILURE);
         }
 

--- a/src/cpp/rtps/network/NetworkFactory.cpp
+++ b/src/cpp/rtps/network/NetworkFactory.cpp
@@ -298,6 +298,9 @@ uint16_t NetworkFactory::calculateWellKnownPort(const RTPSParticipantAttributes&
     {
         logError(RTPS, "Calculated port number is too high. Probably the domainId is over 232, there are "
             << "too much participants created or portBase is too high.");
+        std::cout << "Calculated port number is too high. Probably the domainId is over 232, there are "
+            << "too much participants created or portBase is too high." << std::endl;
+        std::cout.flush();
         exit(EXIT_FAILURE);
     }
 

--- a/src/cpp/rtps/network/NetworkFactory.cpp
+++ b/src/cpp/rtps/network/NetworkFactory.cpp
@@ -288,10 +288,20 @@ void NetworkFactory::Shutdown()
 
 uint16_t NetworkFactory::calculateWellKnownPort(const RTPSParticipantAttributes& att) const
 {
-    return static_cast<uint16_t>(att.port.portBase +
-            att.port.domainIDGain*att.builtin.domainId +
-            att.port.offsetd3 +
-            att.port.participantIDGain*att.participantID);
+
+    uint32_t port = att.port.portBase +
+        att.port.domainIDGain * att.builtin.domainId +
+        att.port.offsetd3 +
+        att.port.participantIDGain * att.participantID;
+
+    if (port > 65535)
+    {
+        logError(RTPS, "Calculated port number is too high. Probably the domainId is over 232, there are "
+            << "too much participants created or portBase is too high.");
+        exit(EXIT_FAILURE);
+    }
+
+    return static_cast<uint16_t>(port);
 }
 
 } // namespace rtps

--- a/test/unittest/rtps/common/CMakeLists.txt
+++ b/test/unittest/rtps/common/CMakeLists.txt
@@ -18,6 +18,9 @@ if(NOT ((MSVC OR MSVC_IDE) AND EPROSIMA_INSTALLER))
 
     if(GTEST_FOUND)
         set(SEQUENCENUMBERTESTS_SOURCE SequenceNumberTests.cpp)
+        set(PORTPARAMETERSTESTS_SOURCE PortParametersTests.cpp
+            ${PROJECT_SOURCE_DIR}/src/cpp/log/Log.cpp
+            ${PROJECT_SOURCE_DIR}/src/cpp/log/StdoutConsumer.cpp)
 
         add_executable(SequenceNumberTests ${SEQUENCENUMBERTESTS_SOURCE})
         target_compile_definitions(SequenceNumberTests PRIVATE FASTRTPS_NO_LIB)
@@ -25,5 +28,12 @@ if(NOT ((MSVC OR MSVC_IDE) AND EPROSIMA_INSTALLER))
             ${PROJECT_SOURCE_DIR}/include ${PROJECT_BINARY_DIR}/include)
         target_link_libraries(SequenceNumberTests ${GTEST_LIBRARIES})
         add_gtest(SequenceNumberTests SOURCES ${SEQUENCENUMBERTESTS_SOURCE})
+
+        add_executable(PortParametersTests ${PORTPARAMETERSTESTS_SOURCE})
+        target_compile_definitions(PortParametersTests PRIVATE FASTRTPS_NO_LIB)
+        target_include_directories(PortParametersTests PRIVATE ${GTEST_INCLUDE_DIRS}
+            ${PROJECT_SOURCE_DIR}/include ${PROJECT_BINARY_DIR}/include)
+        target_link_libraries(PortParametersTests ${GTEST_LIBRARIES})
+        add_gtest(PortParametersTests SOURCES ${PORTPARAMETERSTESTS_SOURCE})
     endif()
 endif()

--- a/test/unittest/rtps/common/CMakeLists.txt
+++ b/test/unittest/rtps/common/CMakeLists.txt
@@ -34,6 +34,6 @@ if(NOT ((MSVC OR MSVC_IDE) AND EPROSIMA_INSTALLER))
         target_include_directories(PortParametersTests PRIVATE ${GTEST_INCLUDE_DIRS}
             ${PROJECT_SOURCE_DIR}/include ${PROJECT_BINARY_DIR}/include)
         target_link_libraries(PortParametersTests ${GTEST_LIBRARIES})
-        add_gtest(PortParametersTests SOURCES ${PORTPARAMETERSTESTS_SOURCE})
+        add_gtest(PortParametersTests SOURCES ${PORTPARAMETERSTESTS_SOURCE} LABELS "NoMemoryCheck")
     endif()
 endif()

--- a/test/unittest/rtps/common/PortParametersTests.cpp
+++ b/test/unittest/rtps/common/PortParametersTests.cpp
@@ -1,0 +1,95 @@
+// Copyright 2016 Proyectos y Sistemas de Mantenimiento SL (eProsima).
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <fastrtps/rtps/common/PortParameters.h>
+
+#include <climits>
+#include <gtest/gtest.h>
+
+using namespace eprosima::fastrtps::rtps;
+
+/*!
+ * @fn TEST(PortParameters, Limit_Unicast_Domain_OK)
+ * @brief This test checks the maximum valid domain with default parameters.
+ */
+TEST(PortParameters, Limit_Unicast_Domain_OK)
+{
+    PortParameters params;
+
+    uint32_t port = params.getUnicastPort(232, 0);
+
+    ASSERT_TRUE(port > 0);
+}
+
+/*!
+ * @fn TEST(PortParameters, Limit_Unicast_Domain_Participant_OK)
+ * @brief This test checks the maximum valid domain + participant with default parameters.
+ */
+TEST(PortParameters, Limit_Unicast_Domain_Participant_OK)
+{
+    PortParameters params;
+
+    uint32_t port = params.getUnicastPort(232, 62);
+
+    ASSERT_TRUE(port > 0);
+}
+
+/*!
+ * @fn TEST(PortParametersDeathTest, Limit_Unicast_Domain_FAIL)
+ * @brief This test checks the minimum invalid domain with default parameters.
+ */
+TEST(PortParametersDeathTest, Limit_Unicast_Domain_FAIL)
+{
+    PortParameters params;
+    ASSERT_EXIT( { params.getUnicastPort(233, 0); }, ::testing::ExitedWithCode(EXIT_FAILURE), "");
+}
+
+/*!
+ * @fn TEST(PortParametersDeathTest, Limit_Unicast_Domain_Participant_FAIL)
+ * @brief This test checks the minimum invalid domain+participant with default parameters.
+ */
+TEST(PortParametersDeathTest, Limit_Unicast_Domain_Participant_FAIL)
+{
+    PortParameters params;
+    ASSERT_EXIT( { params.getUnicastPort(232, 63); }, ::testing::ExitedWithCode(EXIT_FAILURE), "");
+}
+
+/*!
+ * @fn TEST(PortParameters, Limit_Multicast_Domain_OK)
+ * @brief This test checks the maximum valid domain with default parameters.
+ */
+TEST(PortParameters, Limit_Multicast_Domain_OK)
+{
+    PortParameters params;
+
+    uint32_t port = params.getMulticastPort(232);
+
+    ASSERT_TRUE(port > 0);
+}
+
+/*!
+ * @fn TEST(PortParametersDeathTest, Limit_Multicast_Domain_FAIL)
+ * @brief This test checks the minimum invalid domain with default parameters.
+ */
+TEST(PortParametersDeathTest, Limit_Multicast_Domain_FAIL)
+{
+    PortParameters params;
+    ASSERT_EXIT( { params.getMulticastPort(233); }, ::testing::ExitedWithCode(EXIT_FAILURE), "");
+}
+
+int main(int argc, char **argv)
+{
+    testing::InitGoogleTest(&argc, argv);
+    return RUN_ALL_TESTS();
+}

--- a/test/unittest/rtps/network/CMakeLists.txt
+++ b/test/unittest/rtps/network/CMakeLists.txt
@@ -27,6 +27,8 @@ if(NOT ((MSVC OR MSVC_IDE) AND EPROSIMA_INSTALLER))
             ${PROJECT_SOURCE_DIR}/src/cpp/rtps/network/NetworkFactory.cpp
             ${PROJECT_SOURCE_DIR}/src/cpp/utils/IPFinder.cpp
             ${PROJECT_SOURCE_DIR}/src/cpp/utils/IPLocator.cpp
+            ${PROJECT_SOURCE_DIR}/src/cpp/log/Log.cpp
+            ${PROJECT_SOURCE_DIR}/src/cpp/log/StdoutConsumer.cpp
         )
 
         include_directories(mock/)


### PR DESCRIPTION
It checks the calculated port so it is able to detect other potential overflows when calculating the port number.

Fixes [#261](https://github.com/ros2/rmw_fastrtps/issues/261).