### PR TITLE
Eliminating use of acceptMsgDirectTo [6277]

### DIFF
--- a/include/fastrtps/rtps/common/Guid.h
+++ b/include/fastrtps/rtps/common/Guid.h
@@ -24,6 +24,7 @@
 
 #include <cstdint>
 #include <cstring>
+#include <sstream>
 
 namespace eprosima{
 namespace fastrtps{
@@ -564,5 +565,18 @@ inline std::ostream& operator<<(std::ostream& output,const GUID_t& guid)
 }
 }
 
+namespace std {
+  template <>
+    struct hash<eprosima::fastrtps::rtps::EntityId_t>
+  {
+    std::size_t operator()(const eprosima::fastrtps::rtps::EntityId_t& k) const
+    {
+      std::stringstream ss_guid;
+      ss_guid << k;
+      std::hash<std::string> hash_fn;
+      return hash_fn(ss_guid.str());
+    }
+  };
+}
 
 #endif /* RTPS_GUID_H_ */

--- a/include/fastrtps/rtps/messages/MessageReceiver.h
+++ b/include/fastrtps/rtps/messages/MessageReceiver.h
@@ -22,6 +22,7 @@
 #define MESSAGERECEIVER_H_
 #ifndef DOXYGEN_SHOULD_SKIP_THIS_PUBLIC
 
+#include <unordered_map>
 #include "../common/all_common.h"
 #include "../../qos/ParameterList.h"
 
@@ -79,7 +80,7 @@ class MessageReceiver
 
     private:
         std::vector<RTPSWriter *> AssociatedWriters;
-        std::vector<RTPSReader *> AssociatedReaders;
+        std::unordered_map<EntityId_t, std::vector<RTPSReader*>> AssociatedReaders;
         std::mutex mtx;
         //!Protocol version of the message
         ProtocolVersion_t sourceVersion;
@@ -124,6 +125,19 @@ class MessageReceiver
          * @return True if correctly read.
          */
         bool readSubmessageHeader(CDRMessage_t*msg, SubmessageHeader_t* smh);
+
+        /**
+         * Find if there is a reader (in AssociatedReaders) that will accept a msg directed
+         * to the given entity ID.
+         */
+        bool willAReaderAcceptMsgDirectedTo(const EntityId_t & readerID);
+
+        /**
+         * Find all readers (in AssociatedReaders), with the given entity ID, and call the
+         * callback provided.
+         */
+        void findAllReaders(const EntityId_t & readerID, std::function<void(RTPSReader*)>);
+
         /**
          *
          * @param msg

--- a/include/fastrtps/rtps/reader/RTPSReader.h
+++ b/include/fastrtps/rtps/reader/RTPSReader.h
@@ -91,12 +91,7 @@ public:
     RTPS_DllAPI virtual bool matched_writer_is_matched(const GUID_t& writer_guid) = 0;
 
     /**
-     * Returns true if the reader accepts a message directed to entityId.
-     */
-    RTPS_DllAPI bool acceptMsgDirectedTo(const EntityId_t& entityId) const;
-
-    /**
-     * Processes a new DATA message. Previously the message must have been accepted by function acceptMsgDirectedTo.
+     * Processes a new DATA message.
      *
      * @param change Pointer to the CacheChange_t.
      * @return true if the reader accepts messages from the.
@@ -104,8 +99,7 @@ public:
     RTPS_DllAPI virtual bool processDataMsg(CacheChange_t* change) = 0;
 
     /**
-     * Processes a new DATA FRAG message. Previously the message must have been accepted by function
-     * acceptMsgDirectedTo.
+     * Processes a new DATA FRAG message.
      *
      * @param change Pointer to the CacheChange_t.
      * @param sampleSize Size of the complete, assembled message.
@@ -118,8 +112,7 @@ public:
             uint32_t fragmentStartingNum) = 0;
 
     /**
-     * Processes a new HEARTBEAT message. Previously the message must have been accepted by function
-     * acceptMsgDirectedTo.
+     * Processes a new HEARTBEAT message.
      * @param writerGUID
      * @param hbCount
      * @param firstSN
@@ -137,8 +130,7 @@ public:
             bool livelinessFlag) = 0;
 
     /**
-     * Processes a new GAP message. Previously the message must have been accepted by function
-     * acceptMsgDirectedTo.
+     * Processes a new GAP message.
      * @param writerGUID
      * @param gapStart
      * @param gapList

--- a/include/fastrtps/rtps/reader/StatefulReader.h
+++ b/include/fastrtps/rtps/reader/StatefulReader.h
@@ -91,14 +91,14 @@ class StatefulReader : public RTPSReader
                 WriterProxy** WP);
 
         /**
-         * Processes a new DATA message. Previously the message must have been accepted by function acceptMsgDirectedTo.
+         * Processes a new DATA message.
          * @param change Pointer to the CacheChange_t.
          * @return true if the reader accepts messages.
          */
         bool processDataMsg(CacheChange_t* change) override;
 
         /**
-         * Processes a new DATA FRAG message. Previously the message must have been accepted by function acceptMsgDirectedTo.
+         * Processes a new DATA FRAG message.
          * @param change Pointer to the CacheChange_t.
          * @param sampleSize Size of the complete assembled message.
          * @param fragmentStartingNum fragment number of this particular fragment.
@@ -110,7 +110,7 @@ class StatefulReader : public RTPSReader
                 uint32_t fragmentStartingNum) override;
 
         /**
-         * Processes a new HEARTBEAT message. Previously the message must have been accepted by function acceptMsgDirectedTo.
+         * Processes a new HEARTBEAT message.
          *
          * @return true if the reader accepts messages.
          */

--- a/include/fastrtps/rtps/reader/StatelessReader.h
+++ b/include/fastrtps/rtps/reader/StatelessReader.h
@@ -87,7 +87,7 @@ public:
             WriterProxy* prox = nullptr) override;
 
     /**
-     * Processes a new DATA message. Previously the message must have been accepted by function acceptMsgDirectedTo.
+     * Processes a new DATA message.
      *
      * @param change Pointer to the CacheChange_t.
      * @return true if the reader accepts messages from the.
@@ -95,7 +95,7 @@ public:
     bool processDataMsg(CacheChange_t *change) override;
 
     /**
-     * Processes a new DATA FRAG message. Previously the message must have been accepted by function acceptMsgDirectedTo.
+     * Processes a new DATA FRAG message.
      * @param change Pointer to the CacheChange_t.
      * @param sampleSize Size of the complete assembled message.
      * @param fragmentStartingNum fragment number of this particular fragment.
@@ -107,7 +107,7 @@ public:
             uint32_t fragmentStartingNum) override;
 
     /**
-     * Processes a new HEARTBEAT message. Previously the message must have been accepted by function acceptMsgDirectedTo.
+     * Processes a new HEARTBEAT message.
      *
      * @return true if the reader accepts messages from the.
      */

--- a/src/cpp/rtps/messages/MessageReceiver.cpp
+++ b/src/cpp/rtps/messages/MessageReceiver.cpp
@@ -90,15 +90,24 @@ void MessageReceiver::associateEndpoint(Endpoint *to_add){
     }
     else
     {
-        for(auto it = AssociatedReaders.begin(); it != AssociatedReaders.end(); ++it)
-        {
-            if( (*it) == (RTPSReader*)to_add )
-            {
-                found = true;
-                break;
-            }
+        const auto reader = static_cast<RTPSReader*>(to_add);
+        const auto entityId = reader->getGuid().entityId;
+        // search for set of readers by entity ID
+        const auto readers = AssociatedReaders.find(entityId);
+        if (readers == AssociatedReaders.end()) {
+            auto vec = std::vector<RTPSReader*>();
+            vec.push_back(reader);
+            AssociatedReaders.emplace(entityId, vec);
         }
-        if(!found) AssociatedReaders.push_back((RTPSReader*)to_add);
+        else {
+            for (const auto & it : readers->second) {
+                if (it == reader) {
+                    found = true;
+                    break;
+                }
+            }
+            if (!found) readers->second.push_back(reader);
+        }
     }
     return;
 }
@@ -114,11 +123,15 @@ void MessageReceiver::removeEndpoint(Endpoint *to_remove){
             }
         }
     }else{
-        RTPSReader *var = (RTPSReader *)to_remove;
-        for(auto it=AssociatedReaders.begin(); it !=AssociatedReaders.end(); ++it){
-            if ((*it) == var){
-                AssociatedReaders.erase(it);
-                break;
+        auto readers = AssociatedReaders.find(to_remove->getGuid().entityId);
+        if (readers != AssociatedReaders.end()) {
+            RTPSReader *var = (RTPSReader *)to_remove;
+            for (auto it = readers->second.begin(); it != readers->second.end(); ++it) {
+                if (*it == var){
+                    readers->second.erase(it);
+                    if (readers->second.empty()) AssociatedReaders.erase(readers);
+                    break;
+                }
             }
         }
     }
@@ -406,6 +419,47 @@ bool MessageReceiver::readSubmessageHeader(CDRMessage_t* msg, SubmessageHeader_t
     return true;
 }
 
+bool MessageReceiver::willAReaderAcceptMsgDirectedTo(const EntityId_t & readerID)
+{
+    if(AssociatedReaders.empty()) {
+        logWarning(RTPS_MSG_IN,IDSTRING"Data received when NO readers are listening");
+        return false;
+    }
+
+    if (readerID != c_EntityId_Unknown) {
+        const auto readers = AssociatedReaders.find(readerID);
+        if (readers != AssociatedReaders.end() && !readers->second.empty()) {
+            return true;
+        }
+    }
+    else {
+        for(const auto & readers : AssociatedReaders) {
+            if (readers.second.empty()) continue;
+            for (const auto & it : readers.second) {
+                if (it->m_acceptMessagesToUnknownReaders) return true;
+            }
+        }
+    }
+
+    logWarning(RTPS_MSG_IN, IDSTRING"No Reader accepts this message (directed to: " <<readerID << ")");
+    return false;
+}
+
+void MessageReceiver::findAllReaders(const EntityId_t & readerID, std::function<void(RTPSReader*)> callback)
+{
+    if (readerID != c_EntityId_Unknown) {
+        const auto readers = AssociatedReaders.find(readerID);
+        for (const auto & it : readers->second) callback(it);
+    }
+    else {
+        for (const auto & readers : AssociatedReaders) {
+            for (const auto & it : readers.second) {
+                if (it->m_acceptMessagesToUnknownReaders) callback(it);
+            }
+        }
+    }
+}
+
 bool MessageReceiver::proc_Submsg_Data(CDRMessage_t* msg,SubmessageHeader_t* smh)
 {
     std::lock_guard<std::mutex> guard(mtx);
@@ -445,28 +499,8 @@ bool MessageReceiver::proc_Submsg_Data(CDRMessage_t* msg,SubmessageHeader_t* smh
     valid &= CDRMessage::readEntityId(msg,&readerID);
 
     //WE KNOW THE READER THAT THE MESSAGE IS DIRECTED TO SO WE LOOK FOR IT:
+    if (!willAReaderAcceptMsgDirectedTo(readerID)) return false;
 
-    RTPSReader* firstReader = nullptr;
-    if(AssociatedReaders.empty())
-    {
-        logWarning(RTPS_MSG_IN,IDSTRING"Data received when NO readers are listening");
-        return false;
-    }
-
-    for(std::vector<RTPSReader*>::iterator it=AssociatedReaders.begin();
-            it != AssociatedReaders.end(); ++it)
-    {
-        if((*it)->acceptMsgDirectedTo(readerID)) //add
-        {
-            firstReader = *it;
-            break;
-        }
-    }
-    if(firstReader == nullptr) //Reader not found
-    {
-        logWarning(RTPS_MSG_IN, IDSTRING"No Reader accepts this message (directed to: " <<readerID << ")");
-        return false;
-    }
     //FOUND THE READER.
     //We ask the reader for a cachechange to store the information.
     CacheChange_t ch;
@@ -560,16 +594,14 @@ bool MessageReceiver::proc_Submsg_Data(CDRMessage_t* msg,SubmessageHeader_t* smh
 
 
     //FIXME: DO SOMETHING WITH PARAMETERLIST CREATED.
-    logInfo(RTPS_MSG_IN,IDSTRING"from Writer " << ch.writerGUID << "; possible RTPSReaders: "<<AssociatedReaders.size());
+    logInfo(RTPS_MSG_IN,IDSTRING"from Writer " << ch.writerGUID << "; possible RTPSReader entities: "
+        << AssociatedReaders.size());
     //Look for the correct reader to add the change
-    for(std::vector<RTPSReader*>::iterator it = AssociatedReaders.begin();
-            it != AssociatedReaders.end(); ++it)
-    {
-        if((*it)->acceptMsgDirectedTo(readerID))
-        {
-            (*it)->processDataMsg(&ch);
-        }
-    }
+    findAllReaders(readerID, [
+            &ch
+        ] (RTPSReader* reader) {
+            reader->processDataMsg(&ch);
+        });
 
     //TODO(Ricardo) If a exception is thrown (ex, by fastcdr), this line is not executed -> segmentation fault
     ch.serializedPayload.data = nullptr;
@@ -612,28 +644,7 @@ bool MessageReceiver::proc_Submsg_DataFrag(CDRMessage_t* msg, SubmessageHeader_t
     valid &= CDRMessage::readEntityId(msg, &readerID);
 
     //WE KNOW THE READER THAT THE MESSAGE IS DIRECTED TO SO WE LOOK FOR IT:
-    if(AssociatedReaders.empty())
-    {
-        logWarning(RTPS_MSG_IN, IDSTRING"Data received when NO readers are listening");
-        return false;
-    }
-
-    RTPSReader* firstReader = nullptr;
-    for (std::vector<RTPSReader*>::iterator it = AssociatedReaders.begin();
-            it != AssociatedReaders.end(); ++it)
-    {
-        if ((*it)->acceptMsgDirectedTo(readerID)) //add
-        {
-            firstReader = *it;
-            break;
-        }
-    }
-
-    if (firstReader == nullptr) //Reader not found
-    {
-        logWarning(RTPS_MSG_IN, IDSTRING"No Reader accepts this message (directed to: " << readerID << ")");
-        return false;
-    }
+    if (!willAReaderAcceptMsgDirectedTo(readerID)) return false;
 
     //FOUND THE READER.
     //We ask the reader for a cachechange to store the information.
@@ -750,16 +761,14 @@ bool MessageReceiver::proc_Submsg_DataFrag(CDRMessage_t* msg, SubmessageHeader_t
         ch.sourceTimestamp = this->timestamp;
 
     //FIXME: DO SOMETHING WITH PARAMETERLIST CREATED.
-    logInfo(RTPS_MSG_IN, IDSTRING"from Writer " << ch.writerGUID << "; possible RTPSReaders: " << AssociatedReaders.size());
+    logInfo(RTPS_MSG_IN, IDSTRING"from Writer " << ch.writerGUID << "; possible RTPSReader entities: "
+        << AssociatedReaders.size());
     //Look for the correct reader to add the change
-    for (std::vector<RTPSReader*>::iterator it = AssociatedReaders.begin();
-            it != AssociatedReaders.end(); ++it)
-    {
-        if ((*it)->acceptMsgDirectedTo(readerID))
-        {
-            (*it)->processDataFragMsg(&ch, sampleSize, fragmentStartingNum);
-        }
-    }
+    findAllReaders(readerID, [
+            &ch, sampleSize, fragmentStartingNum
+        ] (RTPSReader* reader) {
+            reader->processDataFragMsg(&ch, sampleSize, fragmentStartingNum);
+        });
 
     ch.serializedPayload.data = nullptr;
 
@@ -799,14 +808,12 @@ bool MessageReceiver::proc_Submsg_Heartbeat(CDRMessage_t* msg,SubmessageHeader_t
 
     std::lock_guard<std::mutex> guard(mtx);
     //Look for the correct reader and writers:
-    for (std::vector<RTPSReader*>::iterator it = AssociatedReaders.begin();
-            it != AssociatedReaders.end(); ++it)
-    {
-        if((*it)->acceptMsgDirectedTo(readerGUID.entityId))
-        {
-            (*it)->processHeartbeatMsg(writerGUID, HBCount, firstSN, lastSN, finalFlag, livelinessFlag);
-        }
-    }
+    findAllReaders(readerGUID.entityId, [
+            &writerGUID, &HBCount, &firstSN, &lastSN, finalFlag, livelinessFlag
+        ] (RTPSReader* reader) {
+            reader->processHeartbeatMsg(writerGUID, HBCount, firstSN, lastSN, finalFlag, livelinessFlag);
+        });
+
     return true;
 }
 
@@ -874,14 +881,11 @@ bool MessageReceiver::proc_Submsg_Gap(CDRMessage_t* msg,SubmessageHeader_t* smh)
         return false;
 
     std::lock_guard<std::mutex> guard(mtx);
-    for (std::vector<RTPSReader*>::iterator it = AssociatedReaders.begin();
-            it != AssociatedReaders.end(); ++it)
-    {
-        if((*it)->acceptMsgDirectedTo(readerGUID.entityId))
-        {
-            (*it)->processGapMsg(writerGUID, gapStart, gapList);
-        }
-    }
+    findAllReaders(readerGUID.entityId, [
+            &writerGUID, &gapStart, &gapList
+        ] (RTPSReader* reader) {
+            reader->processGapMsg(writerGUID, gapStart, gapList);
+        });
 
     return true;
 }
@@ -1021,17 +1025,16 @@ bool MessageReceiver::proc_Submsg_HeartbeatFrag(CDRMessage_t*msg, SubmessageHead
 
     std::lock_guard<std::mutex> guard(mtx);
     //Look for the correct reader and writers:
+    /* XXX TODO
     for (std::vector<RTPSReader*>::iterator it = AssociatedReaders.begin();
             it != AssociatedReaders.end(); ++it)
     {
-        /* XXX TODO PROCESS
            if ((*it)->acceptMsgDirectedTo(readerGUID.entityId))
            {
            (*it)->processHeartbeatMsg(writerGUID, HBCount, firstSN, lastSN, finalFlag, livelinessFlag);
            }
-           */
     }
-
+    */
     return true;
 }
 

--- a/src/cpp/rtps/reader/RTPSReader.cpp
+++ b/src/cpp/rtps/reader/RTPSReader.cpp
@@ -70,16 +70,6 @@ RTPSReader::~RTPSReader()
     mp_history->mp_mutex = nullptr;
 }
 
-bool RTPSReader::acceptMsgDirectedTo(const EntityId_t& entityId) const
-{
-    if(entityId == m_guid.entityId)
-        return true;
-    if(m_acceptMessagesToUnknownReaders && entityId == c_EntityId_Unknown)
-        return true;
-    else
-        return false;
-}
-
 bool RTPSReader::reserveCache(
         CacheChange_t** change, 
         uint32_t dataCdrSerializedSize)


### PR DESCRIPTION
Optimization to reduce calls to EntityId_t::operator== by converting
MessageReceiver::AssociatedReaders from a vector<RTPSReader*> to an
unordered_map<EntityId_t, vector<RTPSReader*>>.