### PR TITLE
Refs #6191 - Reconnect recreate strategy update

### DIFF
--- a/include/fastrtps/rtps/attributes/RTPSParticipantAttributes.h
+++ b/include/fastrtps/rtps/attributes/RTPSParticipantAttributes.h
@@ -341,7 +341,11 @@ class RTPSParticipantAttributes
          */
         uint32_t listenSocketBufferSize;
 
-        //! Optionally allow user defined GuidPrefix_t
+        /**
+         * Allows user to define a specific GuidPrefix_t. After participant initialization the local copy of
+         * RTPSParticipantAttributes would keep here the persistent GuidPrefix_t linked with the participant instance.
+         * Default value: c_GuidPrefix_Unknown.
+         */
         GuidPrefix_t prefix;
 
         RTPS_DllAPI inline bool ReadguidPrefix(const char * pfx)

--- a/include/fastrtps/rtps/builtin/data/ParticipantProxyData.h
+++ b/include/fastrtps/rtps/builtin/data/ParticipantProxyData.h
@@ -159,6 +159,18 @@ class ParticipantProxyData
          * @param pdata Object to copy the data from
          */
         void copy(const ParticipantProxyData& pdata);
+
+        /**
+         * Set participant persistent GUID_t
+         * @param guid valid GUID_t
+         */
+        void set_persistence_guid(const GUID_t & guid);
+
+        /**
+         * Retrieve participant persistent GUID_t
+         * @return guid persistent GUID_t or c_Guid_Unknown
+         */
+        GUID_t get_persistence_guid() const;
 };
 
 } /* namespace rtps */

--- a/include/fastrtps/rtps/common/Guid.h
+++ b/include/fastrtps/rtps/common/Guid.h
@@ -558,6 +558,39 @@ inline std::ostream& operator<<(std::ostream& output,const GUID_t& guid)
     return output;
 }
 
+/**
+ * Stream operator, retrieves a GUID.
+ * @param output Output stream.
+ * @param guid GUID_t to print.
+ * @return Stream operator.
+ */
+inline std::istream& operator>>(std::istream& input, GUID_t& guid)
+{
+    std::istream::sentry s(input);
+
+    if(s)
+    {
+        std::ios_base::iostate excp_mask = input.exceptions();
+
+        try
+        {
+            input.exceptions(excp_mask | std::ios_base::failbit | std::ios_base::badbit);
+
+            input >> guid.guidPrefix;
+            input >> guid.entityId;
+        }
+        catch(std::ios_base::failure &)
+        {
+            // maybe is unknown or just invalid
+            guid = c_Guid_Unknown;
+        }
+
+        input.exceptions(excp_mask);
+    }
+
+    return input;
+}
+
 #endif
 
 }

--- a/include/fastrtps/rtps/reader/RTPSReader.h
+++ b/include/fastrtps/rtps/reader/RTPSReader.h
@@ -71,10 +71,9 @@ public:
     /**
      * Add a matched writer represented by its attributes.
      * @param wdata Attributes of the writer to add.
-     * @param persist If the Reader must try to recover Writer formered registered state
      * @return True if correctly added.
      */
-    RTPS_DllAPI virtual bool matched_writer_add(const WriterProxyData& wdata, bool persist = true) = 0;
+    RTPS_DllAPI virtual bool matched_writer_add(const WriterProxyData& wdata) = 0;
 
     /**
      * Remove a writer represented by its attributes from the matched writers.

--- a/include/fastrtps/rtps/reader/StatefulReader.h
+++ b/include/fastrtps/rtps/reader/StatefulReader.h
@@ -61,10 +61,9 @@ class StatefulReader : public RTPSReader
         /**
          * Add a matched writer represented by its attributes.
          * @param wdata Attributes of the writer to add.
-         * @param persist If the Reader must try to recover Writer formered registered state
          * @return True if correctly added.
          */
-        bool matched_writer_add(const WriterProxyData& wdata, bool persist = true) override;
+        bool matched_writer_add(const WriterProxyData& wdata) override;
 
         /**
          * Remove a WriterProxyData from the matached writers.

--- a/include/fastrtps/rtps/reader/StatelessReader.h
+++ b/include/fastrtps/rtps/reader/StatelessReader.h
@@ -57,10 +57,9 @@ public:
     /**
      * Add a matched writer represented by a WriterProxyData object.
      * @param wdata Pointer to the WPD object to add.
-     * @param persist If the Reader must try to recover Writer formered registered state
      * @return True if correctly added.
      */
-    bool matched_writer_add(const WriterProxyData& wdata, bool persist = true) override;
+    bool matched_writer_add(const WriterProxyData& wdata) override;
 
     /**
      * Remove a WriterProxyData from the matached writers.

--- a/src/cpp/rtps/RTPSDomain.cpp
+++ b/src/cpp/rtps/RTPSDomain.cpp
@@ -113,9 +113,10 @@ RTPSParticipant* RTPSDomain::createParticipant(
         PParam.builtin.initialPeersList.push_back(local);
     }
 
-    GuidPrefix_t guidP(PParam.prefix);
+    // Generate a new GuidPrefix_t
 
-    if (guidP == c_GuidPrefix_Unknown)
+    GuidPrefix_t guidP;
+
     {
         // Make a new participant GuidPrefix_t up
         int pid = System::GetPID();
@@ -152,6 +153,14 @@ RTPSParticipant* RTPSDomain::createParticipant(
         guidP.value[9] = octet(ID >> 8);
         guidP.value[10] = octet(ID >> 16);
         guidP.value[11] = octet(ID >> 24);
+    }
+
+    // If we force the participant to have a specific prefix we must define a different persistence GuidPrefix_t for 
+    // its endpoint. This instance-bounded persitence GuidPrefix_t will be kept in the participant instance local copy
+    // of the attributes (prefix member).
+    if(PParam.prefix != c_GuidPrefix_Unknown)
+    {
+        std::swap(guidP, PParam.prefix);
     }
     
     RTPSParticipant* p = new RTPSParticipant(nullptr);

--- a/src/cpp/rtps/builtin/data/ParticipantProxyData.cpp
+++ b/src/cpp/rtps/builtin/data/ParticipantProxyData.cpp
@@ -452,6 +452,68 @@ bool ParticipantProxyData::updateData(ParticipantProxyData& pdata)
     return true;
 }
 
+void ParticipantProxyData::set_persistence_guid(const GUID_t & guid)
+{
+    // only valid values
+    if(guid == c_Guid_Unknown)
+    {
+        return;
+    }
+
+    // generate pair
+    std::pair<std::string, std::string> persistent_guid;
+    persistent_guid.first = "PID_PERSISTENCE_GUID";
+
+    std::ostringstream data;
+    data << guid;
+    persistent_guid.second = data.str();
+
+    // if exists replace
+    std::vector<std::pair<std::string, std::string>> & props = m_properties.properties;
+
+    std::vector<std::pair<std::string, std::string>>::iterator it =
+        std::find_if(
+            props.begin(),
+            props.end(),
+            [&persistent_guid](const std::pair<std::string, std::string> & p) {
+        return persistent_guid.first == p.first;
+    });
+
+    if(it != props.end())
+    {
+        *it = std::move(persistent_guid);
+    }
+    else
+    {
+        // if not exists add
+        m_properties.properties.push_back(std::move(persistent_guid));
+    }
+}
+
+GUID_t ParticipantProxyData::get_persistence_guid() const
+{
+    GUID_t persistent(c_Guid_Unknown);
+
+    const std::vector<std::pair<std::string, std::string>> & props = m_properties.properties;
+
+    std::vector<std::pair<std::string, std::string>>::const_iterator it =
+        std::find_if(
+            props.cbegin(),
+            props.cend(),
+            [](const std::pair<std::string, std::string> & p) {
+        return "PID_PERSISTENCE_GUID" == p.first;
+    });
+
+    if(it != props.end())
+    {
+        std::istringstream in(it->second);
+        in >> persistent;
+    }
+
+    return persistent;
+}
+
+
 } /* namespace rtps */
 } /* namespace fastrtps */
 } /* namespace eprosima */

--- a/src/cpp/rtps/builtin/discovery/endpoint/EDPSimple.cpp
+++ b/src/cpp/rtps/builtin/discovery/endpoint/EDPSimple.cpp
@@ -664,7 +664,7 @@ void EDPSimple::assignRemoteEndpoints(const ParticipantProxyData& pdata)
 
     temp_writer_proxy_data_.clear();
     temp_writer_proxy_data_.guid().guidPrefix = pdata.m_guid.guidPrefix;
-    temp_writer_proxy_data_.persistence_guid().guidPrefix = pdata.m_guid.guidPrefix;
+    temp_writer_proxy_data_.persistence_guid(pdata.get_persistence_guid());
     temp_writer_proxy_data_.set_remote_locators(pdata.metatraffic_locators, network, true);
     temp_writer_proxy_data_.m_qos.m_durability.kind = TRANSIENT_LOCAL_DURABILITY_QOS;
     temp_writer_proxy_data_.m_qos.m_reliability.kind = RELIABLE_RELIABILITY_QOS;
@@ -675,7 +675,7 @@ void EDPSimple::assignRemoteEndpoints(const ParticipantProxyData& pdata)
     {
         logInfo(RTPS_EDP,"Adding SEDP Pub Writer to my Pub Reader");
         temp_writer_proxy_data_.guid().entityId = c_EntityId_SEDPPubWriter;
-        temp_writer_proxy_data_.persistence_guid().entityId = c_EntityId_SEDPPubWriter;
+        temp_writer_proxy_data_.persistence_guid().entityId = temp_writer_proxy_data_.persistence_guid().guidPrefix != c_GuidPrefix_Unknown ? c_EntityId_SEDPPubWriter : c_EntityId_Unknown;
         publications_reader_.first->matched_writer_add(temp_writer_proxy_data_);
     }
     auxendp = endp;
@@ -696,7 +696,7 @@ void EDPSimple::assignRemoteEndpoints(const ParticipantProxyData& pdata)
     {
         logInfo(RTPS_EDP,"Adding SEDP Sub Writer to my Sub Reader");
         temp_writer_proxy_data_.guid().entityId = c_EntityId_SEDPSubWriter;
-        temp_writer_proxy_data_.persistence_guid().entityId = c_EntityId_SEDPSubWriter;
+        temp_writer_proxy_data_.persistence_guid().entityId = temp_writer_proxy_data_.persistence_guid().guidPrefix != c_GuidPrefix_Unknown ? c_EntityId_SEDPSubWriter : c_EntityId_Unknown;
         subscriptions_reader_.first->matched_writer_add(temp_writer_proxy_data_);
     }
     auxendp = endp;
@@ -718,7 +718,8 @@ void EDPSimple::assignRemoteEndpoints(const ParticipantProxyData& pdata)
     if(auxendp != 0 && publications_secure_reader_.first != nullptr)
     {
         temp_writer_proxy_data_.guid().entityId = sedp_builtin_publications_secure_writer;
-        temp_writer_proxy_data_.persistence_guid().entityId = sedp_builtin_publications_secure_writer;
+        temp_writer_proxy_data_.persistence_guid().entityId = temp_writer_proxy_data_.persistence_guid().guidPrefix != c_GuidPrefix_Unknown ? sedp_builtin_publications_secure_writer : c_EntityId_Unknown;
+
         if(!mp_RTPSParticipant->security_manager().discovered_builtin_writer(
                     publications_secure_reader_.first->getGuid(), pdata.m_guid, temp_writer_proxy_data_,
                     publications_secure_reader_.first->getAttributes().security_attributes()))
@@ -751,7 +752,8 @@ void EDPSimple::assignRemoteEndpoints(const ParticipantProxyData& pdata)
     if(auxendp != 0 && subscriptions_secure_reader_.first != nullptr)
     {
         temp_writer_proxy_data_.guid().entityId = sedp_builtin_subscriptions_secure_writer;
-        temp_writer_proxy_data_.persistence_guid().entityId = sedp_builtin_subscriptions_secure_writer;
+        temp_writer_proxy_data_.persistence_guid().entityId = temp_writer_proxy_data_.persistence_guid().guidPrefix != c_GuidPrefix_Unknown ? sedp_builtin_subscriptions_secure_writer : c_EntityId_Unknown;
+
         if(!mp_RTPSParticipant->security_manager().discovered_builtin_writer(
                     subscriptions_secure_reader_.first->getGuid(), pdata.m_guid, temp_writer_proxy_data_,
                     subscriptions_secure_reader_.first->getAttributes().security_attributes()))

--- a/src/cpp/rtps/builtin/discovery/participant/PDP.cpp
+++ b/src/cpp/rtps/builtin/discovery/participant/PDP.cpp
@@ -243,7 +243,19 @@ void PDP::initializeParticipantProxyData(ParticipantProxyData* participant_data)
             participant_data->m_key.value[i] = participant_data->m_guid.entityId.value[i - 12];
     }
 
+    // Keep persistence Guid_Prefix_t in a specific property. This info must be propagated to all builtin endpoints
+    {
+        GuidPrefix_t persistent = mp_RTPSParticipant->getAttributes().prefix;
 
+        if(persistent != c_GuidPrefix_Unknown)
+        {
+            participant_data->set_persistence_guid(
+                GUID_t(
+                    persistent,
+                    c_EntityId_RTPSParticipant));
+        }
+    }
+ 
     participant_data->metatraffic_locators.multicast.clear();
     for(const Locator_t& loc: this->mp_builtin->m_metatrafficMulticastLocatorList)
     { 

--- a/src/cpp/rtps/builtin/discovery/participant/PDPClient.cpp
+++ b/src/cpp/rtps/builtin/discovery/participant/PDPClient.cpp
@@ -383,15 +383,16 @@ void PDPClient::removeRemoteEndpoints(ParticipantProxyData* pdata)
             mp_PDPReader->matched_writer_remove(wguid);
 
             // rematch but discarding any previous state of the server
-            // because we know the server shutdown intencionally (sent a DATA(p[UD]))
+            // because we know the server shutdown intencionally
             std::lock_guard<std::mutex> data_guard(temp_data_lock_);
             temp_writer_data_.clear();
             temp_writer_data_.guid(wguid);
-            temp_writer_data_.persistence_guid(temp_writer_data_.guid());
+            temp_writer_data_.persistence_guid(pdata->get_persistence_guid());
+            temp_writer_data_.persistence_guid().entityId = temp_writer_data_.persistence_guid().guidPrefix != c_GuidPrefix_Unknown ? c_EntityId_SPDPWriter : c_EntityId_Unknown;
             temp_writer_data_.set_remote_locators(pdata->metatraffic_locators, network, true);
             temp_writer_data_.m_qos.m_reliability.kind = RELIABLE_RELIABILITY_QOS;
             temp_writer_data_.m_qos.m_durability.kind = TRANSIENT_DURABILITY_QOS;
-            mp_PDPReader->matched_writer_add(temp_writer_data_, false);
+            mp_PDPReader->matched_writer_add(temp_writer_data_);
         }
 
         auxendp = endp;

--- a/src/cpp/rtps/builtin/discovery/participant/PDPServer.cpp
+++ b/src/cpp/rtps/builtin/discovery/participant/PDPServer.cpp
@@ -302,6 +302,7 @@ void PDPServer::assignRemoteEndpoints(ParticipantProxyData* pdata)
 
     // boilerplate, note that PDPSimple version doesn't use RELIABLE entities
     logInfo(RTPS_PDP, "For RTPSParticipant: " << pdata->m_guid.guidPrefix);
+
     uint32_t endp = pdata->m_availableBuiltinEndpoints;
     uint32_t auxendp = endp;
     auxendp &= DISC_BUILTIN_ENDPOINT_PARTICIPANT_ANNOUNCER;
@@ -311,7 +312,8 @@ void PDPServer::assignRemoteEndpoints(ParticipantProxyData* pdata)
         temp_writer_data_.clear();
         temp_writer_data_.guid().guidPrefix = pdata->m_guid.guidPrefix;
         temp_writer_data_.guid().entityId = c_EntityId_SPDPWriter;
-        temp_writer_data_.persistence_guid(temp_writer_data_.guid());
+        temp_writer_data_.persistence_guid(pdata->get_persistence_guid());
+        temp_writer_data_.persistence_guid().entityId = temp_writer_data_.persistence_guid().guidPrefix != c_GuidPrefix_Unknown ? c_EntityId_SPDPWriter : c_EntityId_Unknown;
         temp_writer_data_.set_remote_locators(pdata->metatraffic_locators, network, true);
         temp_writer_data_.m_qos.m_reliability.kind = RELIABLE_RELIABILITY_QOS;
         temp_writer_data_.m_qos.m_durability.kind = TRANSIENT_LOCAL_DURABILITY_QOS;
@@ -407,7 +409,7 @@ void PDPServer::removeRemoteEndpoints(ParticipantProxyData* pdata)
             temp_writer_data_.set_remote_locators(pdata->metatraffic_locators, network, true);
             temp_writer_data_.m_qos.m_reliability.kind = RELIABLE_RELIABILITY_QOS;
             temp_writer_data_.m_qos.m_durability.kind = TRANSIENT_LOCAL_DURABILITY_QOS;
-            mp_PDPReader->matched_writer_add(temp_writer_data_, false);
+            mp_PDPReader->matched_writer_add(temp_writer_data_);
         }
 
     }

--- a/src/cpp/rtps/builtin/discovery/participant/PDPSimple.cpp
+++ b/src/cpp/rtps/builtin/discovery/participant/PDPSimple.cpp
@@ -327,7 +327,8 @@ void PDPSimple::assignRemoteEndpoints(ParticipantProxyData* pdata)
         temp_writer_data_.clear();
         temp_writer_data_.guid().guidPrefix = pdata->m_guid.guidPrefix;
         temp_writer_data_.guid().entityId = c_EntityId_SPDPWriter;
-        temp_writer_data_.persistence_guid(temp_writer_data_.guid());
+        temp_writer_data_.persistence_guid(pdata->get_persistence_guid());
+        temp_writer_data_.persistence_guid().entityId = temp_writer_data_.persistence_guid().guidPrefix != c_GuidPrefix_Unknown ? c_EntityId_SPDPWriter : c_EntityId_Unknown;
         temp_writer_data_.set_remote_locators(pdata->metatraffic_locators, network, true);
         temp_writer_data_.m_qos.m_reliability.kind = BEST_EFFORT_RELIABILITY_QOS;
         temp_writer_data_.m_qos.m_durability.kind = TRANSIENT_LOCAL_DURABILITY_QOS;

--- a/src/cpp/rtps/builtin/liveliness/WLP.cpp
+++ b/src/cpp/rtps/builtin/liveliness/WLP.cpp
@@ -391,7 +391,7 @@ bool WLP::assignRemoteEndpoints(const ParticipantProxyData& pdata)
     std::lock_guard<std::mutex> data_guard(temp_data_lock_);
 
     temp_writer_proxy_data_.guid().guidPrefix = pdata.m_guid.guidPrefix;
-    temp_writer_proxy_data_.persistence_guid().guidPrefix = pdata.m_guid.guidPrefix;
+    temp_writer_proxy_data_.persistence_guid(pdata.get_persistence_guid());
     temp_writer_proxy_data_.set_remote_locators(pdata.metatraffic_locators, network, true);
     temp_writer_proxy_data_.topicKind(WITH_KEY);
     temp_writer_proxy_data_.m_qos.m_durability.kind = TRANSIENT_LOCAL_DURABILITY_QOS;
@@ -412,7 +412,7 @@ bool WLP::assignRemoteEndpoints(const ParticipantProxyData& pdata)
     {
         logInfo(RTPS_LIVELINESS,"Adding remote writer to my local Builtin Reader");
         temp_writer_proxy_data_.guid().entityId = c_EntityId_WriterLiveliness;
-        temp_writer_proxy_data_.persistence_guid().entityId = c_EntityId_WriterLiveliness;
+        temp_writer_proxy_data_.persistence_guid().entityId = temp_writer_proxy_data_.persistence_guid().guidPrefix != c_GuidPrefix_Unknown ? c_EntityId_WriterLiveliness : c_EntityId_Unknown;
         mp_builtinReader->matched_writer_add(temp_writer_proxy_data_);
     }
     auxendp = endp;
@@ -431,7 +431,8 @@ bool WLP::assignRemoteEndpoints(const ParticipantProxyData& pdata)
     {
         logInfo(RTPS_LIVELINESS, "Adding remote writer to my local Builtin Secure Reader");
         temp_writer_proxy_data_.guid().entityId = c_EntityId_WriterLivelinessSecure;
-        temp_writer_proxy_data_.persistence_guid().entityId = c_EntityId_WriterLivelinessSecure;
+        temp_writer_proxy_data_.persistence_guid().entityId = temp_writer_proxy_data_.persistence_guid().guidPrefix != c_GuidPrefix_Unknown ? c_EntityId_WriterLivelinessSecure : c_EntityId_Unknown;
+
         if (!mp_participant->security_manager().discovered_builtin_writer(
             mp_builtinReaderSecure->getGuid(), pdata.m_guid, temp_writer_proxy_data_,
             mp_builtinReaderSecure->getAttributes().security_attributes()))

--- a/src/cpp/rtps/participant/RTPSParticipantImpl.cpp
+++ b/src/cpp/rtps/participant/RTPSParticipantImpl.cpp
@@ -374,6 +374,14 @@ bool RTPSParticipantImpl::createWriter(
         return false;
     }
 
+    // Update persistence guidPrefix
+    if(param.endpoint.persistence_guid == c_Guid_Unknown)
+    {
+        param.endpoint.persistence_guid = GUID_t(
+                                                m_att.prefix,
+                                                c_EntityId_RTPSParticipant);
+    }
+
     // Get persistence service
     IPersistenceService* persistence = nullptr;
     if (param.endpoint.durabilityKind >= TRANSIENT)

--- a/src/cpp/rtps/reader/StatefulReader.cpp
+++ b/src/cpp/rtps/reader/StatefulReader.cpp
@@ -96,8 +96,7 @@ StatefulReader::StatefulReader(
 }
 
 bool StatefulReader::matched_writer_add(
-        const WriterProxyData& wdata,
-        bool persist /*=true*/)
+        const WriterProxyData& wdata)
 {
     assert(wdata.guid() != c_Guid_Unknown);
 
@@ -151,11 +150,8 @@ bool StatefulReader::matched_writer_add(
     }
 
     SequenceNumber_t initial_sequence;
-    if (persist)
-    {
-        add_persistence_guid(wdata.guid(), wdata.persistence_guid());
-        initial_sequence = get_last_notified(wdata.guid());
-    }
+    add_persistence_guid(wdata.guid(), wdata.persistence_guid());
+    initial_sequence = get_last_notified(wdata.guid());
     
     wp->start(wdata, initial_sequence);
 

--- a/src/cpp/rtps/reader/StatelessReader.cpp
+++ b/src/cpp/rtps/reader/StatelessReader.cpp
@@ -55,8 +55,7 @@ StatelessReader::StatelessReader(
 }
 
 bool StatelessReader::matched_writer_add(
-        const WriterProxyData& wdata,
-        bool persist /*=true*/ )
+        const WriterProxyData& wdata)
 {
     std::lock_guard<RecursiveTimedMutex> guard(mp_mutex);
     for (const RemoteWriterInfo_t& writer : matched_writers_)
@@ -75,10 +74,8 @@ bool StatelessReader::matched_writer_add(
     RemoteWriterInfo_t* att = matched_writers_.emplace_back(info);
     if (att != nullptr)
     {
-        if(persist)
-        {
-            add_persistence_guid(info.guid, info.persistence_guid);
-        }
+        add_persistence_guid(info.guid, info.persistence_guid);
+
         m_acceptMessagesFromUnkownWriters = false;
         logInfo(RTPS_READER, "Writer " << info.guid << " added to " << m_guid.entityId);
 


### PR DESCRIPTION
Translate the persistentence RTPS mechanism to Discovery server framework. This mechanism allows differentiate between a communication loss and a participant shut down.
Implementation steps:
1. Remove the former mechanism to avoid persistence update in WriterProxy creation ( RTPSReader::match_writer_add).
2. make sure that in RTPSParticipant creation a persistent guid is created if necessary and keep in guidPrefix attributes local copy. RTPSDomain::createParticipant. We modify PDP::initializeParticipantProxyData to keep in the local ParticipantProxyData the persistence_guid as a property.
3. make sure tha the DATA keep a copy of the persistent guid:
+ ParticipantProxyData for each RTPSParticipantImpl is initialize on PDP::initializeParticipantProxyData. We must add PID_PERSISTENCE_GUID to the ParameterPropertyList_t. A hint in how to do this is provided in EDPStatic, one must just push_back a property a std::pair<std::string,std::string>. This will be automatically serialized and deserialized. New methods get_persistence_guid and set_persistence_guid have been added to ParticipantProxyData.
+ WriterProxyData keeps an specific member and takes care of serialize and deserialize at will. Note how StatefulReader::matched_writer_add and StatelessReader::matched_writer_add profits from it. When we create the writer we must udpate this value RTPSParticipantImpl::createWriter must be given a WriterAttributes with this value set.
4. make sure that on DATA reception the corresponding ParticipantProxy and WriterProxy properly deserialize and store the persistent GUID.
5. make sure of specifying the persistence_id when WriterProxies linked with builtin endpoints are created. Note that it must be retrieved from the remote ParticipantProxyData. Review XXX::assignRemoteEndpoints methods:
- PDPServer::assignRemoteEndpoints
- PDPSimple::assignRemoteEndpoints
- EDPSimple::assignRemoteEndpoints
- WLP::assignRemoteEndpoints
- PDPClient::removeRemoteEndpoints
Validate that whenever PDPClient recevies a server DATA the persistent guid of the linked proxy is updated. When a DATA from a known participant is received ParticipantProxyData::updateData(.) is called and the properties copied.
6. make sure each time a Writer is created by a participant it's persistent_guid is kept within and duly reported on announcement. persistent_guid is stored in the Endpoint superclass. EDP::newLocalWriterProxyData takes care of update WriterProxyData::persistence_guid.