### PR TITLE
Fix Resource Generation on windows in fastrtspgen

### DIFF
--- a/fastrtpsgen/build.gradle
+++ b/fastrtpsgen/build.gradle
@@ -44,8 +44,10 @@ task copyResources {
     Properties pversion = new Properties()
     project.hasProperty('customversion') ? pversion.setProperty('version', project.customversion.toString()) : pversion.setProperty('version', '0.0.0')
     File versionFile = new File("${project.buildDir}/resources/main/version")
-    versionFile.createNewFile();
-    pversion.store(versionFile.newWriter(), null)
+    versionFile.withWriter {
+        pversion.store(it, null)
+    }
+
 }
 
 sourceSets {


### PR DESCRIPTION
The old method was holding a file open during the entire execution, causing races and the build to sometimes succeed or fail