### PR TITLE
Refs #6246 Protecting AuthInfo timed event. [6345]

### DIFF
--- a/src/cpp/rtps/security/SecurityManager.h
+++ b/src/cpp/rtps/security/SecurityManager.h
@@ -252,6 +252,8 @@ private:
 
                 TimedEvent* event_;
 
+                std::mutex mtx_event_;
+
             private:
 
                 AuthenticationInfo(


### PR DESCRIPTION
This PR fixes #6246.
It adds a protecting mutex to the AuthenticationInfo event, which could be canceled incorrectly on receiving `data(p)` messages from new participants.