### PR TITLE
Fix fastrtpsgen.jar build on Windows [5667]

### DIFF
--- a/cmake/dev/java_support.cmake
+++ b/cmake/dev/java_support.cmake
@@ -47,10 +47,7 @@ macro(gradle_build directory command_build)
         endif()
 
         add_custom_target(java ALL
-            COMMAND ${CMAKE_COMMAND} -E env
-            --unset=JAVA_HOME
-            "PATH=${Java_JAVA_EXECUTABLE_DIR_NATIVE}${delimiter_}$<JOIN:$ENV{PATH},${delimiter_}>"
-            "${GRADLE_EXE}" -Pcustomversion=${PROJECT_VERSION} ${command_build}
+            COMMAND "${GRADLE_EXE}" -Pcustomversion=${PROJECT_VERSION} ${command_build}
             WORKING_DIRECTORY ${directory}
             COMMENT "Generating Java application" VERBATIM)
     endif()

--- a/fastrtpsgen/build.gradle
+++ b/fastrtpsgen/build.gradle
@@ -85,8 +85,8 @@ jar {
 
 compileJava.dependsOn buildIDLParser,copyResources
 compileJava {
-    sourceCompatibility = 1.6
-    targetCompatibility = 1.6
+    sourceCompatibility = 1.7
+    targetCompatibility = 1.7
 }
 
 test {


### PR DESCRIPTION
update source and target for fastrtpsgen to java 7
fix issue with long PATH env variables during build 
fixes issue #550 