### PR TITLE
Fix for volatile reliable [5425]

### DIFF
--- a/src/cpp/rtps/reader/StatefulReader.cpp
+++ b/src/cpp/rtps/reader/StatefulReader.cpp
@@ -462,11 +462,11 @@ bool StatefulReader::processGapMsg(
             }
         });
 
-		wpLock.unlock();
+        wpLock.unlock();
 
-		// Maybe now we have to notify user from new CacheChanges.
-		NotifyChanges(pWP);
-	}
+        // Maybe now we have to notify user from new CacheChanges.
+        NotifyChanges(pWP);
+    }
 
     return true;
 }

--- a/src/cpp/rtps/reader/StatefulReader.cpp
+++ b/src/cpp/rtps/reader/StatefulReader.cpp
@@ -443,7 +443,7 @@ bool StatefulReader::processGapMsg(
 
     if(acceptMsgFrom(writerGUID, &pWP))
     {
-        std::lock_guard<std::recursive_mutex> guardWriterProxy(*pWP->getMutex());
+        std::unique_lock<std::recursive_mutex> wpLock(*pWP->getMutex());
         SequenceNumber_t auxSN;
         SequenceNumber_t finalSN = gapList.base() - 1;
         for(auxSN = gapStart; auxSN<=finalSN;auxSN++)
@@ -461,7 +461,12 @@ bool StatefulReader::processGapMsg(
                 fragmentedChangePitStop_->try_to_remove(it, pWP->m_att.guid);
             }
         });
-    }
+
+		wpLock.unlock();
+
+		// Maybe now we have to notify user from new CacheChanges.
+		NotifyChanges(pWP);
+	}
 
     return true;
 }

--- a/src/cpp/rtps/writer/StatefulWriter.cpp
+++ b/src/cpp/rtps/writer/StatefulWriter.cpp
@@ -139,7 +139,7 @@ StatefulWriter::~StatefulWriter()
 }
 
 /*
- *	CHANGE-RELATED METHODS
+ * CHANGE-RELATED METHODS
  */
 
 void StatefulWriter::unsent_change_added_to_history(
@@ -585,7 +585,7 @@ void StatefulWriter::send_any_unsent_changes()
 
 
 /*
- *	MATCHED_READER-RELATED METHODS
+ * MATCHED_READER-RELATED METHODS
  */
 bool StatefulWriter::matched_reader_add(RemoteReaderAttributes& rdata)
 {
@@ -1240,7 +1240,7 @@ bool StatefulWriter::process_acknack(
                     }
                     else if (sn_set.empty() && !final_flag)
                     {
-						// This is the preemptive acknack. Always send heartbeat
+                        // This is the preemptive acknack. Always send heartbeat
                         send_heartbeat_to_nts(*remote_reader);
                     }
 

--- a/src/cpp/rtps/writer/StatefulWriter.cpp
+++ b/src/cpp/rtps/writer/StatefulWriter.cpp
@@ -1238,8 +1238,9 @@ bool StatefulWriter::process_acknack(
                             mp_periodicHB->restart_timer();
                         }
                     }
-                    else if (SequenceNumber_t() == remote_reader->changes_low_mark() && sn_set.empty() && !final_flag)
+                    else if (sn_set.empty() && !final_flag)
                     {
+						// This is the preemptive acknack. Always send heartbeat
                         send_heartbeat_to_nts(*remote_reader);
                     }
 

--- a/test/blackbox/BlackboxTestsVolatile.cpp
+++ b/test/blackbox/BlackboxTestsVolatile.cpp
@@ -239,3 +239,46 @@ BLACKBOXTEST(BlackBox, ReqRepVolatileHelloworldRequesterCheckWriteParams)
     requester.send(1);
 }
 
+// Test created to check bug #5423, github ros2/ros2 #703
+BLACKBOXTEST(BlackBox, AsyncVolatileSubBetweenPubs)
+{
+	PubSubReader<HelloWorldType> reader(TEST_TOPIC_NAME);
+	PubSubWriter<HelloWorldType> writer(TEST_TOPIC_NAME);
+
+	writer.history_kind(eprosima::fastrtps::KEEP_ALL_HISTORY_QOS).
+		reliability(eprosima::fastrtps::RELIABLE_RELIABILITY_QOS).
+		durability_kind(eprosima::fastrtps::VOLATILE_DURABILITY_QOS).
+		resource_limits_allocated_samples(9).
+		resource_limits_max_samples(9).
+		asynchronously(eprosima::fastrtps::ASYNCHRONOUS_PUBLISH_MODE).
+		heartbeat_period_seconds(3600).
+		init();
+
+	ASSERT_TRUE(writer.isInitialized());
+
+	HelloWorld hello;
+	hello.index(1);
+	hello.message("HelloWorld 1");
+
+	writer.send_sample(hello);
+
+	reader.history_kind(eprosima::fastrtps::KEEP_ALL_HISTORY_QOS).
+		reliability(eprosima::fastrtps::RELIABLE_RELIABILITY_QOS).
+		durability_kind(eprosima::fastrtps::VOLATILE_DURABILITY_QOS).
+		init();
+
+	ASSERT_TRUE(reader.isInitialized());
+
+	writer.wait_discovery();
+	reader.wait_discovery();
+
+	auto data = default_helloworld_data_generator(1);
+	reader.startReception(data);
+	// Send data with some interval, to let async writer thread send samples
+	writer.send(data, 300);
+	// In this test all data should be sent.
+	ASSERT_TRUE(data.empty());
+	// Block reader until reception finished or timeout.
+	reader.block_for_all();
+}
+


### PR DESCRIPTION
Found an issue (ros2/ros2#703) with late joining volatile readers on volatile writers. 

**Reproduction steps:**
1. Reliable volatile asynchronous publisher is created, and a call to write is performed.
2. A matching reliable volatile subscriber is created.
3. A new call to write is performed.

**Expected result:**
A call to the subscription listener is made shortly after the write call.

**Observed result:**
The call to the listener is made after a time that matches the heartbeat period.

**Explanation:**
1. The subscriber may receive the initial heartbeat before discovering the publisher (thus ignoring it)
2. The publisher has not received the pre-emptive ACKNACK, so it hasn't repeated the initial heartbeat.
3. When the second write call is made, the publisher sends a DATA message for sequence number 2, followed by a GAP to indicate that it will not receive sequence number 1.
4. (bug) After receiving the GAP, the subscriber was not checking it could notify the user of sequence number 2.
