### PR TITLE
Fix for StatefulWriter.check_acked_status [5270]

### DIFF
--- a/include/fastrtps/rtps/writer/StatefulWriter.h
+++ b/include/fastrtps/rtps/writer/StatefulWriter.h
@@ -74,8 +74,8 @@ private:
     using ReaderProxyIterator = ResourceLimitedVector<ReaderProxy*>::iterator;
     using ReaderProxyConstIterator = ResourceLimitedVector<ReaderProxy*>::const_iterator;
 
-    //!EntityId used to send the HB.(only for builtin types performance)
-    EntityId_t m_HBReaderEntityId;
+    //!To avoid notifying twice of the same sequence number
+    SequenceNumber_t next_all_acked_notify_sequence_;
     // TODO Join this mutex when main mutex would not be recursive.
     std::mutex all_acked_mutex_;
     std::condition_variable all_acked_cond_;
@@ -168,14 +168,6 @@ public:
     inline Count_t getHeartbeatCount() const
     {
         return this->m_heartbeatCount;
-    }
-
-    /** Get heartbeat reader entity id
-     * @return heartbeat reader entity id
-     */
-    inline EntityId_t getHBReaderEntityId()
-    {
-        return this->m_HBReaderEntityId;
     }
 
     /**

--- a/src/cpp/rtps/writer/StatefulWriter.cpp
+++ b/src/cpp/rtps/writer/StatefulWriter.cpp
@@ -885,12 +885,12 @@ void StatefulWriter::check_acked_status()
             for(SequenceNumber_t current_seq = next_all_acked_notify_sequence_; current_seq <= min_low_mark; ++current_seq)
             {
                 std::vector<CacheChange_t*>::iterator history_end = mp_history->changesEnd();
-                std::vector<CacheChange_t*>::iterator cit = std::find_if(mp_history->changesBegin(), history_end,
-                    [current_seq](const CacheChange_t* change)
+                std::vector<CacheChange_t*>::iterator cit = std::lower_bound(mp_history->changesBegin(), history_end, current_seq,
+                    [](const CacheChange_t* change, const SequenceNumber_t& seq)
                     {
-                        return change->sequenceNumber == current_seq;
+                        return change->sequenceNumber < seq;
                     });
-                if(cit != history_end)
+                if(cit != history_end && (*cit)->sequenceNumber == current_seq)
                 {
                     mp_listener->onWriterChangeReceivedByAll(this, *cit);
                 }


### PR DESCRIPTION
Not calling `onWriterChangeReceivedByAll` twice for the same sequence number.