### PR TITLE
Fix leak on RemoteParticipantLeaseDuration [6438]

### DIFF
--- a/include/fastrtps/rtps/resources/TimedEvent.h
+++ b/include/fastrtps/rtps/resources/TimedEvent.h
@@ -111,6 +111,8 @@ public:
 
     void destroy();
 
+    void mark_for_destruction();
+
 private:
 	TimedEventImpl* mp_impl;
 };

--- a/src/cpp/rtps/builtin/discovery/participant/timedevent/RemoteParticipantLeaseDuration.cpp
+++ b/src/cpp/rtps/builtin/discovery/participant/timedevent/RemoteParticipantLeaseDuration.cpp
@@ -87,6 +87,7 @@ void RemoteParticipantLeaseDuration::event(EventCode code, const char* msg)
                             mp_PDP->getRTPSParticipant()->getUserRTPSParticipant(), std::move(info));
                 }
             }
+            mark_for_destruction();
             return;
         }
 

--- a/src/cpp/rtps/resources/TimedEvent.cpp
+++ b/src/cpp/rtps/resources/TimedEvent.cpp
@@ -72,6 +72,11 @@ void TimedEvent::destroy()
     mp_impl->destroy();
 }
 
+void TimedEvent::mark_for_destruction()
+{
+    mp_impl->mark_for_destruction();
+}
+
 }
 } /* namespace rtps */
 } /* namespace eprosima */

--- a/src/cpp/rtps/resources/TimedEventImpl.cpp
+++ b/src/cpp/rtps/resources/TimedEventImpl.cpp
@@ -100,6 +100,11 @@ void TimedEventImpl::destroy()
         cond_.wait(lock);
 }
 
+void TimedEventImpl::mark_for_destruction()
+{
+    std::unique_lock<std::mutex> lock(mutex_);
+    state_.get()->autodestruction_ = TimedEvent::ALLWAYS;
+}
 
 /* In this function we don't need to exchange the state,
  * because this function try to cancel, but if the event is running

--- a/src/cpp/rtps/resources/TimedEventImpl.h
+++ b/src/cpp/rtps/resources/TimedEventImpl.h
@@ -111,6 +111,8 @@ namespace eprosima
 
                     void destroy();
 
+                    void mark_for_destruction();
+
                     /**
                      * Get interval in milliseconds
                      * @return Event interval in milliseconds


### PR DESCRIPTION
This PR fixes a leak introduced by #726. 

When a remote participant is dropped due to its lease duration being elapsed, the RemoteParticipantLeaseDuration event is not deleted.

Before #726, it was configured to self destruct upon success, but now the event may be triggered without triggering a participant drop. This adds the requirement on TimedEvent to allow to be marked for destruction (i.e. changing its self-destruction behavior on demand).