### PR TITLE
Fixing valgrind error on Nightly builds [6108]

### DIFF
--- a/include/fastrtps/rtps/common/LocatorSelectorEntry.hpp
+++ b/include/fastrtps/rtps/common/LocatorSelectorEntry.hpp
@@ -75,6 +75,7 @@ struct LocatorSelectorEntry
         , unicast(ResourceLimitedContainerConfig::fixed_size_configuration(max_unicast_locators))
         , multicast(ResourceLimitedContainerConfig::fixed_size_configuration(max_multicast_locators))
         , state(max_unicast_locators, max_multicast_locators)
+        , enabled(false)
         , transport_should_process(false)
     {
     }


### PR DESCRIPTION
Nightly Linux builds are complaining of a possibly uninitialized usage.