### PR TITLE
Refs #6270 Remove deprecated guards. [6273]

### DIFF
--- a/include/fastrtps/rtps/common/SequenceNumber.h
+++ b/include/fastrtps/rtps/common/SequenceNumber.h
@@ -63,8 +63,6 @@ struct RTPS_DllAPI SequenceNumber_t
     {
     }
 
-    // Check the target support 64bits.
-#ifdef LLONG_MAX
     /*! Convert the number to 64 bit.
      * @return 64 bit representation of the SequenceNumber
      */
@@ -72,7 +70,6 @@ struct RTPS_DllAPI SequenceNumber_t
     {
         return (((uint64_t)high) << 32) + low;
     }
-#endif
 
     /*!
      * Assignment operator
@@ -343,10 +340,10 @@ inline bool sort_seqNum(const SequenceNumber_t& s1, const SequenceNumber_t& s2) 
 }
 
 /**
- * 
+ *
  * @param output
  * @param seqNum
- * @return 
+ * @return
  */
 inline std::ostream& operator<<(std::ostream& output, const SequenceNumber_t& seqNum)
 {


### PR DESCRIPTION
All modern compilers supported by Fast-RTPS define `uint64_t` so preventing the definition of the method `to64long` doesn't have a sense now. Additionally, it caused compilation errors when building on 32 bits platforms that support `uint64_t`, a type that is used in a lot of parts of Fast-RTPS code without checkings.

Fixes #686 