### PR TITLE
Reduce dynamic allocations on SecurityException

### DIFF
--- a/include/fastrtps/rtps/security/exceptions/SecurityException.h
+++ b/include/fastrtps/rtps/security/exceptions/SecurityException.h
@@ -15,7 +15,9 @@
 #ifndef _RTPS_SECURITY_EXCEPTIONS_SECURITYEXCEPTION_H_
 #define _RTPS_SECURITY_EXCEPTIONS_SECURITYEXCEPTION_H_
 
-#include "../../exceptions/Exception.h"
+#include "fastrtps/fastrtps_dll.h"
+
+#include <string>
 
 namespace eprosima {
 namespace fastrtps {
@@ -26,48 +28,62 @@ namespace security {
  * @brief This class is thrown as an exception when there is an error in security module.
  * @ingroup EXCEPTIONMODULE
  */
-class SecurityException : public Exception
+class SecurityException
 {
-    public:
 
-        RTPS_DllAPI SecurityException() {}
+public:
 
-        /**
-         * @brief Default constructor.
-         * @param message An error message. This message is copied.
-         */
-        RTPS_DllAPI SecurityException(const std::string& message) : Exception(message.c_str(), 1) {}
+    RTPS_DllAPI SecurityException() {}
 
-        /**
-         * @brief Default copy constructor.
-         * @param ex SecurityException that will be copied.
-         */
-        RTPS_DllAPI SecurityException(const SecurityException &ex);
+    /// \brief Default constructor
+    virtual RTPS_DllAPI ~SecurityException() throw() = default;
 
-        /**
-         * @brief Default move constructor.
-         * @param ex SecurityException that will be moved.
-         */
-        RTPS_DllAPI SecurityException(SecurityException&& ex);
+    /**
+     * @brief Default copy constructor.
+     * @param ex SecurityException that will be copied.
+     */
+    SecurityException(const SecurityException &ex) = delete;
 
-        /**
-         * @brief Assigment operation.
-         * @param ex SecurityException that will be copied.
-         */
-        RTPS_DllAPI SecurityException& operator=(const SecurityException &ex);
+    /**
+     * @brief Default move constructor.
+     * @param ex SecurityException that will be moved.
+     */
+    SecurityException(SecurityException&& ex) = delete;
 
-        /**
-         * @brief Assigment operation.
-         * @param ex SecurityException that will be moved.
-         */
-        RTPS_DllAPI SecurityException& operator=(SecurityException&& ex);
+    /**
+     * @brief Assigment operation.
+     * @param ex SecurityException that will be copied.
+     */
+    SecurityException& operator=(const SecurityException &ex) = delete;
 
-        /// \brief Default constructor
-        virtual RTPS_DllAPI ~SecurityException() throw();
+    /**
+     * @brief Assigment operation.
+     * @param ex SecurityException that will be moved.
+     */
+    SecurityException& operator=(SecurityException&& ex) = delete;
 
-        /// \brief This function throws the object as an exception.
-        virtual RTPS_DllAPI void raise() const;
+    /**
+     * @brief 
+     */
+    RTPS_DllAPI void set_msg(
+            const std::string& msg)
+    {
+        msg_ = msg;
+    }
+
+    /**
+     * @brief This function returns the error message.
+     * @return The error message.
+     */
+    RTPS_DllAPI const char* const what() const throw()
+    {
+        return msg_.c_str();
+    }
+
+private:
+    std::string msg_;
 };
+
 } // namespace security
 } // namespace rtps
 } // namespace fastrtps

--- a/include/fastrtps/rtps/security/exceptions/SecurityException.h
+++ b/include/fastrtps/rtps/security/exceptions/SecurityException.h
@@ -99,13 +99,13 @@ public:
      * @brief This function returns the error message.
      * @return The error message.
      */
-    RTPS_DllAPI const char* const what() const throw()
+    RTPS_DllAPI const char* what() const throw()
     {
         return msg_;
     }
 
 private:
-    char msg_[SECURITY_ERROR_MAX_LENGTH + 1];
+    char msg_[SECURITY_ERROR_MAX_LENGTH];
 };
 
 } // namespace security

--- a/include/fastrtps/rtps/security/exceptions/SecurityException.h
+++ b/include/fastrtps/rtps/security/exceptions/SecurityException.h
@@ -24,6 +24,8 @@ namespace fastrtps {
 namespace rtps {
 namespace security {
 
+constexpr std::size_t SECURITY_ERROR_MAX_LENGTH = 512;
+
 /**
  * @brief This class is thrown as an exception when there is an error in security module.
  * @ingroup EXCEPTIONMODULE
@@ -33,43 +35,65 @@ class SecurityException
 
 public:
 
-    RTPS_DllAPI SecurityException() {}
+    /**
+     * @brief Default constructor
+     */
+    RTPS_DllAPI SecurityException() throw();
 
-    /// \brief Default constructor
+    /**
+     * @brief Default destructor
+     */
     virtual RTPS_DllAPI ~SecurityException() throw() = default;
 
     /**
-     * @brief Default copy constructor.
+     * @brief Default copy constructor (deleted).
      * @param ex SecurityException that will be copied.
      */
-    SecurityException(const SecurityException &ex) = delete;
+    SecurityException(const SecurityException& ex) = delete;
 
     /**
-     * @brief Default move constructor.
+     * @brief Default move constructor (deleted).
      * @param ex SecurityException that will be moved.
      */
     SecurityException(SecurityException&& ex) = delete;
 
     /**
-     * @brief Assigment operation.
+     * @brief Assigment operation (deleted).
      * @param ex SecurityException that will be copied.
      */
-    SecurityException& operator=(const SecurityException &ex) = delete;
+    SecurityException& operator=(const SecurityException& ex) = delete;
 
     /**
-     * @brief Assigment operation.
+     * @brief Assigment operation (deleted).
      * @param ex SecurityException that will be moved.
      */
     SecurityException& operator=(SecurityException&& ex) = delete;
 
     /**
-     * @brief 
+     * @brief Set message value.
+     * @param msg String with new message value.
+     * @return own reference.
      */
-    RTPS_DllAPI void set_msg(
-            const std::string& msg)
-    {
-        msg_ = msg;
-    }
+    RTPS_DllAPI SecurityException& set_msg(
+            const char* const msg) throw();
+
+    /**
+     * @brief Set message value.
+     * @param msg String with new message value.
+     * @param code Error code.
+     * @return own reference.
+     */
+    RTPS_DllAPI SecurityException& set_msg(
+            const char* const msg,
+            unsigned long code) throw();
+
+    /**
+     * @brief Set message value.
+     * @param msg String with message to append.
+     * @return own reference.
+     */
+    RTPS_DllAPI SecurityException& append_msg(
+            const char* const msg) throw();
 
     /**
      * @brief This function returns the error message.
@@ -77,11 +101,11 @@ public:
      */
     RTPS_DllAPI const char* const what() const throw()
     {
-        return msg_.c_str();
+        return msg_;
     }
 
 private:
-    std::string msg_;
+    char msg_[SECURITY_ERROR_MAX_LENGTH + 1];
 };
 
 } // namespace security

--- a/src/cpp/rtps/security/exceptions/SecurityException.cpp
+++ b/src/cpp/rtps/security/exceptions/SecurityException.cpp
@@ -14,5 +14,39 @@
 
 #include <fastrtps/rtps/security/exceptions/SecurityException.h>
 
-using namespace eprosima::fastrtps::rtps::security;
+namespace eprosima {
+namespace fastrtps {
+namespace rtps {
+namespace security {
 
+RTPS_DllAPI SecurityException::SecurityException() throw()
+{
+    std::memset(msg_, 0, sizeof(msg_));
+}
+
+RTPS_DllAPI SecurityException& SecurityException::set_msg(
+        const char* const msg) throw()
+{
+    strncpy_s(msg_, msg, SECURITY_ERROR_MAX_LENGTH);
+    return *this;
+}
+
+RTPS_DllAPI SecurityException& SecurityException::set_msg(
+        const char* const msg,
+        unsigned long code) throw()
+{
+    snprintf(msg_, SECURITY_ERROR_MAX_LENGTH, "%s (%lu)", msg, code);
+    return *this;
+}
+
+RTPS_DllAPI SecurityException& SecurityException::append_msg(
+        const char* const msg) throw()
+{
+    snprintf(msg_, SECURITY_ERROR_MAX_LENGTH, "%s%s", msg_, msg);
+    return *this;
+}
+
+} /* namespace security */
+} /* namespace rtps */
+} /* namespace fastrtps */
+} /* namespace eprosima */

--- a/src/cpp/rtps/security/exceptions/SecurityException.cpp
+++ b/src/cpp/rtps/security/exceptions/SecurityException.cpp
@@ -16,39 +16,3 @@
 
 using namespace eprosima::fastrtps::rtps::security;
 
-SecurityException::SecurityException(const SecurityException &ex) : Exception(ex)
-{
-}
-
-SecurityException::SecurityException(SecurityException&& ex) : Exception(std::move(ex))
-{
-}
-
-SecurityException& SecurityException::operator=(const SecurityException &ex)
-{
-    if(this != &ex)
-    {
-        Exception::operator=(ex);
-    }
-
-    return *this;
-}
-
-SecurityException& SecurityException::operator=(SecurityException&& ex)
-{
-    if(this != &ex)
-    {
-        Exception::operator=(std::move(ex));
-    }
-
-    return *this;
-}
-
-SecurityException::~SecurityException() throw()
-{
-}
-
-void SecurityException::raise() const
-{
-    throw *this;
-}

--- a/src/cpp/rtps/security/exceptions/SecurityException.cpp
+++ b/src/cpp/rtps/security/exceptions/SecurityException.cpp
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 #include <fastrtps/rtps/security/exceptions/SecurityException.h>
+#include <cstring>
 
 namespace eprosima {
 namespace fastrtps {
@@ -27,7 +28,7 @@ RTPS_DllAPI SecurityException::SecurityException() throw()
 RTPS_DllAPI SecurityException& SecurityException::set_msg(
         const char* const msg) throw()
 {
-    strncpy_s(msg_, msg, SECURITY_ERROR_MAX_LENGTH);
+    snprintf(msg_, SECURITY_ERROR_MAX_LENGTH, "%s", msg);
     return *this;
 }
 

--- a/src/cpp/security/accesscontrol/Permissions.cpp
+++ b/src/cpp/security/accesscontrol/Permissions.cpp
@@ -49,7 +49,7 @@
 #define S1(x) #x
 #define S2(x) S1(x)
 #define LOCATION " (" __FILE__ ":" S2(__LINE__) ")"
-#define _SecurityException_(str) SecurityException(std::string(str) + LOCATION)
+#define _SecurityException_(ex, str) ex.set_msg(std::string(str) + LOCATION)
 
 using namespace eprosima::fastrtps;
 using namespace eprosima::fastrtps::rtps;
@@ -199,16 +199,16 @@ static bool get_signature_algorithm(X509* certificate, std::string& signature_al
                     }
                 }
                 else
-                    exception = _SecurityException_("OpenSSL library cannot retrieve mem ptr");
+                    _SecurityException_(exception, "OpenSSL library cannot retrieve mem ptr");
             }
         }
         else
-            exception = _SecurityException_("OpenSSL library cannot write cert");
+            _SecurityException_(exception, "OpenSSL library cannot write cert");
 
         BIO_free(out);
     }
     else
-        exception = _SecurityException_("OpenSSL library cannot allocate mem");
+        _SecurityException_(exception, "OpenSSL library cannot allocate mem");
 
     return returnedValue;
 }
@@ -342,31 +342,31 @@ static X509_STORE* load_permissions_ca(const std::string& permissions_ca, bool& 
                     }
                     else
                     {
-                        exception = _SecurityException_(std::string("OpenSSL library cannot read X509 info in file ") + permissions_ca.substr(7));
+                        _SecurityException_(exception, std::string("OpenSSL library cannot read X509 info in file ") + permissions_ca.substr(7));
                     }
                 }
                 else
                 {
-                    exception = _SecurityException_(std::string("OpenSSL library cannot read file ") + permissions_ca.substr(7));
+                    _SecurityException_(exception, std::string("OpenSSL library cannot read file ") + permissions_ca.substr(7));
                 }
 
                 BIO_free(in);
             }
             else
             {
-                exception = _SecurityException_("OpenSSL library cannot allocate file");
+                _SecurityException_(exception, "OpenSSL library cannot allocate file");
             }
         }
         else
         {
-            exception = _SecurityException_("Unsupported permissions_ca format");
+            _SecurityException_(exception, "Unsupported permissions_ca format");
         }
 
         X509_STORE_free(store);
     }
     else
     {
-        exception = _SecurityException_("Creation of X509 storage");
+        _SecurityException_(exception, "Creation of X509 storage");
     }
 
     return nullptr;
@@ -391,7 +391,7 @@ static BIO* load_signed_file(X509_STORE* store, std::string& file, SecurityExcep
                 out = BIO_new(BIO_s_mem());
                 if(!PKCS7_verify(p7, nullptr, store, indata, out, PKCS7_TEXT))
                 {
-                    exception = _SecurityException_(std::string("Failed verification of the file ") + file);
+                    _SecurityException_(exception, std::string("Failed verification of the file ") + file);
                     BIO_free(out);
                     out = nullptr;
                 }
@@ -400,7 +400,7 @@ static BIO* load_signed_file(X509_STORE* store, std::string& file, SecurityExcep
             }
             else
             {
-                exception = _SecurityException_(std::string("Cannot read as PKCS7 the file ") + file);
+                _SecurityException_(exception, std::string("Cannot read as PKCS7 the file ") + file);
             }
 
             if(indata != nullptr)
@@ -412,12 +412,12 @@ static BIO* load_signed_file(X509_STORE* store, std::string& file, SecurityExcep
         }
         else
         {
-            exception = _SecurityException_(std::string("Cannot read file ") + file);
+            _SecurityException_(exception, std::string("Cannot read file ") + file);
         }
     }
     else
     {
-        exception = _SecurityException_(std::string("Unsupported governance file format ") + file);
+        _SecurityException_(exception, std::string("Unsupported governance file format ") + file);
     }
 
     return out;
@@ -444,12 +444,12 @@ static bool load_governance_file(AccessPermissionsHandle& ah, std::string& gover
             }
             else
             {
-                exception = _SecurityException_(std::string("Malformed governance file ") + governance_file);
+                _SecurityException_(exception, std::string("Malformed governance file ") + governance_file);
             }
         }
         else
         {
-            exception = _SecurityException_(std::string("OpenSSL library cannot retrieve mem ptr from file ")
+            _SecurityException_(exception, std::string("OpenSSL library cannot retrieve mem ptr from file ")
                     + governance_file);
         }
 
@@ -480,12 +480,12 @@ static bool load_permissions_file(AccessPermissionsHandle& ah, std::string& perm
             }
             else
             {
-                exception = _SecurityException_(std::string("Malformed permissions file ") + permissions_file);
+                _SecurityException_(exception, std::string("Malformed permissions file ") + permissions_file);
             }
         }
         else
         {
-            exception = _SecurityException_(std::string("OpenSSL library cannot retrieve mem ptr from file ")
+            _SecurityException_(exception, std::string("OpenSSL library cannot retrieve mem ptr from file ")
                     + permissions_file);
         }
 
@@ -527,17 +527,17 @@ static bool verify_permissions_file(const AccessPermissionsHandle& local_handle,
                         }
                         else
                         {
-                            exception = _SecurityException_(std::string("Malformed permissions file ") + permissions_file);
+                            _SecurityException_(exception, std::string("Malformed permissions file ") + permissions_file);
                         }
                     }
                     else
                     {
-                        exception = _SecurityException_("OpenSSL library cannot retrieve mem ptr from file.");
+                        _SecurityException_(exception, "OpenSSL library cannot retrieve mem ptr from file.");
                     }
                 }
                 else
                 {
-                    exception = _SecurityException_("Failed verification of the permissions file");
+                    _SecurityException_(exception, "Failed verification of the permissions file");
                 }
 
                 BIO_free(out);
@@ -545,7 +545,7 @@ static bool verify_permissions_file(const AccessPermissionsHandle& local_handle,
             }
             else
             {
-                exception = _SecurityException_("Cannot read as PKCS7 the permissions file.");
+                _SecurityException_(exception, "Cannot read as PKCS7 the permissions file.");
             }
 
             if(indata != nullptr)
@@ -684,13 +684,13 @@ static bool check_subject_name(const IdentityHandle& ih, AccessPermissionsHandle
         }
         else
         {
-            exception = _SecurityException_(std::string("Not found the identity subject name in permissions file. Subject name: ") +
+            _SecurityException_(exception, std::string("Not found the identity subject name in permissions file. Subject name: ") +
                     lih->cert_sn_rfc2253_);
         }
     }
     else
     {
-        exception = _SecurityException_("IdentityHandle is not of the type PKIIdentityHandle");
+        _SecurityException_(exception, "IdentityHandle is not of the type PKIIdentityHandle");
     }
 
     return returned_value;
@@ -738,12 +738,12 @@ static bool generate_credentials_token(AccessPermissionsHandle& handle, const st
         }
         catch(std::exception&)
         {
-            exception = _SecurityException_(std::string("Cannot find file ") + file);
+            _SecurityException_(exception, std::string("Cannot find file ") + file);
         }
     }
     else
     {
-        exception = _SecurityException_("Unsupported permissions_ca format");
+        _SecurityException_(exception, "Unsupported permissions_ca format");
     }
 
     return returned_value;
@@ -759,7 +759,7 @@ PermissionsHandle* Permissions::validate_local_permissions(Authentication&,
 
     if(PropertyPolicyHelper::length(access_properties) == 0)
     {
-        exception = _SecurityException_("Not found any dds.sec.access.builtin.Access-Permissions property");
+        _SecurityException_(exception, "Not found any dds.sec.access.builtin.Access-Permissions property");
         return nullptr;
     }
 
@@ -767,7 +767,7 @@ PermissionsHandle* Permissions::validate_local_permissions(Authentication&,
 
     if(permissions_ca == nullptr)
     {
-        exception = _SecurityException_("Not found dds.sec.access.builtin.Access-Permissions.permissions_ca property");
+        _SecurityException_(exception, "Not found dds.sec.access.builtin.Access-Permissions.permissions_ca property");
         return nullptr;
     }
 
@@ -775,7 +775,7 @@ PermissionsHandle* Permissions::validate_local_permissions(Authentication&,
 
     if(governance == nullptr)
     {
-        exception = _SecurityException_("Not found dds.sec.access.builtin.Access-Permissions.governance property");
+        _SecurityException_(exception, "Not found dds.sec.access.builtin.Access-Permissions.governance property");
         return nullptr;
     }
 
@@ -783,7 +783,7 @@ PermissionsHandle* Permissions::validate_local_permissions(Authentication&,
 
     if(permissions == nullptr)
     {
-        exception = _SecurityException_("Not found dds.sec.access.builtin.Access-Permissions.permissions property");
+        _SecurityException_(exception, "Not found dds.sec.access.builtin.Access-Permissions.permissions property");
         return nullptr;
     }
 
@@ -832,7 +832,7 @@ bool Permissions::get_permissions_token(PermissionsToken** permissions_token,
     }
     else
     {
-        exception = _SecurityException_("Invalid permissions handle");
+        _SecurityException_(exception, "Invalid permissions handle");
     }
 
     return false;
@@ -857,7 +857,7 @@ bool Permissions::get_permissions_credential_token(PermissionsCredentialToken** 
     }
     else
     {
-        exception = _SecurityException_("Invalid permissions handle");
+        _SecurityException_(exception, "Invalid permissions handle");
     }
 
     return false;
@@ -898,7 +898,7 @@ PermissionsHandle* Permissions::validate_remote_permissions(Authentication&,
 
     if(lih.nil() || lph.nil() || rih.nil())
     {
-        exception = _SecurityException_("Bad precondition");
+        _SecurityException_(exception, "Bad precondition");
         return nullptr;
     }
 
@@ -910,7 +910,7 @@ PermissionsHandle* Permissions::validate_remote_permissions(Authentication&,
     {
         if(sn->compare(lph->sn) != 0)
         {
-            exception = _SecurityException_("Remote participant PermissionsCA differs from local");
+            _SecurityException_(exception, "Remote participant PermissionsCA differs from local");
             return nullptr;
         }
     }
@@ -921,7 +921,7 @@ PermissionsHandle* Permissions::validate_remote_permissions(Authentication&,
     {
         if(algo->compare(lph->algo) != 0)
         {
-            exception = _SecurityException_("Remote participant PermissionsCA algorithm differs from local");
+            _SecurityException_(exception, "Remote participant PermissionsCA algorithm differs from local");
             return nullptr;
         }
     }
@@ -931,7 +931,7 @@ PermissionsHandle* Permissions::validate_remote_permissions(Authentication&,
 
     if(permissions_file == nullptr)
     {
-        exception = _SecurityException_("Remote participant doesn't sent the signed permissions file");
+        _SecurityException_(exception, "Remote participant doesn't sent the signed permissions file");
         return nullptr;
     }
 
@@ -957,7 +957,7 @@ PermissionsHandle* Permissions::validate_remote_permissions(Authentication&,
 
     if(remote_grant.subject_name.empty())
     {
-        exception = _SecurityException_("Remote participant doesn't found in its permissions file");
+        _SecurityException_(exception, "Remote participant doesn't found in its permissions file");
         return nullptr;
     }
 
@@ -978,7 +978,7 @@ bool Permissions::check_create_participant(const PermissionsHandle& local_handle
 
     if(lah.nil())
     {
-        exception = _SecurityException_("Bad precondition");
+        _SecurityException_(exception, "Bad precondition");
         return false;
     }
 
@@ -994,7 +994,7 @@ bool Permissions::check_create_participant(const PermissionsHandle& local_handle
 
     if(!returned_value)
     {
-        exception = _SecurityException_("Not found a rule allowing to use the domain_id");
+        _SecurityException_(exception, "Not found a rule allowing to use the domain_id");
     }
 
     return returned_value;
@@ -1008,7 +1008,7 @@ bool Permissions::check_remote_participant(const PermissionsHandle& remote_handl
 
     if(rah.nil())
     {
-        exception = _SecurityException_("Bad precondition");
+        _SecurityException_(exception, "Bad precondition");
         return false;
     }
 
@@ -1032,7 +1032,7 @@ bool Permissions::check_remote_participant(const PermissionsHandle& remote_handl
 
     if(!returned_value)
     {
-        exception = _SecurityException_("Not found a rule allowing to use the domain_id");
+        _SecurityException_(exception, "Not found a rule allowing to use the domain_id");
     }
 
     return returned_value;
@@ -1047,7 +1047,7 @@ bool Permissions::check_create_datawriter(const PermissionsHandle& local_handle,
 
     if(lah.nil())
     {
-        exception = _SecurityException_("Bad precondition");
+        _SecurityException_(exception, "Bad precondition");
         return false;
     }
 
@@ -1062,7 +1062,7 @@ bool Permissions::check_create_datawriter(const PermissionsHandle& local_handle,
     }
     else
     {
-        exception = _SecurityException_("Not found topic access rule for topic " + topic_name);
+        _SecurityException_(exception, "Not found topic access rule for topic " + topic_name);
         return false;
     }
 
@@ -1080,7 +1080,7 @@ bool Permissions::check_create_datawriter(const PermissionsHandle& local_handle,
                     if (!is_partition_in_criterias(std::string(), rule.publishes))
                     {
                         returned_value = false;
-                        exception = _SecurityException_(std::string("<empty> partition not found in rule."));
+                        _SecurityException_(exception, std::string("<empty> partition not found in rule."));
                     }
                 }
                 else
@@ -1092,14 +1092,14 @@ bool Permissions::check_create_datawriter(const PermissionsHandle& local_handle,
                         if (!is_partition_in_criterias(*partition_it, rule.publishes))
                         {
                             returned_value = false;
-                            exception = _SecurityException_(*partition_it + std::string(" partition not found in rule."));
+                            _SecurityException_(exception, *partition_it + std::string(" partition not found in rule."));
                         }
                     }
                 }
             }
             else
             {
-                exception = _SecurityException_(topic_name + std::string(" topic denied by deny rule."));
+                _SecurityException_(exception, topic_name + std::string(" topic denied by deny rule."));
             }
 
             break;
@@ -1108,7 +1108,7 @@ bool Permissions::check_create_datawriter(const PermissionsHandle& local_handle,
 
     if(!returned_value && strlen(exception.what()) == 0)
     {
-        exception = _SecurityException_(topic_name + std::string(" topic not found in allow rule."));
+        _SecurityException_(exception, topic_name + std::string(" topic not found in allow rule."));
     }
 
     return returned_value;
@@ -1123,7 +1123,7 @@ bool Permissions::check_create_datareader(const PermissionsHandle& local_handle,
 
     if(lah.nil())
     {
-        exception = _SecurityException_("Bad precondition");
+        _SecurityException_(exception, "Bad precondition");
         return false;
     }
 
@@ -1138,7 +1138,7 @@ bool Permissions::check_create_datareader(const PermissionsHandle& local_handle,
     }
     else
     {
-        exception = _SecurityException_("Not found topic access rule for topic " + topic_name);
+        _SecurityException_(exception, "Not found topic access rule for topic " + topic_name);
         return false;
     }
 
@@ -1155,7 +1155,7 @@ bool Permissions::check_create_datareader(const PermissionsHandle& local_handle,
                     if (!is_partition_in_criterias(std::string(), rule.subscribes))
                     {
                         returned_value = false;
-                        exception = _SecurityException_(std::string("<empty> partition not found in rule."));
+                        _SecurityException_(exception, std::string("<empty> partition not found in rule."));
                     }
                 }
                 else
@@ -1167,14 +1167,14 @@ bool Permissions::check_create_datareader(const PermissionsHandle& local_handle,
                         if (!is_partition_in_criterias(*partition_it, rule.subscribes))
                         {
                             returned_value = false;
-                            exception = _SecurityException_(*partition_it + std::string(" partition not found in rule."));
+                            _SecurityException_(exception, *partition_it + std::string(" partition not found in rule."));
                         }
                     }
                 }
             }
             else
             {
-                exception = _SecurityException_(topic_name + std::string(" topic denied by deny rule."));
+                _SecurityException_(exception, topic_name + std::string(" topic denied by deny rule."));
             }
 
             break;
@@ -1183,7 +1183,7 @@ bool Permissions::check_create_datareader(const PermissionsHandle& local_handle,
 
     if(!returned_value && strlen(exception.what()) == 0)
     {
-        exception = _SecurityException_(topic_name + std::string(" topic not found in allow rule."));
+        _SecurityException_(exception, topic_name + std::string(" topic not found in allow rule."));
     }
 
     return returned_value;
@@ -1198,7 +1198,7 @@ bool Permissions::check_remote_datawriter(const PermissionsHandle& remote_handle
 
     if(rah.nil())
     {
-        exception = _SecurityException_("Bad precondition");
+        _SecurityException_(exception, "Bad precondition");
         return false;
     }
 
@@ -1214,7 +1214,7 @@ bool Permissions::check_remote_datawriter(const PermissionsHandle& remote_handle
     }
     else
     {
-        exception = _SecurityException_("Not found topic access rule for topic " + publication_data.topicName().to_string());
+        _SecurityException_(exception, "Not found topic access rule for topic " + publication_data.topicName().to_string());
         return false;
     }
 
@@ -1230,7 +1230,7 @@ bool Permissions::check_remote_datawriter(const PermissionsHandle& remote_handle
                 }
                 else
                 {
-                    exception = _SecurityException_(publication_data.topicName().to_string() +
+                    _SecurityException_(exception, publication_data.topicName().to_string() +
                             std::string(" topic denied by deny rule."));
                 }
 
@@ -1241,7 +1241,7 @@ bool Permissions::check_remote_datawriter(const PermissionsHandle& remote_handle
 
     if(!returned_value && strlen(exception.what()) == 0)
     {
-        exception = _SecurityException_(publication_data.topicName().to_string() +
+        _SecurityException_(exception, publication_data.topicName().to_string() +
                 std::string(" topic not found in allow rule."));
     }
 
@@ -1259,7 +1259,7 @@ bool Permissions::check_remote_datareader(const PermissionsHandle& remote_handle
 
     if(rah.nil())
     {
-        exception = _SecurityException_("Bad precondition");
+        _SecurityException_(exception, "Bad precondition");
         return false;
     }
 
@@ -1275,7 +1275,7 @@ bool Permissions::check_remote_datareader(const PermissionsHandle& remote_handle
     }
     else
     {
-        exception = _SecurityException_("Not found topic access rule for topic " + subscription_data.topicName().to_string());
+        _SecurityException_(exception, "Not found topic access rule for topic " + subscription_data.topicName().to_string());
         return false;
     }
 
@@ -1291,7 +1291,7 @@ bool Permissions::check_remote_datareader(const PermissionsHandle& remote_handle
                 }
                 else
                 {
-                    exception = _SecurityException_(subscription_data.topicName().to_string() +
+                    _SecurityException_(exception, subscription_data.topicName().to_string() +
                             std::string(" topic denied by deny rule."));
                 }
 
@@ -1313,7 +1313,7 @@ bool Permissions::check_remote_datareader(const PermissionsHandle& remote_handle
 
     if(!returned_value && strlen(exception.what()) == 0)
     {
-        exception = _SecurityException_(subscription_data.topicName().to_string() +
+        _SecurityException_(exception, subscription_data.topicName().to_string() +
                 std::string(" topic not found in allow rule."));
     }
 
@@ -1327,7 +1327,7 @@ bool Permissions::get_participant_sec_attributes(const PermissionsHandle& local_
 
     if(lah.nil())
     {
-        exception = _SecurityException_("Bad precondition");
+        _SecurityException_(exception, "Bad precondition");
         return false;
     }
 
@@ -1351,7 +1351,7 @@ bool Permissions::get_datawriter_sec_attributes(const PermissionsHandle& permiss
     }
     else
     {
-        exception = _SecurityException_("Not found topic access rule for topic " + topic_name);
+        _SecurityException_(exception, "Not found topic access rule for topic " + topic_name);
     }
 
     return false;
@@ -1372,7 +1372,7 @@ bool Permissions::get_datareader_sec_attributes(const PermissionsHandle& permiss
     }
     else
     {
-        exception = _SecurityException_("Not found topic access rule for topic " + topic_name);
+        _SecurityException_(exception, "Not found topic access rule for topic " + topic_name);
     }
 
     return false;

--- a/src/cpp/security/cryptography/AESGCMGMAC_KeyExchange.cpp
+++ b/src/cpp/security/cryptography/AESGCMGMAC_KeyExchange.cpp
@@ -91,19 +91,19 @@ bool AESGCMGMAC_KeyExchange::set_remote_participant_crypto_tokens(
     //As only relevant KeyMaterials are tokenized, only one Token is exchanged
     if(remote_participant_tokens.size() != 1){
         logWarning(SECURITY_CRYPTO, "Invalid CryptoTokenSeq length");
-        exception = SecurityException("Incorrect remote CryptoSequence length");
+        exception.set_msg("Incorrect remote CryptoSequence length");
         return false;
     }
     if(remote_participant_tokens.at(0).class_id() != "DDS:Crypto:AES_GCM_GMAC"){
         logWarning(SECURITY_CRYPTO, "MalformedCryptoToken");
-        exception = SecurityException("Incorrect token type received");
+        exception.set_msg("Incorrect token type received");
         return false;
     }
     if(remote_participant_tokens.at(0).binary_properties().size() !=1 || remote_participant_tokens.at(0).properties().size() != 0 ||
         remote_participant_tokens.at(0).binary_properties().at(0).name() != "dds.cryp.keymat")
     {
         logWarning(SECURITY_CRYPTO, "MalformedCryptoToken");
-        exception = SecurityException("Malformed CryptoToken");
+        exception.set_msg("Malformed CryptoToken");
         return false;
     }
     //Valid CryptoToken, we can decrypt and push the resulting KeyMaterial in as a RemoteParticipant2ParticipantKeyMaterial
@@ -215,7 +215,7 @@ bool AESGCMGMAC_KeyExchange::set_remote_datareader_crypto_tokens(
     auto nTokens = remote_datareader_tokens.size();
     if(nTokens != 1 && nTokens != 2){
         logWarning(SECURITY_CRYPTO,"Malformed CryptoTokenSequence");
-        exception = SecurityException("Incorrect remote CryptoSequence length");
+        exception.set_msg("Incorrect remote CryptoSequence length");
         return false;
     }
     for (size_t i = 0; i < nTokens; i++)
@@ -223,7 +223,7 @@ bool AESGCMGMAC_KeyExchange::set_remote_datareader_crypto_tokens(
         if (remote_datareader_tokens.at(i).class_id() != "DDS:Crypto:AES_GCM_GMAC")
         {
             logWarning(SECURITY_CRYPTO, "Malformed CryptoToken");
-            exception = SecurityException("Incorrect token type received");
+            exception.set_msg("Incorrect token type received");
             return false;
         }
 
@@ -231,7 +231,7 @@ bool AESGCMGMAC_KeyExchange::set_remote_datareader_crypto_tokens(
             remote_datareader_tokens.at(i).binary_properties().at(0).name() != "dds.cryp.keymat")
         {
             logWarning(SECURITY_CRYPTO, "Malformed CryptoToken");
-            exception = SecurityException("Malformed CryptoToken");
+            exception.set_msg("Malformed CryptoToken");
             return false;
         }
 
@@ -276,7 +276,7 @@ bool AESGCMGMAC_KeyExchange::set_remote_datawriter_crypto_tokens(
     auto nTokens = remote_datawriter_tokens.size();
     if(nTokens != 1 && nTokens != 2){
         logWarning(SECURITY_CRYPTO,"Malformed CryptoTokenSequence");
-        exception = SecurityException("Incorrect remote CryptoSequence length");
+        exception.set_msg("Incorrect remote CryptoSequence length");
         return false;
     }
 
@@ -285,7 +285,7 @@ bool AESGCMGMAC_KeyExchange::set_remote_datawriter_crypto_tokens(
         if (remote_datawriter_tokens.at(i).class_id() != "DDS:Crypto:AES_GCM_GMAC")
         {
             logWarning(SECURITY_CRYPTO, "Malformed CryptoToken");
-            exception = SecurityException("Incorrect token type received");
+            exception.set_msg("Incorrect token type received");
             return false;
         }
 
@@ -293,7 +293,7 @@ bool AESGCMGMAC_KeyExchange::set_remote_datawriter_crypto_tokens(
             remote_datawriter_tokens.at(i).binary_properties().at(0).name() != "dds.cryp.keymat")
         {
             logWarning(SECURITY_CRYPTO, "Malformed CryptoToken");
-            exception = SecurityException("Malformed CryptoToken");
+            exception.set_msg("Malformed CryptoToken");
             return false;
         }
 
@@ -328,7 +328,7 @@ bool AESGCMGMAC_KeyExchange::return_crypto_tokens(
             SecurityException &exception)
 {
 
-    exception = SecurityException("Not implemented");
+    exception.set_msg("Not implemented");
     return false;
 }
 

--- a/src/cpp/security/cryptography/AESGCMGMAC_KeyFactory.cpp
+++ b/src/cpp/security/cryptography/AESGCMGMAC_KeyFactory.cpp
@@ -187,7 +187,7 @@ ParticipantCryptoHandle * AESGCMGMAC_KeyFactory::register_matched_remote_partici
     const std::vector<uint8_t>* challenge_2 = SharedSecretHelper::find_data_value(**shared_secret,"Challenge2");
     if( (challenge_1 == nullptr) | (shared_secret_ss == nullptr) | (challenge_2 == nullptr) ){
         logWarning(SECURITY_CRYPTO,"Malformed SharedSecretHandle");
-        exception = SecurityException("Unable to read SharedSecret and Challenges");
+        exception.set_msg("Unable to read SharedSecret and Challenges");
         return nullptr;
     }
 
@@ -234,7 +234,7 @@ ParticipantCryptoHandle * AESGCMGMAC_KeyFactory::register_matched_remote_partici
         if (!create_kx_key(buffer.master_salt, challenge_1, "keyexchange salt", challenge_2, shared_secret_ss))
         {
             logWarning(SECURITY_CRYPTO, "Error generating the keys to perform token transaction");
-            exception = SecurityException("Encountered an error while creating KxKeyMaterials");
+            exception.set_msg("Encountered an error while creating KxKeyMaterials");
             delete RPCrypto;
             return nullptr;
         }
@@ -242,7 +242,7 @@ ParticipantCryptoHandle * AESGCMGMAC_KeyFactory::register_matched_remote_partici
         if(!create_kx_key(buffer.master_sender_key, challenge_2, "key exchange key", challenge_1, shared_secret_ss))
         {
             logWarning(SECURITY_CRYPTO, "Error generating the keys to perform token transaction");
-            exception = SecurityException("Encountered an error while creating KxKeyMaterials");
+            exception.set_msg("Encountered an error while creating KxKeyMaterials");
             delete RPCrypto;
             return nullptr;
         }
@@ -699,7 +699,7 @@ bool AESGCMGMAC_KeyFactory::unregister_datawriter(
     AESGCMGMAC_WriterCryptoHandle& datawriter = AESGCMGMAC_WriterCryptoHandle::narrow(*datawriter_crypto_handle);
 
     if(datawriter.nil()){
-        exception = SecurityException("Not a valid DataWriterCryptoHandle has been passed as an argument");
+        exception.set_msg("Not a valid DataWriterCryptoHandle has been passed as an argument");
         return false;
     }
     if( (datawriter->Parent_participant) == nullptr){
@@ -709,7 +709,7 @@ bool AESGCMGMAC_KeyFactory::unregister_datawriter(
     }
     AESGCMGMAC_ParticipantCryptoHandle& parent_participant = AESGCMGMAC_ParticipantCryptoHandle::narrow( *(datawriter->Parent_participant) );
     if(parent_participant.nil()){
-        exception = SecurityException("Malformed AESGCMGMAC_WriterCryptohandle");
+        exception.set_msg("Malformed AESGCMGMAC_WriterCryptohandle");
         return false;
     }
 
@@ -737,7 +737,7 @@ bool AESGCMGMAC_KeyFactory::unregister_datareader(
     AESGCMGMAC_ReaderCryptoHandle& datareader = AESGCMGMAC_ReaderCryptoHandle::narrow(*datareader_crypto_handle);
 
     if(datareader.nil()){
-        exception = SecurityException("Not a valid DataReaderCryptoHandle has been passed as an argument");
+        exception.set_msg("Not a valid DataReaderCryptoHandle has been passed as an argument");
         return false;
     }
     if( (datareader->Parent_participant) == nullptr){
@@ -747,7 +747,7 @@ bool AESGCMGMAC_KeyFactory::unregister_datareader(
     }
     AESGCMGMAC_ParticipantCryptoHandle& parent_participant = AESGCMGMAC_ParticipantCryptoHandle::narrow( *(datareader->Parent_participant) );
     if(parent_participant.nil()){
-        exception = SecurityException("Malformed AESGCMGMAC_WriterCryptohandle");
+        exception.set_msg("Malformed AESGCMGMAC_WriterCryptohandle");
         return false;
     }
 

--- a/src/cpp/security/cryptography/AESGCMGMAC_Transform.cpp
+++ b/src/cpp/security/cryptography/AESGCMGMAC_Transform.cpp
@@ -801,14 +801,14 @@ bool AESGCMGMAC_Transform::preprocess_secure_submsg(
     AESGCMGMAC_ParticipantCryptoHandle& remote_participant = AESGCMGMAC_ParticipantCryptoHandle::narrow(sending_crypto);
     if(remote_participant.nil()){
         logWarning(SECURITY_CRYPTO,"Invalid CryptoHandle");
-        exception = SecurityException("Not a valid ParticipantCryptoHandle received");
+        exception.set_msg("Not a valid ParticipantCryptoHandle received");
         return false;
     }
 
     AESGCMGMAC_ParticipantCryptoHandle& local_participant = AESGCMGMAC_ParticipantCryptoHandle::narrow(receiving_crypto);
     if(local_participant.nil()){
         logWarning(SECURITY_CRYPTO,"Invalid CryptoHandle");
-        exception = SecurityException("Not a valid ParticipantCryptoHandle received");
+        exception.set_msg("Not a valid ParticipantCryptoHandle received");
         return false;
     }
 
@@ -1322,7 +1322,7 @@ bool AESGCMGMAC_Transform::decode_serialized_payload(
     AESGCMGMAC_WriterCryptoHandle& sending_writer = AESGCMGMAC_WriterCryptoHandle::narrow(sending_datawriter_crypto);
 
     if(sending_writer.nil()){
-        exception = SecurityException("Not a valid sending_writer handle");
+        exception.set_msg("Not a valid sending_writer handle");
         return false;
     }
 
@@ -2045,7 +2045,7 @@ bool AESGCMGMAC_Transform::deserialize_SecureDataTag(eprosima::fastcdr::Cdr& dec
         if(!mac_found)
         {
             logWarning(SECURITY_CRYPTO,"Unable to authenticate the message: message does not target this Participant");
-            exception = SecurityException("Message does not contain a suitable specific MAC for the receiving Participant");
+            exception.set_msg("Message does not contain a suitable specific MAC for the receiving Participant");
             return false;
         }
 

--- a/src/cpp/security/cryptography/AESGCMGMAC_Transform.cpp
+++ b/src/cpp/security/cryptography/AESGCMGMAC_Transform.cpp
@@ -590,7 +590,7 @@ bool AESGCMGMAC_Transform::decode_rtps_message(
         const CDRMessage_t& encoded_buffer,
         const ParticipantCryptoHandle& /*receiving_crypto*/,
         const ParticipantCryptoHandle &sending_crypto,
-        SecurityException& /*exception*/)
+        SecurityException& exception)
 {
     const AESGCMGMAC_ParticipantCryptoHandle& sending_participant = AESGCMGMAC_ParticipantCryptoHandle::narrow(sending_crypto);
 
@@ -750,8 +750,6 @@ bool AESGCMGMAC_Transform::decode_rtps_message(
 
         decoder >> length;
         const char* const current_position = decoder.getCurrentPosition();
-
-        SecurityException exception;
 
         if(!deserialize_SecureDataTag(decoder, tag, sending_participant->RemoteParticipant2ParticipantKeyMaterial.at(0).transformation_kind,
                 sending_participant->RemoteParticipant2ParticipantKeyMaterial.at(0).receiver_specific_key_id,
@@ -959,7 +957,7 @@ bool AESGCMGMAC_Transform::decode_datawriter_submessage(
         CDRMessage_t& encoded_rtps_submessage,
         DatareaderCryptoHandle& /*receiving_datareader_crypto*/,
         DatawriterCryptoHandle& sending_datawriter_cryupto,
-        SecurityException& /*exception*/)
+        SecurityException& exception)
 {
     AESGCMGMAC_WriterCryptoHandle& sending_writer = AESGCMGMAC_WriterCryptoHandle::narrow(sending_datawriter_cryupto);
 
@@ -1093,8 +1091,6 @@ bool AESGCMGMAC_Transform::decode_datawriter_submessage(
         decoder >> length;
         const char* const current_position = decoder.getCurrentPosition();
 
-        SecurityException exception;
-
         if(!deserialize_SecureDataTag(decoder, tag, keyMat->transformation_kind,
                 keyMat->receiver_specific_key_id,
                 keyMat->master_receiver_specific_key,
@@ -1137,7 +1133,7 @@ bool AESGCMGMAC_Transform::decode_datareader_submessage(
         CDRMessage_t& encoded_rtps_submessage,
         DatawriterCryptoHandle& /*receiving_datawriter_crypto*/,
         DatareaderCryptoHandle& sending_datareader_crypto,
-        SecurityException& /*exception*/)
+        SecurityException& exception)
 {
     AESGCMGMAC_ReaderCryptoHandle& sending_reader = AESGCMGMAC_ReaderCryptoHandle::narrow(sending_datareader_crypto);
 
@@ -1270,8 +1266,6 @@ bool AESGCMGMAC_Transform::decode_datareader_submessage(
 
         decoder >> length;
         const char* const current_position = decoder.getCurrentPosition();
-
-        SecurityException exception;
 
         if(!deserialize_SecureDataTag(decoder, tag, keyMat->transformation_kind,
                 keyMat->receiver_specific_key_id,


### PR DESCRIPTION
Using a fixed-sized character array instead of a `std::string` to avoid dynamic allocations