### PR TITLE
Fix closing multicast UDP channel with whitelist [5732]

### DIFF
--- a/include/fastrtps/transport/UDPChannelResource.h
+++ b/include/fastrtps/transport/UDPChannelResource.h
@@ -141,9 +141,7 @@ public:
         ChannelResource::disable();
     }
 
-    void release(
-            const Locator_t& locator,
-            const asio::ip::address& address);
+    void release();
 
 protected:
     /**

--- a/include/fastrtps/transport/UDPChannelResource.h
+++ b/include/fastrtps/transport/UDPChannelResource.h
@@ -173,9 +173,6 @@ private:
     bool only_multicast_purpose_;
     std::string interface_;
     UDPTransportInterface* transport_;
-    bool closing_;
-    std::mutex mtx_closing_;
-    std::condition_variable cv_closing_;
 
     UDPChannelResource(const UDPChannelResource&) = delete;
     UDPChannelResource& operator=(const UDPChannelResource&) = delete;

--- a/include/fastrtps/transport/UDPTransportInterface.h
+++ b/include/fastrtps/transport/UDPTransportInterface.h
@@ -64,9 +64,6 @@ public:
            SendResourceList& sender_resource_list,
            const Locator_t&) override;
 
-   //! Release the listening socket for the specified port.
-   bool ReleaseInputChannel(const Locator_t& locator, const asio::ip::address& interface_address);
-
    /**
    * Converts a given remote locator (that is, a locator referring to a remote
    * destination) to the main local locator whose channel can write to that

--- a/src/cpp/transport/UDPChannelResource.cpp
+++ b/src/cpp/transport/UDPChannelResource.cpp
@@ -108,8 +108,8 @@ bool UDPChannelResource::Receive(
     catch (const std::exception& error)
     {
         (void)error;
-        logWarning(RTPS_MSG_OUT, "Error receiving data: " << error.what());
-        std::cout << "+++ERROR: " << error.what() << " - " << message_receiver() << " (" << this << ")" << std::endl;
+        logWarning(RTPS_MSG_OUT, "Error receiving data: " << error.what() << " - " << message_receiver()
+            << " (" << this << ")");
         return false;
     }
 }
@@ -139,8 +139,8 @@ void UDPChannelResource::release()
             closing_ = true;
             message_receiver(nullptr);
         }
+        socket()->close();
     }
-    socket()->close();
 }
 
 } // namespace rtps

--- a/src/cpp/transport/UDPTransportInterface.cpp
+++ b/src/cpp/transport/UDPTransportInterface.cpp
@@ -84,28 +84,11 @@ bool UDPTransportInterface::CloseInputChannel(const Locator_t& locator)
 
     }
 
-    std::map<UDPChannelResource*, asio::ip::address> addresses;
-    // It may sound redundant, but we must mark all the related channel to be killed first.
-    // Mostly in Windows, but in Linux can happen too, if we access to the endpoint
-    // of an already closed socket we get an exception. So we store the interface address to
-    // be used in the ReleaseInputChannel call later.
-    for (UDPChannelResource* channel_resource : channel_resources)
-    {
-        if (channel_resource->alive())
-        {
-            addresses[channel_resource] = channel_resource->socket()->local_endpoint().address();
-        }
-        else
-        {
-            addresses[channel_resource] = asio::ip::address();
-        }
-        channel_resource->disable();
-    }
-
-    // Then we release the channels
+    // We now disable and release the channels
     for (UDPChannelResource* channel : channel_resources)
     {
-        channel->release(locator, addresses[channel]);
+        channel->disable();
+        channel->release();
         delete channel;
     }
 

--- a/src/cpp/transport/UDPTransportInterface.cpp
+++ b/src/cpp/transport/UDPTransportInterface.cpp
@@ -356,69 +356,6 @@ bool UDPTransportInterface::OpenOutputChannel(
     return true;
 }
 
-bool UDPTransportInterface::ReleaseInputChannel(const Locator_t& locator, const asio::ip::address& interface_address)
-{
-    try
-    {
-        asio::error_code ec;
-        socket_base::message_flags flags = 0;
-        uint16_t port = IPLocator::getPhysicalPort(locator);
-
-        if(is_interface_whitelist_empty())
-        {
-            Locator_t localLocator;
-            fill_local_ip(localLocator);
-
-            ip::udp::socket socket(io_service_);
-            socket.open(generate_protocol());
-            socket.bind(generate_local_endpoint(localLocator, 0));
-            socket.set_option(ip::multicast::enable_loopback(true));
-
-            // We first send directly to localhost, in case all network interfaces are disabled
-            // (which would mean that multicast traffic may not be sent)
-            // We ignore the error message because some OS don't allow this functionality like Windows (WSAENETUNREACH) or Mac (EADDRNOTAVAIL)
-            auto localEndpoint = generate_local_endpoint(localLocator, port);
-            socket.send_to(asio::buffer("EPRORTPSCLOSE", 13), localEndpoint, flags, ec);
-
-            // We then send to the address of the input locator
-            auto destinationEndpoint = generate_local_endpoint(locator, port);
-
-            // We ignore the error message because some OS don't allow this functionality like Windows (WSAENETUNREACH) or Mac (EADDRNOTAVAIL)
-            socket.send_to(asio::buffer("EPRORTPSCLOSE", 13), destinationEndpoint,flags, ec);
-
-            socket.close();
-        }
-        else if (!interface_address.is_multicast())
-        {
-            ip::udp::socket socket(io_service_);
-            socket.open(generate_protocol());
-            auto bound_endpoint = asio::ip::udp::endpoint(interface_address, 0);
-            socket.bind(bound_endpoint);
-            socket.set_option(ip::multicast::enable_loopback(true));
-            SetSocketOutboundInterface(socket, bound_endpoint.address().to_string());
-
-            // We ignore the error message because some OS don't allow this functionality like Windows (WSAENETUNREACH) or Mac (EADDRNOTAVAIL)
-            auto localEndpoint = ip::udp::endpoint(interface_address, port);
-            socket.send_to(asio::buffer("EPRORTPSCLOSE", 13), localEndpoint, flags, ec);
-
-            // We then send to the address of the input locator
-            auto destinationEndpoint = generate_local_endpoint(locator, port);
-
-            // We ignore the error message because some OS don't allow this functionality like Windows (WSAENETUNREACH) or Mac (EADDRNOTAVAIL)
-            socket.send_to(asio::buffer("EPRORTPSCLOSE", 13), destinationEndpoint, flags, ec);
-
-            socket.close();
-        }
-    }
-    catch (const std::exception& error)
-    {
-        logError(RTPS_MSG_OUT, "Error " << error.what());
-        return false;
-    }
-
-    return true;
-}
-
 Locator_t UDPTransportInterface::RemoteToMainLocal(const Locator_t& remote) const
 {
     if (!IsLocatorSupported(remote))

--- a/src/cpp/transport/UDPTransportInterface.cpp
+++ b/src/cpp/transport/UDPTransportInterface.cpp
@@ -89,6 +89,7 @@ bool UDPTransportInterface::CloseInputChannel(const Locator_t& locator)
     {
         channel->disable();
         channel->release();
+        channel->clear();
         delete channel;
     }
 

--- a/test/unittest/transport/UDPv4Tests.cpp
+++ b/test/unittest/transport/UDPv4Tests.cpp
@@ -332,7 +332,6 @@ TEST_F(UDPv4Tests, send_to_allowed_interface)
 
         if (IsAddressDefined(locator))
         {
-            // descriptor.interfaceWhiteList.emplace_back("127.0.0.1");
             descriptor.interfaceWhiteList.emplace_back(IPLocator::toIPv4string(locator));
             UDPv4Transport transportUnderTest(descriptor);
             transportUnderTest.init();

--- a/test/unittest/transport/UDPv4Tests.cpp
+++ b/test/unittest/transport/UDPv4Tests.cpp
@@ -332,7 +332,7 @@ TEST_F(UDPv4Tests, send_to_allowed_interface)
 
         if (IsAddressDefined(locator))
         {
-            descriptor.interfaceWhiteList.emplace_back("127.0.0.1");
+            // descriptor.interfaceWhiteList.emplace_back("127.0.0.1");
             descriptor.interfaceWhiteList.emplace_back(IPLocator::toIPv4string(locator));
             UDPv4Transport transportUnderTest(descriptor);
             transportUnderTest.init();
@@ -351,7 +351,6 @@ TEST_F(UDPv4Tests, send_to_allowed_interface)
             IPLocator::setIPv4(remoteMulticastLocator, 239, 255, 1, 4); // Loopback
 
             // Sending through a ALLOWED IP will work
-            IPLocator::setIPv4(outputChannelLocator, 127, 0, 0, 1);
             std::vector<octet> message = { 'H','e','l','l','o' };
             ASSERT_TRUE(send_resource_list.at(0)->send(message.data(), (uint32_t)message.size(),
                         remoteMulticastLocator));
@@ -520,6 +519,35 @@ TEST_F(UDPv4Tests, send_and_receive_between_allowed_sockets_using_unicast_to_mul
     std::this_thread::sleep_for(std::chrono::milliseconds(1));
     senderThread->join();
     sem.wait();
+}
+
+TEST_F(UDPv4Tests, open_and_close_two_multicast_transports_with_whitelist)
+{
+    std::vector<IPFinder::info_IP> interfaces;
+    GetIP4s(interfaces);
+
+    if (interfaces.size() > 0)
+    {
+        descriptor.interfaceWhiteList.push_back(interfaces.at(0).name);
+
+        UDPv4Transport transport1(descriptor);
+        UDPv4Transport transport2(descriptor);
+        transport1.init();
+        transport2.init();
+
+        Locator_t multicastLocator;
+        multicastLocator.port = g_default_port;
+        multicastLocator.kind = LOCATOR_KIND_UDPv4;
+        IPLocator::setIPv4(multicastLocator, "239.255.1.4");
+
+        std::cout << "Opening input channels" << std::endl;
+        ASSERT_TRUE(transport1.OpenInputChannel(multicastLocator, nullptr, 65500));
+        ASSERT_TRUE(transport2.OpenInputChannel(multicastLocator, nullptr, 65500));
+        std::cout << "Closing input channel on transport 1" << std::endl;
+        ASSERT_TRUE(transport1.CloseInputChannel(multicastLocator));
+        std::cout << "Closing input channel on transport 2" << std::endl;
+        ASSERT_TRUE(transport2.CloseInputChannel(multicastLocator));
+    }
 }
 #endif
 


### PR DESCRIPTION
This probably fixes issue #235, as it is related with a hang during participant destruction.