### PR TITLE
Removing eClock from tests [6321]

### DIFF
--- a/test/communication/Publisher.cpp
+++ b/test/communication/Publisher.cpp
@@ -25,7 +25,6 @@
 #include <fastrtps/publisher/Publisher.h>
 #include <fastrtps/publisher/PublisherListener.h>
 #include <fastrtps/Domain.h>
-#include <fastrtps/utils/eClock.h>
 
 #include <types/HelloWorldType.h>
 
@@ -266,7 +265,7 @@ int main(int argc, char** argv)
             ++data.index();
         }
 
-        eClock::my_sleep(250);
+        std::this_thread::sleep_for(std::chrono::milliseconds(250));
     };
 
     Domain::removeParticipant(participant);

--- a/test/communication/Subscriber.cpp
+++ b/test/communication/Subscriber.cpp
@@ -27,7 +27,6 @@
 #include <fastrtps/subscriber/SubscriberListener.h>
 #include <fastrtps/Domain.h>
 #include <fastrtps/subscriber/SampleInfo.h>
-#include <fastrtps/utils/eClock.h>
 
 #include <types/HelloWorldType.h>
 
@@ -274,7 +273,7 @@ int main(int argc, char** argv)
 
     while(notexit && run)
     {
-        eClock::my_sleep(250);
+        std::this_thread::sleep_for(std::chrono::milliseconds(250));
     }
 
     if (run)

--- a/test/performance/LatencyTestPublisher.cpp
+++ b/test/performance/LatencyTestPublisher.cpp
@@ -589,7 +589,7 @@ void LatencyTestPublisher::run()
         {
             break;
         }
-        eClock::my_sleep(100);
+        std::this_thread::sleep_for(std::chrono::milliseconds(100));
         if (ndata != data_size_pub.end() - 1)
         {
             output_file_minimum << ",";

--- a/test/performance/LatencyTestSubscriber.cpp
+++ b/test/performance/LatencyTestSubscriber.cpp
@@ -404,9 +404,6 @@ void LatencyTestSubscriber::DataSubListener::onNewDataMessage(Subscriber* subscr
     else
     {
         subscriber->takeNextData((void*)mp_up->mp_latency,&mp_up->m_sampleinfo);
-        //	cout << "R: "<< mp_up->mp_latency->seqnum << "|"<<mp_up->m_echo<<std::flush;
-        //	//	eClock::my_sleep(50);
-        //		cout << "NSAMPLES: " << (uint32_t)mp_up->n_samples<< endl;
         if (mp_up->m_echo)
         {
             mp_up->mp_datapub->write((void*)mp_up->mp_latency);
@@ -476,7 +473,7 @@ bool LatencyTestSubscriber::test(uint32_t datasize)
     lock.unlock();
 
     cout << "TEST OF SIZE: " << datasize + 4 << " ENDS" << endl;
-    eClock::my_sleep(50);
+    std::this_thread::sleep_for(std::chrono::milliseconds(50));
     size_t removed;
     this->mp_datapub->removeAllChange(&removed);
     //cout << "REMOVED: "<< removed<<endl;

--- a/test/performance/ThroughputPublisher.cpp
+++ b/test/performance/ThroughputPublisher.cpp
@@ -20,7 +20,6 @@
 #include "ThroughputPublisher.h"
 
 #include <fastrtps/utils/TimeConversion.h>
-#include <fastrtps/utils/eClock.h>
 #include <fastrtps/attributes/ParticipantAttributes.h>
 #include <fastrtps/attributes/SubscriberAttributes.h>
 #include <fastrtps/xmlparser/XMLProfileManager.h>
@@ -322,7 +321,7 @@ void ThroughputPublisher::run(uint32_t test_time, uint32_t recovery_time_ms, int
     {
         for (auto dit = sit->second.begin(); dit != sit->second.end(); ++dit)
         {
-            eClock::my_sleep(100);
+            std::this_thread::sleep_for(std::chrono::milliseconds(100));
             //cout << "Starting test with demand: " << *dit << endl;
             command.m_command = READY_TO_START;
             command.m_size = sit->first;
@@ -465,15 +464,15 @@ bool ThroughputPublisher::test(uint32_t test_time, uint32_t recovery_time_ms, ui
         t_end_ = std::chrono::steady_clock::now();
         samples += demand;
         //cout << "samples sent: "<<samples<< endl;
-        eClock::my_sleep(recovery_time_ms);
+        std::this_thread::sleep_for(std::chrono::milliseconds(recovery_time_ms));
         timewait_us += t_overhead_;
     }
     command.m_command = TEST_ENDS;
 
     //cout << "SEND COMMAND "<< command.m_command << endl;
-    eClock::my_sleep(100);
+    std::this_thread::sleep_for(std::chrono::milliseconds(100));
     mp_commandpub->write((void*)&command);
-    eClock::my_sleep(100);
+    std::this_thread::sleep_for(std::chrono::milliseconds(100));
     mp_datapub->removeAllChange();
 
     if (dynamic_data)

--- a/test/performance/ThroughputSubscriber.cpp
+++ b/test/performance/ThroughputSubscriber.cpp
@@ -20,7 +20,6 @@
 #include "ThroughputSubscriber.h"
 
 #include <fastrtps/utils/TimeConversion.h>
-#include <fastrtps/utils/eClock.h>
 #include <fastrtps/attributes/ParticipantAttributes.h>
 #include <fastrtps/attributes/PublisherAttributes.h>
 #include <fastrtps/xmlparser/XMLProfileManager.h>
@@ -221,7 +220,7 @@ void ThroughputSubscriber::processMessage()
                 mp_datasub = Domain::createSubscriber(mp_par, subAttr, &m_DataSubListener);
 
                 ThroughputCommandType command(BEGIN);
-                eClock::my_sleep(50);
+                std::this_thread::sleep_for(std::chrono::milliseconds(50));
                 m_DataSubListener.reset();
                 //cout << "SEND COMMAND: "<< command.m_command << endl;
                 //cout << "writecall "<< ++writecalls << endl;
@@ -278,7 +277,7 @@ void ThroughputSubscriber::processMessage()
     else
     {
         //std::cout << "Error reading command" << std::endl;
-        eClock::my_sleep(5);
+        std::this_thread::sleep_for(std::chrono::milliseconds(5));
     }
 }
 
@@ -482,7 +481,7 @@ ThroughputSubscriber::ThroughputSubscriber(bool reliable, uint32_t pid, bool hos
         ready = false;
     }
 
-    eClock::my_sleep(1000);
+    std::this_thread::sleep_for(std::chrono::milliseconds(1000));
 }
 
 void ThroughputSubscriber::run()
@@ -509,7 +508,7 @@ void ThroughputSubscriber::run()
             std::cout << "Waiting clean state" << std::endl;
             while (!mp_datasub->isInCleanState())
             {
-                eClock::my_sleep(50);
+                std::this_thread::sleep_for(std::chrono::milliseconds(50));
             }
             std::cout << "Sending results" << std::endl;
             ThroughputCommandType comm;

--- a/test/performance/VideoTestPublisher.cpp
+++ b/test/performance/VideoTestPublisher.cpp
@@ -481,7 +481,7 @@ GstFlowReturn VideoTestPublisher::new_sample(GstElement *sink, VideoTestPublishe
     {
         if (sub->m_sendSleepTime != 0)
         {
-            eClock::my_sleep(rand() % sub->m_sendSleepTime);
+            std::this_thread::sleep_for(std::chrono::milliseconds(rand() % sub->m_sendSleepTime));
         }
 
         GstSample* sample = gst_app_sink_pull_sample(GST_APP_SINK(sink));

--- a/test/performance/VideoTestSubscriber.cpp
+++ b/test/performance/VideoTestSubscriber.cpp
@@ -398,7 +398,7 @@ bool VideoTestSubscriber::test()
     lock.unlock();
 
     cout << "TEST FINISHED" << endl;
-    eClock::my_sleep(50);
+    std::this_thread::sleep_for(std::chrono::milliseconds(50));
 
     analyzeTimes();
     if (m_stats.size() > 0)

--- a/test/performance/main_LatencyTest.cpp
+++ b/test/performance/main_LatencyTest.cpp
@@ -417,7 +417,7 @@ int main(int argc, char** argv)
         latencySub.run();
     }
 
-    eClock::my_sleep(1000);
+    std::this_thread::sleep_for(std::chrono::milliseconds(1000));
 
     cout << "EVERYTHING STOPPED FINE" << endl;
 

--- a/test/performance/main_VideoTest.cpp
+++ b/test/performance/main_VideoTest.cpp
@@ -443,7 +443,7 @@ int main(int argc, char** argv)
         sub.run();
     }
 
-    eClock::my_sleep(1000);
+    std::this_thread::sleep_for(std::chrono::milliseconds(1000));
 
     cout << "EVERYTHING STOPPED FINE" << endl;
 

--- a/test/profiling/MemoryTestPublisher.cpp
+++ b/test/profiling/MemoryTestPublisher.cpp
@@ -337,7 +337,7 @@ void MemoryTestPublisher::run(uint32_t test_time)
     disc_lock.unlock();
 
     test(test_time, m_data_size);
-    eClock::my_sleep(100);
+    std::this_thread::sleep_for(std::chrono::milliseconds(100));
 
     cout << "REMOVING PUBLISHER"<<endl;
     Domain::removePublisher(this->mp_commandpub);

--- a/test/profiling/MemoryTestSubscriber.cpp
+++ b/test/profiling/MemoryTestSubscriber.cpp
@@ -294,7 +294,6 @@ void MemoryTestSubscriber::CommandSubListener::onNewDataMessage(Subscriber* subs
             std::cout << "Something is wrong" << std::endl;
         }
     }
-    //cout << "SAMPLE INFO: "<< mp_up->m_sampleinfo.writerGUID << mp_up->m_sampleinfo.sampleKind << endl;
 }
 
 void MemoryTestSubscriber::DataSubListener::onNewDataMessage(Subscriber* subscriber)
@@ -312,9 +311,6 @@ void MemoryTestSubscriber::DataSubListener::onNewDataMessage(Subscriber* subscri
     else
     {
         subscriber->takeNextData((void*)mp_up->mp_memory,&mp_up->m_sampleinfo);
-        //	cout << "R: "<< mp_up->mp_memory->seqnum << "|"<<mp_up->m_echo<<std::flush;
-        //	//	eClock::my_sleep(50);
-        //		cout << "NSAMPLES: " << (uint32_t)mp_up->n_samples<< endl;
         ++mp_up->n_received;
         if (mp_up->m_echo)
         {
@@ -402,8 +398,7 @@ bool MemoryTestSubscriber::test(uint32_t datasize)
     lock.unlock();
 
     cout << "TEST OF SIZE: " << datasize + 4 << " ENDS" << endl;
-    eClock::my_sleep(50);
-    //cout << "REMOVED: "<< removed<<endl;
+    std::this_thread::sleep_for(std::chrono::milliseconds(50));
     if (dynamic_data)
     {
         DynamicTypeBuilderFactory::delete_instance();

--- a/test/profiling/allocations/AllocTestPublisher.cpp
+++ b/test/profiling/allocations/AllocTestPublisher.cpp
@@ -24,7 +24,6 @@
 #include <fastrtps/attributes/PublisherAttributes.h>
 #include <fastrtps/publisher/Publisher.h>
 #include <fastrtps/Domain.h>
-#include <fastrtps/utils/eClock.h>
 #include <fastrtps/xmlparser/XMLProfileManager.h>
 
 using namespace eprosima::fastrtps;
@@ -125,7 +124,7 @@ void AllocTestPublisher::run(uint32_t samples, bool wait_unmatch)
     eprosima_profiling::discovery_finished();
 
     std::cout << "Publisher matched. Sending samples" << std::endl;
-    eClock::my_sleep(500);
+    std::this_thread::sleep_for(std::chrono::milliseconds(500));
 
     for(uint32_t i = 0;i<samples;++i)
     {
@@ -135,7 +134,7 @@ void AllocTestPublisher::run(uint32_t samples, bool wait_unmatch)
         {
             std::cout << "Message with index: "<< m_data.index() << " SENT" << std::endl;
         }
-        eClock::my_sleep(500);
+        std::this_thread::sleep_for(std::chrono::milliseconds(500));
 
         if (i == 0)
         {
@@ -144,7 +143,7 @@ void AllocTestPublisher::run(uint32_t samples, bool wait_unmatch)
             eprosima_profiling::first_sample_exchanged();
 
             std::cout << "First message has been sent" << std::endl;
-            eClock::my_sleep(500);
+            std::this_thread::sleep_for(std::chrono::milliseconds(500));
         }
     }
 
@@ -160,7 +159,7 @@ void AllocTestPublisher::run(uint32_t samples, bool wait_unmatch)
     else
     {
         std::cout << "All messages have been sent. Waiting a bit to let subscriber receive samples." << std::endl;
-        eClock::my_sleep(500);
+        std::this_thread::sleep_for(std::chrono::milliseconds(500));
     }
 
     // Flush callgrind graph

--- a/test/profiling/allocations/AllocTestSubscriber.cpp
+++ b/test/profiling/allocations/AllocTestSubscriber.cpp
@@ -24,7 +24,6 @@
 #include <fastrtps/attributes/SubscriberAttributes.h>
 #include <fastrtps/subscriber/Subscriber.h>
 #include <fastrtps/Domain.h>
-#include <fastrtps/utils/eClock.h>
 #include <fastrtps/xmlparser/XMLProfileManager.h>
 
 using namespace eprosima::fastrtps;
@@ -161,7 +160,7 @@ void AllocTestSubscriber::run(uint32_t number, bool wait_unmatch)
     else
     {
         std::cout << "All messages received. Waiting a bit to let publisher receive acks." << std::endl;
-        eClock::my_sleep(500);
+        std::this_thread::sleep_for(std::chrono::milliseconds(500));
     }
 
     // Flush callgrind graph

--- a/test/profiling/allocations/AllocTest_main.cpp
+++ b/test/profiling/allocations/AllocTest_main.cpp
@@ -21,8 +21,6 @@
 #include "AllocTestSubscriber.h"
 
 #include <fastrtps/Domain.h>
-
-#include <fastrtps/utils/eClock.h>
 #include <fastrtps/log/Log.h>
 
 using namespace eprosima;

--- a/test/profiling/main_MemoryTest.cpp
+++ b/test/profiling/main_MemoryTest.cpp
@@ -415,7 +415,7 @@ int main(int argc, char** argv)
         memorySub.run();
     }
 
-    eClock::my_sleep(1000);
+    std::this_thread::sleep_for(std::chrono::milliseconds(1000));
 
     cout << "EVERYTHING STOPPED FINE" << endl;
 


### PR DESCRIPTION
This PR removes the usage of `eClock` from our tests. To test the changes:

* Do a grep and ensure that there are no occurrences of `eClock`
* Check that performance tests are built successfully (cmake flags are `-DEPROSIMA_BUILD_TESTS=ON`, `-DPERFORMANCE_TESTS=ON` and `-DPROFILING_TESTS=ON`)