### PR TITLE
Refs #6341 FastCDR version that fixes cmake paths. [6377]

### DIFF
--- a/fastrtps.repos
+++ b/fastrtps.repos
@@ -6,7 +6,7 @@ repositories:
     fastcdr:
         type: git
         url: https://github.com/eProsima/Fast-CDR.git
-        version: v1.0.10
+        version: v1.0.11
     fastrtps:
         type: git
         url: https://github.com/eProsima/Fast-RTPS.git


### PR DESCRIPTION
Changes the version of FastCDR needed by fastrtps.repos to fix generated cmake paths.