### PR TITLE
Added STRICT_REALTIME option [6355]

### DIFF
--- a/include/fastrtps/config.h.in
+++ b/include/fastrtps/config.h.in
@@ -68,6 +68,11 @@
 #define TLS_FOUND @TLS_FOUND@
 #endif
 
+// Strict real-time
+#ifndef HAVE_STRICT_REALTIME
+#define HAVE_STRICT_REALTIME @HAVE_STRICT_REALTIME@
+#endif
+
 // Deprecated macro
 #if __cplusplus >= 201402L
 #define FASTRTPS_DEPRECATED(msg) [[ deprecated(msg) ]]

--- a/src/cpp/CMakeLists.txt
+++ b/src/cpp/CMakeLists.txt
@@ -243,6 +243,17 @@ if(ANDROID)
         )
 endif()
 
+# Option to enable strict real-time. In this case, several API functions have a real-time behaviour.
+# * Publisher::write() - Uses ReliabilityQosPolicy.max_blocking_time
+# * Subscriber::takeNextData() - Uses ReliabilityQosPolicy.max_blocking_time
+# * Subscriber::readNextData() - Uses ReliabilityQosPolicy.max_blocking_time
+option(STRICT_REALTIME "Enable a strict real-time behavour." OFF)
+if(STRICT_REALTIME)
+    set(HAVE_STRICT_REALTIME 1)
+else()
+    set(HAVE_STRICT_REALTIME 0)
+endif()
+
 configure_file(${PROJECT_SOURCE_DIR}/include/${PROJECT_NAME}/config.h.in
     ${PROJECT_BINARY_DIR}/include/${PROJECT_NAME}/config.h)
 

--- a/src/cpp/publisher/PublisherImpl.cpp
+++ b/src/cpp/publisher/PublisherImpl.cpp
@@ -160,9 +160,13 @@ bool PublisherImpl::create_new_change_with_params(
     // Block lowlevel writer
     auto max_blocking_time = std::chrono::steady_clock::now() +
         std::chrono::microseconds(::TimeConv::Time_t2MicroSecondsInt64(m_att.qos.m_reliability.max_blocking_time));
-    std::unique_lock<RecursiveTimedMutex> lock(mp_writer->getMutex(), std::defer_lock);
 
+#if HAVE_STRICT_REALTIME
+    std::unique_lock<RecursiveTimedMutex> lock(mp_writer->getMutex(), std::defer_lock);
     if(lock.try_lock_until(max_blocking_time))
+#else
+    std::unique_lock<RecursiveTimedMutex> lock(mp_writer->getMutex());
+#endif
     {
         CacheChange_t* ch = mp_writer->new_change(mp_type->getSerializedSizeProvider(data), changeKind, handle);
         if(ch != nullptr)

--- a/src/cpp/subscriber/SubscriberImpl.cpp
+++ b/src/cpp/subscriber/SubscriberImpl.cpp
@@ -104,14 +104,22 @@ bool SubscriberImpl::wait_for_unread_samples(const Duration_t& timeout)
 bool SubscriberImpl::readNextData(void* data,SampleInfo_t* info)
 {
     auto max_blocking_time = std::chrono::steady_clock::now() +
+#if HAVE_STRICT_REALTIME
         std::chrono::microseconds(::TimeConv::Time_t2MicroSecondsInt64(m_att.qos.m_reliability.max_blocking_time));
+#else
+        std::chrono::hours(24);
+#endif
     return this->m_history.readNextData(data, info, max_blocking_time);
 }
 
 bool SubscriberImpl::takeNextData(void* data,SampleInfo_t* info)
 {
     auto max_blocking_time = std::chrono::steady_clock::now() +
+#if HAVE_STRICT_REALTIME
         std::chrono::microseconds(::TimeConv::Time_t2MicroSecondsInt64(m_att.qos.m_reliability.max_blocking_time));
+#else
+        std::chrono::hours(24);
+#endif
     return this->m_history.takeNextData(data, info, max_blocking_time);
 }
 

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -35,7 +35,7 @@ if(EPROSIMA_BUILD_TESTS AND IS_TOP_LEVEL AND NOT EPROSIMA_INSTALLER)
     add_subdirectory(communication)
     add_subdirectory(unittest)
 
-    if(UNIX AND NOT APPLE)
+    if(UNIX AND NOT APPLE AND STRICT_REALTIME)
         add_subdirectory(realtime)
     endif()
 endif()


### PR DESCRIPTION
Added a CMake configuration option: `-DSTRICT_REALTIME=ON`

This option enables strict real-time. In this case, several API functions have a real-time behaviour.
* `Publisher::write()` - Uses ReliabilityQosPolicy.max_blocking_time
* `Subscriber::takeNextData()` - Uses ReliabilityQosPolicy.max_blocking_time
* `Subscriber::readNextData()` - Uses ReliabilityQosPolicy.max_blocking_time
