### PR TITLE
Added copy constructor to ResourceLimitedVector. [6247]

### DIFF
--- a/include/fastrtps/utils/collections/ResourceLimitedVector.hpp
+++ b/include/fastrtps/utils/collections/ResourceLimitedVector.hpp
@@ -95,7 +95,8 @@ public:
         collection_.reserve(cfg.initial);
     }
 
-    ResourceLimitedVector(const ResourceLimitedVector& other)
+    ResourceLimitedVector(
+            const ResourceLimitedVector& other)
         : configuration_(other.configuration_)
         , collection_(other.collection_.get_allocator())
     {

--- a/include/fastrtps/utils/collections/ResourceLimitedVector.hpp
+++ b/include/fastrtps/utils/collections/ResourceLimitedVector.hpp
@@ -95,6 +95,13 @@ public:
         collection_.reserve(cfg.initial);
     }
 
+    ResourceLimitedVector(const ResourceLimitedVector& other)
+        : configuration_(other.configuration_)
+        , collection_(other.collection_.capacity(), other.collection_.get_allocator())
+    {
+        collection_.assign(other.collection_.begin(), other.collection_.end());
+    }
+
     ResourceLimitedVector& operator = (const ResourceLimitedVector& other)
     {
         clear();

--- a/include/fastrtps/utils/collections/ResourceLimitedVector.hpp
+++ b/include/fastrtps/utils/collections/ResourceLimitedVector.hpp
@@ -97,8 +97,9 @@ public:
 
     ResourceLimitedVector(const ResourceLimitedVector& other)
         : configuration_(other.configuration_)
-        , collection_(other.collection_.capacity(), other.collection_.get_allocator())
+        , collection_(other.collection_.get_allocator())
     {
+        collection_.reserve(other.collection_.capacity());
         collection_.assign(other.collection_.begin(), other.collection_.end());
     }
 


### PR DESCRIPTION
This PR fixed an assertion failure. The application fails with next log:

```
[INFO] [showimage]: Subscribing to topic 'image'
showimage: /home/ricardo/workspace/eprosima/ros2/eloquent/src/eProsima/Fast-RTPS/include/fastrtps/rtps/writer/../common/../../utils/collections/ResourceLimitedVector.hpp:341: bool eprosima::fastrtps::ResourceLimitedVector<_Ty, _KeepOrderEnabler, _LimitsConfig, _Alloc, _Collection>::ensure_capacity() [with _Ty = eprosima::fastrtps::rtps::Locator_t; _KeepOrderEnabler = std::integral_constant<bool, false>; _LimitsConfig = eprosima::fastrtps::ResourceLimitedContainerConfig; _Alloc = std::allocator<eprosima::fastrtps::rtps::Locator_t>; _Collection = std::vector<eprosima::fastrtps::rtps::Locator_t>]: La declaración `configuration_.increment > 0' no se cumple.
```