### PR TITLE
libddssec integration [WIP]

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -13,3 +13,6 @@
 [submodule "thirdparty/tinyxml2"]
 	path = thirdparty/tinyxml2
 	url = https://github.com/leethomason/tinyxml2.git
+[submodule "thirdparty/libddssec"]
+	path = thirdparty/libddssec
+	url = https://github.com/ARM-software/libddssec

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -221,10 +221,19 @@ endif()
 # Options
 ###############################################################################
 option(SECURITY "Activate security" OFF)
+option(TEE "Activate TEE support. Only available if SECURITY is ON" OFF)
 
 if(SECURITY)
     find_package(OpenSSL REQUIRED)
+
+    if(TEE)
+        eprosima_find_package(libddssec REQUIRED)
+    endif()
 else()
+    if(TEE)
+        message(FATAL_ERROR "TEE support must be used in conjunction with SECURITY")
+    endif()
+
     find_package(OpenSSL)
 endif()
 

--- a/examples/C++/SecureHelloWorldExample/CMakeLists.txt
+++ b/examples/C++/SecureHelloWorldExample/CMakeLists.txt
@@ -48,6 +48,30 @@ file(GLOB HELLOWORLD_EXAMPLE_SOURCES_CPP "*.cpp")
 add_executable(SecureHelloWorldExample ${HELLOWORLD_EXAMPLE_SOURCES_CXX} ${HELLOWORLD_EXAMPLE_SOURCES_CPP})
 target_include_directories(SecureHelloWorldExample PRIVATE)
 target_link_libraries(SecureHelloWorldExample fastrtps fastcdr)
+
+if(TEE)
+    if(NOT libddssec_FOUND)
+        find_package(libddssec REQUIRED)
+    endif()
+
+    dsec_build_ta(
+        TARGET_NAME
+            ta-secure-helloworld
+        TA_UUID
+            ${DSEC_TA_UUID}
+        OUTPUT_DIR
+            ${PROJECT_BINARY_DIR}/ta
+        FILE_PATH
+            certs/maincacert.pem
+            certs/mainpubcert.pem
+            certs/mainpubkey.pem
+            certs/mainsubcert.pem
+            certs/mainsubkey.pem
+    )
+
+    add_dependencies(SecureHelloWorldExample ta-secure-helloworld)
+endif()
+
 install(TARGETS SecureHelloWorldExample
     RUNTIME DESTINATION examples/C++/SecureHelloWorldExample/${BIN_INSTALL_DIR})
 

--- a/include/fastrtps/rtps/security/common/SharedSecretHandle.h
+++ b/include/fastrtps/rtps/security/common/SharedSecretHandle.h
@@ -116,6 +116,10 @@ class SharedSecret
 
         static const char* const class_id_;
 
+#ifdef LIBDDSSEC_ENABLED
+        int32_t ssh_id;
+#endif
+
         std::vector<BinaryData> data_;
 };
 

--- a/include/fastrtps/rtps/security/common/TEE.h
+++ b/include/fastrtps/rtps/security/common/TEE.h
@@ -1,0 +1,41 @@
+#ifndef TEE_INIT_H_
+#define TEE_INIT_H_
+
+#include <dsec_ca.h>
+#include <fastrtps/log/Log.h>
+
+class TEE_Init
+{
+    public:
+
+        TEE_Init()
+        {
+            instance = dsec_ca_instance_create(&session, &context);
+            int32_t error_code = dsec_ca_instance_open(&instance);
+            if (error_code != 0) {
+                instanceOpenFailLog(error_code);
+                abort();
+            }
+        }
+
+        ~TEE_Init()
+        {
+            int32_t error_code = dsec_ca_instance_close(&instance);
+            if (error_code != 0) {
+                instanceCloseFailLog(error_code);
+            }
+        }
+
+        struct dsec_instance instance;
+
+    private:
+        TEEC_Session session;
+        TEEC_Context context;
+
+        void instanceOpenFailLog(int32_t error_code);
+        void instanceCloseFailLog(int32_t error_code);
+};
+
+extern TEE_Init tee;
+
+#endif /* TEE_INIT_H_ */

--- a/src/cpp/CMakeLists.txt
+++ b/src/cpp/CMakeLists.txt
@@ -176,6 +176,7 @@ set(${PROJECT_NAME}_security_source_files
     rtps/security/SecurityPluginFactory.cpp
     rtps/security/timedevent/HandshakeMessageTokenResent.cpp
     security/OpenSSLInit.cpp
+    $<$<BOOL:${TEE}>:security/TEE.cpp>
     security/authentication/PKIDH.cpp
     security/accesscontrol/Permissions.cpp
     security/cryptography/AESGCMGMAC.cpp
@@ -266,6 +267,7 @@ elseif(NOT EPROSIMA_INSTALLER)
         $<$<AND:$<BOOL:${WIN32}>,$<NOT:$<STREQUAL:"${CMAKE_SYSTEM_NAME}","WindowsStore">>>:_WIN32_WINNT=0x0601>
         $<$<AND:$<BOOL:${WIN32}>,$<STREQUAL:"${CMAKE_SYSTEM_NAME}","WindowsStore">>:SQLITE_OS_WINRT>
         $<$<AND:$<BOOL:${ANDROID}>,$<NOT:$<BOOL:${HAVE_CXX14}>>,$<NOT:$<BOOL:${HAVE_CXX1Y}>>>:ASIO_DISABLE_STD_STRING_VIEW>
+        $<$<BOOL:${TEE}>:LIBDDSSEC_ENABLED>
         )
 
     # Define public headers
@@ -297,7 +299,9 @@ elseif(NOT EPROSIMA_INSTALLER)
         ${TINYXML2_LIBRARY}
         $<$<BOOL:${LINK_SSL}>:OpenSSL::SSL$<SEMICOLON>OpenSSL::Crypto>
         $<$<BOOL:${WIN32}>:iphlpapi$<SEMICOLON>Shlwapi>
-        )
+        $<$<BOOL:${TEE}>:arm::libddssec>
+        $<$<BOOL:${TEE}>:OPTEECLIENT::OPTEECLIENT>
+    )
 
     if(MSVC OR MSVC_IDE)
         set_target_properties(${PROJECT_NAME} PROPERTIES RELEASE_POSTFIX -${PROJECT_VERSION_MAJOR}.${PROJECT_VERSION_MINOR})

--- a/src/cpp/security/TEE.cpp
+++ b/src/cpp/security/TEE.cpp
@@ -1,0 +1,17 @@
+#include <fastrtps/rtps/security/common/TEE.h>
+
+using namespace eprosima::fastrtps;
+
+TEE_Init tee;
+
+void TEE_Init::instanceOpenFailLog(int32_t error_code)
+{
+    logError(SECURITY_AUTHENTICATION,
+             "Fatal: could not create dsec instance. Error: " << error_code);
+}
+
+void TEE_Init::instanceCloseFailLog(int32_t error_code)
+{
+    logWarning(SECURITY_AUTHENTICATION,
+               "Could not close dsec instance. Error: " << error_code);
+}

--- a/src/cpp/security/authentication/PKIHandshakeHandle.h
+++ b/src/cpp/security/authentication/PKIHandshakeHandle.h
@@ -21,7 +21,15 @@
 #include "PKIIdentityHandle.h"
 #include <fastrtps/rtps/security/authentication/Handshake.h>
 #include <fastrtps/rtps/security/common/SharedSecretHandle.h>
+
+#ifdef LIBDDSSEC_ENABLED
+#include <dsec_hh.h>
+#include <fastrtps/rtps/security/common/TEE.h>
+#include <fastrtps/log/Log.h>
+#else
 #include <openssl/evp.h>
+#endif
+
 #include <string>
 
 namespace eprosima {
@@ -33,9 +41,36 @@ class PKIHandshake
 {
     public:
 
+#ifdef LIBDDSSEC_ENABLED
+
+        PKIHandshake() : hh_id(-1), local_identity_handle_(nullptr),
+        remote_identity_handle_(nullptr), sharedsecret_(nullptr)
+        {
+            int32_t libddssec_success;
+            libddssec_success = dsec_hh_create(&hh_id, &(tee.instance));
+            if (libddssec_success != 0) {
+                logWarning(SECURITY_AUTHENTICATION, "Could not create handshake handle.");
+            }
+        }
+
+        ~PKIHandshake()
+        {
+            dsec_hh_delete(&(tee.instance), hh_id);
+
+            if(sharedsecret_ != nullptr)
+            {
+                delete sharedsecret_;
+            }
+        }
+
+        int hh_id;
+
+#else
+
         PKIHandshake() : dhkeys_(nullptr), peerkeys_(nullptr),
         local_identity_handle_(nullptr), remote_identity_handle_(nullptr),
-        sharedsecret_(nullptr) {}
+        sharedsecret_(nullptr)
+        {}
 
         ~PKIHandshake()
         {
@@ -55,12 +90,15 @@ class PKIHandshake
             }
         }
 
+        EVP_PKEY* dhkeys_;
+        EVP_PKEY* peerkeys_;
+
+#endif
 
         static const char* const class_id_;
 
         std::string kagree_alg_;
-        EVP_PKEY* dhkeys_;
-        EVP_PKEY* peerkeys_;
+
         const PKIIdentityHandle* local_identity_handle_;
         PKIIdentityHandle* remote_identity_handle_;
         HandshakeMessageToken handshake_message_;
@@ -75,4 +113,3 @@ typedef HandleImpl<PKIHandshake> PKIHandshakeHandle;
 } //namespace eprosima
 
 #endif // _SECURITY_AUTHENTICATION_PKIHANDSHAKEHANDLE_H_
-

--- a/test/blackbox/CMakeLists.txt
+++ b/test/blackbox/CMakeLists.txt
@@ -185,5 +185,51 @@ if(NOT ((MSVC OR MSVC_IDE) AND EPROSIMA_INSTALLER) AND fastcdr_FOUND)
             "MULTICAST_PORT_RANDOM_NUMBER=${MULTICAST_PORT_RANDOM_NUMBER}"
             LABELS "NoMemoryCheck"
             )
+
+        if(TEE)
+            if(NOT libddssec_FOUND)
+                find_package(libddssec REQUIRED)
+            endif()
+
+            dsec_build_ta(
+                TARGET_NAME
+                    ta-secure-test
+                TA_UUID
+                    ${DSEC_TA_UUID}
+                OUTPUT_DIR
+                    ${CMAKE_CURRENT_BINARY_DIR}/ta
+                FILE_PATH
+                    ${PROJECT_SOURCE_DIR}/test/certs/pwdpubcert.pem
+                    ${PROJECT_SOURCE_DIR}/test/certs/maincacert.pem
+                    ${PROJECT_SOURCE_DIR}/test/certs/mainpubcert.pem
+                    ${PROJECT_SOURCE_DIR}/test/certs/revokedpubkey.pem
+                    ${PROJECT_SOURCE_DIR}/test/certs/seccakey.pem
+                    ${PROJECT_SOURCE_DIR}/test/certs/joinedcacertcrl.pem
+                    ${PROJECT_SOURCE_DIR}/test/certs/seccacert.pem
+                    ${PROJECT_SOURCE_DIR}/test/certs/expiredpubreq.pem
+                    ${PROJECT_SOURCE_DIR}/test/certs/pwdpubkey.pem
+                    ${PROJECT_SOURCE_DIR}/test/certs/revokedpubcert.pem
+                    ${PROJECT_SOURCE_DIR}/test/certs/mainpubkey.pem
+                    ${PROJECT_SOURCE_DIR}/test/certs/maincakey.pem
+                    ${PROJECT_SOURCE_DIR}/test/certs/certs/AE7BAD8C075AEAF5.pem
+                    ${PROJECT_SOURCE_DIR}/test/certs/certs/AE7BAD8C075AEAF4.pem
+                    ${PROJECT_SOURCE_DIR}/test/certs/certs/AE7BAD8C075AEAF7.pem
+                    ${PROJECT_SOURCE_DIR}/test/certs/certs/AE7BAD8C075AEAF3.pem
+                    ${PROJECT_SOURCE_DIR}/test/certs/certs/AE7BAD8C075AEAF6.pem
+                    ${PROJECT_SOURCE_DIR}/test/certs/pwdpubreq.pem
+                    ${PROJECT_SOURCE_DIR}/test/certs/mainsubkey.pem
+                    ${PROJECT_SOURCE_DIR}/test/certs/mainpubreq.pem
+                    ${PROJECT_SOURCE_DIR}/test/certs/revokedpubreq.pem
+                    ${PROJECT_SOURCE_DIR}/test/certs/maincrl.pem
+                    ${PROJECT_SOURCE_DIR}/test/certs/expiredpubcert.pem
+                    ${PROJECT_SOURCE_DIR}/test/certs/mainsubcert.pem
+                    ${PROJECT_SOURCE_DIR}/test/certs/expiredpubkey.pem
+                    ${PROJECT_SOURCE_DIR}/test/certs/mainsubreq.pem
+            )
+
+            add_dependencies(BlackboxTests_DynMem ta-secure-test)
+            add_dependencies(BlackboxTests_ReallocMem ta-secure-test)
+            add_dependencies(BlackboxTests_PreallocMem ta-secure-test)
+        endif()
     endif()
 endif()


### PR DESCRIPTION
We released libddssec v0.1 on Github: https://github.com/ARM-software/libddssec.

The main goal of libddssec is to improve the security implementation of the DDS plugins on Arm based systems by leveraging the use of the TrustZone IP. It is based on Arm Trusted Firmware A (https://developer.trustedfirmware.org/dashboard/view/6/) and OP-TEE (https://www.op-tee.org/).
Secure assets (private keys,..) are stored in a secure memory that can only be accessed by the Trusted Application. The Trusted Application is encrypted and stored into the Linux file system (under `/lib/optee_armtz`). A run-time daemon (tee-supplicant) must be launch in order to load the TA into OP-TEE OS. More information can be found under the readme or doc/ folder of the libddssec project. You can also have a look at the SecureHelloWorld example for more details about generating the Trusted Application.

This PR is a **WIP** integrating libddssec into Fast-RTPS. Currently, it only targets the Authentication Plugin.

The code can be built using the following command line:

```
cmake -DCMAKE_TOOLCHAIN_FILE=<path to toolchain> \
   -DTHIRDPARTY=ON \
   -DCOMPILE_EXAMPLES=ON \
   -DEPROSIMA_BUILD_TESTS=ON \
   -DOPENSSL_ROOT_DIR=<path to openssl> \
   -DGTEST_ROOT=<path to gtest> \
   -DCMAKE_BUILD_TYPE=Debug \
   -DSECURITY=ON \
   -DTEE=ON \
   -DOPTEECLIENT_DIR=<path to OP-TEE Client> \
   ..
```

While building (`make`), the Trusted Application needs to have the following environment variable set: `TA_DEV_KIT_DIR`. Which comes from the build of OP-TEE OS.

This code has been tested using the BlackBox tests from the Fast-RTPS suite and by launching the SecureHelloWorld example with OpenSSL or libddssec support.