### PR TITLE
Use java 1.8 or greater for fastrtpsgen.jar generation [5666]

### DIFF
--- a/fastrtpsgen/build.gradle
+++ b/fastrtpsgen/build.gradle
@@ -85,8 +85,8 @@ jar {
 
 compileJava.dependsOn buildIDLParser,copyResources
 compileJava {
-    sourceCompatibility = 1.6
-    targetCompatibility = 1.6
+    sourceCompatibility = 1.8
+    targetCompatibility = 1.8
 }
 
 test {

--- a/fastrtpsgen/src/main/java/com/eprosima/fastrtps/fastrtpsgen.java
+++ b/fastrtpsgen/src/main/java/com/eprosima/fastrtps/fastrtpsgen.java
@@ -522,7 +522,7 @@ public class fastrtpsgen {
             topicann.addMember(new AnnotationMember("value", new PrimitiveTypeCode(Kind.KIND_BOOLEAN), "true"));
 
             // Create template manager
-            TemplateManager tmanager = new TemplateManager("FastCdrCommon:eprosima:Common",ctx,true);
+            TemplateManager tmanager = new TemplateManager("FastCdrCommon:eprosima:Common", ctx, false);
 
             List<TemplateExtension> extensions = new ArrayList<TemplateExtension>();
 

--- a/fastrtpsgen/src/main/java/com/eprosima/fastrtps/fastrtpsgen.java
+++ b/fastrtpsgen/src/main/java/com/eprosima/fastrtps/fastrtpsgen.java
@@ -522,7 +522,7 @@ public class fastrtpsgen {
             topicann.addMember(new AnnotationMember("value", new PrimitiveTypeCode(Kind.KIND_BOOLEAN), "true"));
 
             // Create template manager
-            TemplateManager tmanager = new TemplateManager("FastCdrCommon:eprosima:Common");
+            TemplateManager tmanager = new TemplateManager("FastCdrCommon:eprosima:Common",ctx,true);
 
             List<TemplateExtension> extensions = new ArrayList<TemplateExtension>();
 


### PR DESCRIPTION
If we use a java version higher than java 6, problems will be like #555 and #550 . 
The method for TemplateManager tmanager has been changed, so it needed be updated.
Now if you use openjdk-1.8 and gradle 5.4.1, everything is fine.

*Remember to fix file /thirdparty/idl/idl.gradle*
`compileJava { sourceCompatibility = 1.8 targetCompatibility = 1.8 }`

Fixes #550 