### PR TITLE
Added a Flush method to the log in order to prevent logged info leakage [#5880]

### DIFF
--- a/include/fastrtps/log/Log.h
+++ b/include/fastrtps/log/Log.h
@@ -107,6 +107,9 @@ class Log
         //! Returns the logging engine to configuration defaults.
         RTPS_DllAPI static void Reset();
 
+        //! Waits until no more log info is availabel
+        RTPS_DllAPI static void Flush();
+
         //! Stops the logging thread. It will re-launch on the next call to a successful log macro.
         RTPS_DllAPI static void KillThread();
 

--- a/src/cpp/log/Log.cpp
+++ b/src/cpp/log/Log.cpp
@@ -57,6 +57,24 @@ void Log::Reset()
     mResources.mConsumers.emplace_back(new StdoutConsumer);
 }
 
+void Log::Flush()
+{
+    std::unique_lock<std::mutex> guard(mResources.mCvMutex);
+
+    if (!mResources.mLogging && !mResources.mLoggingThread)
+    {
+        // already killed
+        return;
+    }
+
+    // Wait till the background thread signals
+    mResources.mCv.wait(guard, [&]()
+    {
+        return mResources.mLogs.BothEmpty();
+    });
+
+}
+
 void Log::Run()
 {
     std::unique_lock<std::mutex> guard(mResources.mCvMutex);

--- a/src/cpp/log/Log.cpp
+++ b/src/cpp/log/Log.cpp
@@ -67,10 +67,10 @@ void Log::Flush()
         return;
     }
 
-    // Wait till the background thread signals
+    // Wait till the background thread signals and...
     mResources.mCv.wait(guard, [&]()
-    {
-        return mResources.mLogs.BothEmpty();
+    {   // ... either the logging has ended or the queue is flushed
+        return !mResources.mLogging || mResources.mLogs.BothEmpty();
     });
 
 }
@@ -102,7 +102,7 @@ void Log::Run()
             }
             guard.lock();
         }
-        mResources.mCv.notify_one();
+        mResources.mCv.notify_all();
         if (mResources.mLogging)
             mResources.mCv.wait(guard);
     }


### PR DESCRIPTION
Now Log::Run() calls mResources.mCv.notify_all() instead of notify_one() to encompass a multiple thread-flush scenario.

All tests pass on Windows.

```
void Log::Flush()
{
    std::unique_lock<std::mutex> guard(mResources.mCvMutex);

    if (!mResources.mLogging && !mResources.mLoggingThread)
    {
        // already killed
        return;
    }

    // Wait till the background thread signals and...
    mResources.mCv.wait(guard, [&]()
    {   // ... either the logging has ended or the queue is flushed
        return !mResources.mLogging || mResources.mLogs.BothEmpty();
    });

}
```