### PR TITLE
Prevents build of test if gtest is not found.

### DIFF
--- a/test/realtime/mutex_testing_tool/CMakeLists.txt
+++ b/test/realtime/mutex_testing_tool/CMakeLists.txt
@@ -15,18 +15,20 @@
 include(${PROJECT_SOURCE_DIR}/cmake/common/gtest.cmake)
 check_gtest()
 
-add_library(mutex_testing_tool SHARED TMutex.cpp)
+if(GTEST_FOUND)
+    add_library(mutex_testing_tool SHARED TMutex.cpp)
 
-add_library(mutex_testing_tool_preload SHARED Mutex.cpp)
-target_link_libraries(mutex_testing_tool_preload PRIVATE mutex_testing_tool ${CMAKE_DL_LIBS})
+    add_library(mutex_testing_tool_preload SHARED Mutex.cpp)
+    target_link_libraries(mutex_testing_tool_preload PRIVATE mutex_testing_tool ${CMAKE_DL_LIBS})
 
-add_executable(TMutexTests TMutexTests.cpp)
-target_include_directories(TMutexTests PRIVATE ${GTEST_INCLUDE_DIRS})
-target_link_libraries(TMutexTests mutex_testing_tool ${GTEST_LIBRARIES})
-STRING(REPLACE " " "\\ " MUTEX_PRELOAD_LIBRARY_FILE "$<TARGET_FILE:mutex_testing_tool_preload>")
-add_gtest(TMutexTests SOURCES TMutexTests.cpp
-    ENVIRONMENTS
-    "LD_LIBRARY_PATH=$<TARGET_FILE_DIR:mutex_testing_tool_preload>"
-    "LD_PRELOAD=$<TARGET_FILE_NAME:mutex_testing_tool_preload>"
-    LABELS "NoMemoryCheck"
-    )
+    add_executable(TMutexTests TMutexTests.cpp)
+    target_include_directories(TMutexTests PRIVATE ${GTEST_INCLUDE_DIRS})
+    target_link_libraries(TMutexTests mutex_testing_tool ${GTEST_LIBRARIES})
+    STRING(REPLACE " " "\\ " MUTEX_PRELOAD_LIBRARY_FILE "$<TARGET_FILE:mutex_testing_tool_preload>")
+    add_gtest(TMutexTests SOURCES TMutexTests.cpp
+        ENVIRONMENTS
+        "LD_LIBRARY_PATH=$<TARGET_FILE_DIR:mutex_testing_tool_preload>"
+        "LD_PRELOAD=$<TARGET_FILE_NAME:mutex_testing_tool_preload>"
+        LABELS "NoMemoryCheck"
+        )
+endif()


### PR DESCRIPTION
While exploring upgrading ROS2 to Fast-RTPS I had build issues with the ROS2 build farm not being able to build the the develop branch of Fast-RTPS because it did not have GTest installed (see build results on this PR: https://github.com/ros2/rmw_fastrtps/pull/272). This was not an issue with previous versions of Fast-RTPS and it looks like it is just because one of the CMakeLists.txt files is missing a guard against compiling the test when GTest is not installed on the system. 

This pull request fixes this by adding the build time guard in the CMakeLists.txt file. 