### PR TITLE
StatelessReader: losing fragments causes not removing old changes from FragmentPitStop. [5360]

### DIFF
--- a/src/cpp/rtps/reader/StatelessReader.cpp
+++ b/src/cpp/rtps/reader/StatelessReader.cpp
@@ -258,6 +258,9 @@ bool StatelessReader::processDataFragMsg(CacheChange_t *incomingChange, uint32_t
             }
 #endif
 
+            // Try to remove previous CacheChange_t from PitStop.
+            fragmentedChangePitStop_->try_to_remove_until(incomingChange->sequenceNumber, incomingChange->writerGUID);
+
             // Fragments manager has to process incomming fragments.
             // If CacheChange_t is completed, it will be returned;
             CacheChange_t* change_completed = fragmentedChangePitStop_->process(change_to_add, sampleSize, fragmentStartingNum);
@@ -270,9 +273,6 @@ bool StatelessReader::processDataFragMsg(CacheChange_t *incomingChange, uint32_t
             // If the change was completed, process it.
             if(change_completed != nullptr)
             {
-                // Try to remove previous CacheChange_t from PitStop.
-                fragmentedChangePitStop_->try_to_remove_until(incomingChange->sequenceNumber, incomingChange->writerGUID);
-
                 if (!change_received(change_completed))
                 {
                     logInfo(RTPS_MSG_IN, IDSTRING"MessageReceiver not add change " << change_completed->sequenceNumber.to64long());


### PR DESCRIPTION
StatelessReader: losing fragments causes not removing old changes from FragmentPitStop.