### PR TITLE
Deprecate RTPSMessageGroup_t in favor of using the CDRMessagePool ins…

### DIFF
--- a/include/fastrtps/rtps/messages/RTPSMessageCreator.h
+++ b/include/fastrtps/rtps/messages/RTPSMessageCreator.h
@@ -18,11 +18,12 @@
 #ifndef CDRMESSAGECREATOR_H_
 #define CDRMESSAGECREATOR_H_
 #ifndef DOXYGEN_SHOULD_SKIP_THIS_PUBLIC
-#include "../common/CDRMessage_t.h"
-#include "../common/Guid.h"
-#include "../common/SequenceNumber.h"
-#include "../common/FragmentNumber.h"
-#include "../common/CacheChange.h"
+#include <fastrtps/rtps/common/CDRMessage_t.h>
+#include <fastrtps/rtps/common/Guid.h>
+#include <fastrtps/rtps/common/SequenceNumber.h>
+#include <fastrtps/rtps/common/FragmentNumber.h>
+#include <fastrtps/rtps/common/CacheChange.h>
+#include <fastrtps/rtps/messages/CDRMessagePool.h>
 
 namespace eprosima {
 namespace fastrtps{
@@ -47,7 +48,11 @@ class RTPSMessageCreator
         //!
         CDRMessage_t rtpsmc_submsgHeader;
 
-
+        /**
+         * Retrieve a reference to the global CDRMessagePool used by the message creator class
+         * @return An instance of the CDRMessagePool class
+         */
+        static CDRMessagePool& getCDRMessagePool();
 
         /**
          * Create a Header to the serialized message.

--- a/include/fastrtps/rtps/messages/RTPSMessageGroup.h
+++ b/include/fastrtps/rtps/messages/RTPSMessageGroup.h
@@ -35,33 +35,6 @@ namespace rtps {
 class RTPSParticipantImpl;
 class Endpoint;
 
-/**
- * Class RTPSMessageGroup_t that contains the messages used to send multiples changes as one message.
- * @ingroup WRITER_MODULE
- */
-class RTPSMessageGroup_t
-{
-    public:
-
-        RTPSMessageGroup_t(uint32_t payload, GuidPrefix_t participant_guid):
-            rtpsmsg_submessage_(payload),
-            rtpsmsg_fullmsg_(payload)
-#if HAVE_SECURITY
-            , rtpsmsg_encrypt_(payload)
-#endif
-        {
-            CDRMessage::initCDRMsg(&rtpsmsg_fullmsg_);
-            RTPSMessageCreator::addHeader(&rtpsmsg_fullmsg_, participant_guid);
-        }
-
-        CDRMessage_t rtpsmsg_submessage_;
-
-        CDRMessage_t rtpsmsg_fullmsg_;
-
-#if HAVE_SECURITY
-        CDRMessage_t rtpsmsg_encrypt_;
-#endif
-};
 
 class RTPSWriter;
 
@@ -85,10 +58,8 @@ class RTPSMessageGroup
          * @param participant Pointer to the participant sending data.
          * @param endpoint Pointer to the endpoint sending data.
          * @param type Type of endpoint (reader / writer).
-         * @param msg_group Reference to data buffer for messages.
          */
-        RTPSMessageGroup(RTPSParticipantImpl* participant, Endpoint* endpoint, ENDPOINT_TYPE type,
-            RTPSMessageGroup_t& msg_group);
+        RTPSMessageGroup(RTPSParticipantImpl* participant, Endpoint* endpoint, ENDPOINT_TYPE type);
 
         /**
          * Fixed destination constructor.
@@ -96,12 +67,11 @@ class RTPSMessageGroup
          * @param participant Pointer to the participant sending data.
          * @param endpoint Pointer to the endpoint sending data.
          * @param type Type of endpoint (reader / writer).
-         * @param msg_group Reference to data buffer for messages.
          * @param locator_list List of locators where messages will be sent
          * @param remote_endpoints List of destination GUIDs
          */
         RTPSMessageGroup(RTPSParticipantImpl* participant, Endpoint* endpoint, ENDPOINT_TYPE type,
-            RTPSMessageGroup_t& msg_group, const LocatorList_t& locator_list,
+            const LocatorList_t& locator_list,
             const std::vector<GUID_t>& remote_endpoints);
 
         ~RTPSMessageGroup();

--- a/include/fastrtps/rtps/reader/timedevent/HeartbeatResponseDelay.h
+++ b/include/fastrtps/rtps/reader/timedevent/HeartbeatResponseDelay.h
@@ -60,8 +60,6 @@ class HeartbeatResponseDelay:public TimedEvent
 
             //!Pointer to the WriterProxy associated with this specific event.
             WriterProxy* mp_WP;
-            //!CDRMessage_t used in the response.
-            RTPSMessageGroup_t m_cdrmessages;
             //!List of destination locators
             LocatorList_t m_destination_locators;
             //!List of destination endpoints

--- a/include/fastrtps/rtps/reader/timedevent/InitialAckNack.h
+++ b/include/fastrtps/rtps/reader/timedevent/InitialAckNack.h
@@ -63,9 +63,6 @@ class InitialAckNack: public TimedEvent
                 EventCode code,
                 const char* msg= nullptr);
 
-        //!
-        RTPSMessageGroup_t m_cdrmessages;
-        //!
         WriterProxy* wp_;
         //!List of destination locators
         LocatorList_t m_destination_locators;

--- a/include/fastrtps/rtps/writer/RTPSWriter.h
+++ b/include/fastrtps/rtps/writer/RTPSWriter.h
@@ -188,8 +188,6 @@ class RTPSWriter : public Endpoint
 
     //!Is the data sent directly or announced by HB and THEN send to the ones who ask for it?.
     bool m_pushMode;
-    //!Group created to send messages more efficiently
-    RTPSMessageGroup_t m_cdrmessages;
     //!INdicates if the liveliness has been asserted
     bool m_livelinessAsserted;
     //!WriterHistory

--- a/include/fastrtps/rtps/writer/timedevent/PeriodicHeartbeat.h
+++ b/include/fastrtps/rtps/writer/timedevent/PeriodicHeartbeat.h
@@ -59,9 +59,6 @@ class PeriodicHeartbeat: public TimedEvent
                 EventCode code,
                 const char* msg= nullptr);
 
-        //!
-        RTPSMessageGroup_t m_cdrmessages;
-        //!
         StatefulWriter* mp_SFW;
 };
 

--- a/src/cpp/rtps/messages/RTPSMessageCreator.cpp
+++ b/src/cpp/rtps/messages/RTPSMessageCreator.cpp
@@ -21,7 +21,6 @@
 #include <fastrtps/rtps/messages/CDRMessage.h>
 #include <fastrtps/qos/ParameterList.h>
 #include <fastrtps/utils/eClock.h>
-#include <fastrtps/rtps/messages/CDRMessagePool.h>
 
 #include <fastrtps/log/Log.h>
 
@@ -32,9 +31,12 @@ namespace fastrtps{
 namespace rtps{
 
 // Auxiliary message to avoid creation of new messages each time.
-CDRMessagePool g_pool_submsg(100);
-eClock g_clock;
+static CDRMessagePool g_pool_submsg(100);
+static eClock g_clock;
 
+CDRMessagePool& RTPSMessageCreator::getCDRMessagePool() {
+  return g_pool_submsg;
+}
 
 RTPSMessageCreator::RTPSMessageCreator() {
 
@@ -74,7 +76,7 @@ bool RTPSMessageCreator::addCustomContent(CDRMessage_t*msg, const octet* content
 {
     CDRMessage::addData(msg, content, static_cast<uint32_t>(contentSize));
     msg->length = msg->pos;
-	
+
     return true;
 }
 
@@ -117,7 +119,7 @@ bool RTPSMessageCreator::addSubmessageInfoTS(CDRMessage_t* msg,Time_t& time,bool
     return true;
 }
 
-bool RTPSMessageCreator::addSubmessageInfoSRC(CDRMessage_t* msg, const ProtocolVersion_t& version, 
+bool RTPSMessageCreator::addSubmessageInfoSRC(CDRMessage_t* msg, const ProtocolVersion_t& version,
     const VendorId_t& vendorId, const GuidPrefix_t& guidPrefix)
 {
     octet flags = 0x0;

--- a/src/cpp/rtps/reader/timedevent/HeartbeatResponseDelay.cpp
+++ b/src/cpp/rtps/reader/timedevent/HeartbeatResponseDelay.cpp
@@ -46,8 +46,6 @@ HeartbeatResponseDelay::HeartbeatResponseDelay(
     : TimedEvent(p_WP->mp_SFR->getRTPSParticipant()->getEventResource().getIOService(),
             p_WP->mp_SFR->getRTPSParticipant()->getEventResource().getThread(), interval)
     , mp_WP(p_WP)
-    , m_cdrmessages(p_WP->mp_SFR->getRTPSParticipant()->getMaxMessageSize(),
-            p_WP->mp_SFR->getRTPSParticipant()->getGuid().guidPrefix)
     , m_destination_locators(mp_WP->mp_SFR->getRTPSParticipant()->network_factory().
             ShrinkLocatorLists({p_WP->m_att.endpoint.unicastLocatorList}))
     , m_remote_endpoints(1, p_WP->m_att.guid)
@@ -78,7 +76,7 @@ void HeartbeatResponseDelay::event(
         std::vector<CacheChange_t*> uncompleted_changes;
 
         RTPSMessageGroup group(mp_WP->mp_SFR->getRTPSParticipant(), mp_WP->mp_SFR, RTPSMessageGroup::READER,
-                m_cdrmessages, m_destination_locators, m_remote_endpoints);
+                               m_destination_locators, m_remote_endpoints);
 
         if(!missing_changes.empty() || !mp_WP->m_heartbeatFinalFlag)
         {

--- a/src/cpp/rtps/reader/timedevent/InitialAckNack.cpp
+++ b/src/cpp/rtps/reader/timedevent/InitialAckNack.cpp
@@ -48,8 +48,6 @@ InitialAckNack::InitialAckNack(
         double interval)
     : TimedEvent(wp->mp_SFR->getRTPSParticipant()->getEventResource().getIOService(),
             wp->mp_SFR->getRTPSParticipant()->getEventResource().getThread(), interval)
-    , m_cdrmessages(wp->mp_SFR->getRTPSParticipant()->getMaxMessageSize(),
-            wp->mp_SFR->getRTPSParticipant()->getGuid().guidPrefix)
     , wp_(wp)
     , m_destination_locators(wp->mp_SFR->getRTPSParticipant()->network_factory().
             ShrinkLocatorLists({wp->m_att.endpoint.unicastLocatorList}))
@@ -85,7 +83,7 @@ void InitialAckNack::event(
 
         logInfo(RTPS_READER,"Sending ACKNACK: "<< sns);
 
-        RTPSMessageGroup group(wp_->mp_SFR->getRTPSParticipant(), wp_->mp_SFR, RTPSMessageGroup::READER, m_cdrmessages,
+        RTPSMessageGroup group(wp_->mp_SFR->getRTPSParticipant(), wp_->mp_SFR, RTPSMessageGroup::READER,
             m_destination_locators, m_remote_endpoints);
 
         group.add_acknack(m_remote_endpoints, sns, acknackCount, false, m_destination_locators);

--- a/src/cpp/rtps/writer/RTPSWriter.cpp
+++ b/src/cpp/rtps/writer/RTPSWriter.cpp
@@ -30,15 +30,8 @@ using namespace eprosima::fastrtps::rtps;
 
 
 RTPSWriter::RTPSWriter(RTPSParticipantImpl* impl, GUID_t& guid, WriterAttributes& att, WriterHistory* hist, WriterListener* listen):
-    Endpoint(impl,guid,att.endpoint),
+    Endpoint(impl, guid, att.endpoint),
     m_pushMode(true),
-    m_cdrmessages(impl->getMaxMessageSize() > att.throughputController.bytesPerPeriod ?
-            att.throughputController.bytesPerPeriod > impl->getRTPSParticipantAttributes().throughputController.bytesPerPeriod ?
-            impl->getRTPSParticipantAttributes().throughputController.bytesPerPeriod :
-            att.throughputController.bytesPerPeriod :
-            impl->getMaxMessageSize() > impl->getRTPSParticipantAttributes().throughputController.bytesPerPeriod ?
-            impl->getRTPSParticipantAttributes().throughputController.bytesPerPeriod :
-            impl->getMaxMessageSize(), impl->getGuid().guidPrefix),
     m_livelinessAsserted(false),
     mp_history(hist),
     mp_listener(listen),

--- a/src/cpp/rtps/writer/StatefulWriter.cpp
+++ b/src/cpp/rtps/writer/StatefulWriter.cpp
@@ -163,7 +163,7 @@ void StatefulWriter::unsent_change_added_to_history(CacheChange_t* change)
                     LocatorList_t remote_locators_shrinked{mp_RTPSParticipant->network_factory().ShrinkLocatorLists(
                             {(*it)->m_att.endpoint.remoteLocatorList})};
 
-                    RTPSMessageGroup group(mp_RTPSParticipant, this, RTPSMessageGroup::WRITER, m_cdrmessages,
+                    RTPSMessageGroup group(mp_RTPSParticipant, this, RTPSMessageGroup::WRITER,
                         remote_locators_shrinked, guids);
                     if (!group.add_data(*change, guids, remote_locators_shrinked, (*it)->m_att.expectsInlineQos))
                     {
@@ -175,7 +175,7 @@ void StatefulWriter::unsent_change_added_to_history(CacheChange_t* change)
 
             if (!m_separateSendingEnabled)
             {
-                RTPSMessageGroup group(mp_RTPSParticipant, this, RTPSMessageGroup::WRITER, m_cdrmessages);
+                RTPSMessageGroup group(mp_RTPSParticipant, this, RTPSMessageGroup::WRITER);
                 if (!group.add_data(*change, mAllRemoteReaders, mAllShrinkedLocatorList, expectsInlineQos))
                 {
                     logError(RTPS_WRITER, "Error sending change " << change->sequenceNumber);
@@ -265,7 +265,7 @@ void StatefulWriter::send_any_unsent_changes()
             guids.at(0) = remoteReader->m_att.guid;
             const LocatorList_t remote_locators_shrinked{mp_RTPSParticipant->network_factory().ShrinkLocatorLists(
                     {remoteReader->m_att.endpoint.remoteLocatorList})};
-            RTPSMessageGroup group(mp_RTPSParticipant, this, RTPSMessageGroup::WRITER, m_cdrmessages,
+            RTPSMessageGroup group(mp_RTPSParticipant, this, RTPSMessageGroup::WRITER,
                    remote_locators_shrinked, guids);
 
             // Loop all changes
@@ -356,7 +356,7 @@ void StatefulWriter::send_any_unsent_changes()
             for (auto& controller : mp_RTPSParticipant->getFlowControllers())
                 (*controller)(relevantChanges);
 
-            RTPSMessageGroup group(mp_RTPSParticipant, this, RTPSMessageGroup::WRITER, m_cdrmessages);
+            RTPSMessageGroup group(mp_RTPSParticipant, this, RTPSMessageGroup::WRITER);
             uint32_t lastBytesProcessed = 0;
 
             while (!relevantChanges.empty())
@@ -477,7 +477,7 @@ void StatefulWriter::send_any_unsent_changes()
         }
         else
         {
-            RTPSMessageGroup group(mp_RTPSParticipant, this, RTPSMessageGroup::WRITER, m_cdrmessages);
+            RTPSMessageGroup group(mp_RTPSParticipant, this, RTPSMessageGroup::WRITER);
             send_heartbeat_nts_(mAllRemoteReaders, mAllShrinkedLocatorList, group, true);
         }
     }
@@ -584,7 +584,7 @@ bool StatefulWriter::matched_reader_add(RemoteReaderAttributes& rdata)
         std::vector<GUID_t> guids(1, rp->m_att.guid);
         const LocatorList_t remote_locators_shrinked{mp_RTPSParticipant->network_factory().ShrinkLocatorLists(
                 {rp->m_att.endpoint.remoteLocatorList})};
-        RTPSMessageGroup group(mp_RTPSParticipant, this, RTPSMessageGroup::WRITER, m_cdrmessages,
+        RTPSMessageGroup group(mp_RTPSParticipant, this, RTPSMessageGroup::WRITER,
                 remote_locators_shrinked, guids);
 
         // Send initial heartbeat
@@ -901,7 +901,7 @@ void StatefulWriter::send_heartbeat_to_nts(ReaderProxy& remoteReaderProxy, bool 
     std::vector<GUID_t> tmp_guids(1, remoteReaderProxy.m_att.guid);
     const LocatorList_t remote_locators_shrinked{mp_RTPSParticipant->network_factory().ShrinkLocatorLists(
             {remoteReaderProxy.m_att.endpoint.remoteLocatorList})};
-    RTPSMessageGroup group(mp_RTPSParticipant, this, RTPSMessageGroup::WRITER, m_cdrmessages,
+    RTPSMessageGroup group(mp_RTPSParticipant, this, RTPSMessageGroup::WRITER,
         remote_locators_shrinked, tmp_guids);
 
     send_heartbeat_nts_(tmp_guids, remote_locators_shrinked, group, final);
@@ -943,7 +943,7 @@ void StatefulWriter::send_heartbeat_nts_(const std::vector<GUID_t>& remote_reade
     logInfo(RTPS_WRITER, getGuid().entityId << " Sending Heartbeat (" << firstSeq << " - " << lastSeq <<")" );
 }
 
-void StatefulWriter::send_heartbeat_piggyback_nts_(const std::vector<GUID_t>& remote_readers, 
+void StatefulWriter::send_heartbeat_piggyback_nts_(const std::vector<GUID_t>& remote_readers,
     const LocatorList_t &locators,
     RTPSMessageGroup& message_group)
 {

--- a/src/cpp/rtps/writer/StatelessWriter.cpp
+++ b/src/cpp/rtps/writer/StatelessWriter.cpp
@@ -87,7 +87,7 @@ void StatelessWriter::unsent_change_added_to_history(CacheChange_t* cptr)
                 for (auto it = m_matched_readers.begin(); it != m_matched_readers.end(); ++it)
                 {
                     guids.at(0) = it->guid;
-                    RTPSMessageGroup group(mp_RTPSParticipant, this, RTPSMessageGroup::WRITER, m_cdrmessages,
+                    RTPSMessageGroup group(mp_RTPSParticipant, this, RTPSMessageGroup::WRITER,
                         it->endpoint.unicastLocatorList, guids);
 
                     if (!group.add_data(*cptr, guids, it->endpoint.unicastLocatorList, false))
@@ -98,7 +98,7 @@ void StatelessWriter::unsent_change_added_to_history(CacheChange_t* cptr)
             }
             else
             {
-                RTPSMessageGroup group(mp_RTPSParticipant, this, RTPSMessageGroup::WRITER, m_cdrmessages,
+                RTPSMessageGroup group(mp_RTPSParticipant, this, RTPSMessageGroup::WRITER,
                     mAllShrinkedLocatorList, mAllRemoteReaders);
 
                 if (!group.add_data(*cptr, mAllRemoteReaders, mAllShrinkedLocatorList, false))
@@ -221,7 +221,7 @@ void StatelessWriter::send_any_unsent_changes()
     for (auto& controller : mp_RTPSParticipant->getFlowControllers())
         (*controller)(changesToSend);
 
-    RTPSMessageGroup group(mp_RTPSParticipant, this,  RTPSMessageGroup::WRITER, m_cdrmessages,
+    RTPSMessageGroup group(mp_RTPSParticipant, this,  RTPSMessageGroup::WRITER,
         mAllShrinkedLocatorList, mAllRemoteReaders);
 
     bool bHasListener = mp_listener != nullptr;

--- a/src/cpp/rtps/writer/timedevent/PeriodicHeartbeat.cpp
+++ b/src/cpp/rtps/writer/timedevent/PeriodicHeartbeat.cpp
@@ -47,8 +47,6 @@ PeriodicHeartbeat::PeriodicHeartbeat(
         double interval)
     : TimedEvent(p_SFW->getRTPSParticipant()->getEventResource().getIOService(),
             p_SFW->getRTPSParticipant()->getEventResource().getThread(), interval)
-    , m_cdrmessages(p_SFW->getRTPSParticipant()->getMaxMessageSize(),
-            p_SFW->getRTPSParticipant()->getGuid().guidPrefix)
     , mp_SFW(p_SFW)
 {
 
@@ -127,7 +125,7 @@ void PeriodicHeartbeat::event(
 
             if (unacked_changes)
             {
-                RTPSMessageGroup group(mp_SFW->getRTPSParticipant(), mp_SFW, RTPSMessageGroup::WRITER, m_cdrmessages);
+                RTPSMessageGroup group(mp_SFW->getRTPSParticipant(), mp_SFW, RTPSMessageGroup::WRITER);
 
                 // FinalFlag is always false because this class is used only by StatefulWriter in Reliable.
                 group.add_heartbeat(remote_readers, firstSeq, lastSeq, heartbeatCount, false, false,

--- a/src/cpp/transport/UDPTransportInterface.cpp
+++ b/src/cpp/transport/UDPTransportInterface.cpp
@@ -424,7 +424,7 @@ bool UDPTransportInterface::Receive(UDPChannelResource* pChannelResource, octet*
     catch (const std::exception& error)
     {
         (void)error;
-        logWarning(RTPS_MSG_OUT, "Error receiving data: " << error.what());
+        logError(RTPS_MSG_OUT, "Error receiving data: " << error.what());
         return false;
     }
 }
@@ -457,7 +457,7 @@ bool UDPTransportInterface::ReleaseInputChannel(const Locator_t& locator, const 
 
             // We ignore the error message because some OS don't allow this functionality like Windows (WSAENETUNREACH) or Mac (EADDRNOTAVAIL)
             socket.send_to(asio::buffer("EPRORTPSCLOSE", 13), destinationEndpoint,flags, ec);
-            
+
             socket.close();
         }
         else
@@ -533,7 +533,7 @@ bool UDPTransportInterface::SendThroughSocket(const octet* sendBuffer, uint32_t 
     }
     catch (const std::exception& error)
     {
-        logWarning(RTPS_MSG_OUT, "Error: " << error.what());
+        logError(RTPS_MSG_OUT, "Error: " << error.what() << ": " << sendBufferSize);
         return false;
     }
 


### PR DESCRIPTION
…tead

Remove the early allocation of the CDRMessage_t contained in RTPSMessageGroup_t and replace it with the usage of the CDRMessagePool.
The savings are linearly proportional to the number of Statefull readers / writers. Those use to preallocate CDRMessage_t buffers for the ACKNACK and HEARTBEAT packets resulting in a significant amount of RAM used.
Instead, these will now leverage the CDRMessagePool and allocate a buffer from there on demand only, saving a large amount of memory for lots of statefull endpoints.

Issue: #684