### PR TITLE
Fix EDP default timings

### DIFF
--- a/src/cpp/rtps/builtin/discovery/endpoint/EDPSimple.cpp
+++ b/src/cpp/rtps/builtin/discovery/endpoint/EDPSimple.cpp
@@ -44,9 +44,9 @@ namespace rtps {
 
 // Default configuration values for EDP entities.
 const Duration_t edp_heartbeat_period{1, 0}; // 1 second
-const Duration_t edp_nack_response_delay{0, 400*1000*1000}; // ~93 milliseconds
-const Duration_t edp_nack_supression_duration{0, 50*1000*1000}; // ~11 milliseconds
-const Duration_t edp_heartbeat_response_delay{0, 50*1000*1000}; // ~11 milliseconds
+const Duration_t edp_nack_response_delay{0, 93*1000*1000}; // 93 milliseconds
+const Duration_t edp_nack_supression_duration{0, 11*1000*1000}; // 11 milliseconds
+const Duration_t edp_heartbeat_response_delay{0, 11*1000*1000}; // 11 milliseconds
 
 const int32_t edp_initial_reserved_caches = 20;
 


### PR DESCRIPTION
On PR #488 we changed the constructor of Duration_t to receive nanoseconds instead of fraction. 
Some constants on EDPSimple.cpp were left unchanged.