### PR TITLE
Flag to avoid builtin multicast [6450]

### DIFF
--- a/include/fastrtps/rtps/attributes/RTPSParticipantAttributes.h
+++ b/include/fastrtps/rtps/attributes/RTPSParticipantAttributes.h
@@ -143,6 +143,9 @@ class BuiltinAttributes
         //!Initial announcements configuration
         InitialAnnouncementConfig initial_announcements;
 
+        //!Set to true to avoid multicast traffic on builtin endpoints
+        bool avoid_builtin_multicast = false;
+
         //!Attributes of the SimpleEDP protocol
         SimpleEDPAttributes m_simpleEDP;
 
@@ -190,6 +193,7 @@ class BuiltinAttributes
                    (leaseDuration == b.leaseDuration) &&
                    (leaseDuration_announcementperiod == b.leaseDuration_announcementperiod) &&
                    (initial_announcements == b.initial_announcements) &&
+                   (avoid_builtin_multicast == b.avoid_builtin_multicast) &&
                    (m_simpleEDP == b.m_simpleEDP) &&
                    (metatrafficUnicastLocatorList == b.metatrafficUnicastLocatorList) &&
                    (metatrafficMulticastLocatorList == b.metatrafficMulticastLocatorList) &&

--- a/include/fastrtps/rtps/attributes/RTPSParticipantAttributes.h
+++ b/include/fastrtps/rtps/attributes/RTPSParticipantAttributes.h
@@ -107,38 +107,38 @@ class BuiltinAttributes
          * Publisher and Subscriber defined with the same topic name would NOT be linked. All matching must be done
          * manually through the addReaderLocator, addReaderProxy, addWriterProxy methods.
          */
-        bool use_SIMPLE_RTPSParticipantDiscoveryProtocol;
+        bool use_SIMPLE_RTPSParticipantDiscoveryProtocol = true;
 
         //!Indicates to use the WriterLiveliness protocol.
-        bool use_WriterLivelinessProtocol;
+        bool use_WriterLivelinessProtocol = true;
 
         /**
          * If set to true, SimpleEDP would be used.
          */
-        bool use_SIMPLE_EndpointDiscoveryProtocol;
+        bool use_SIMPLE_EndpointDiscoveryProtocol = true;
 
         /**
          * If set to true, StaticEDP based on an XML file would be implemented.
          * The XML filename must be provided.
          */
-        bool use_STATIC_EndpointDiscoveryProtocol;
+        bool use_STATIC_EndpointDiscoveryProtocol = false;
 
         /**
-         * DomainId to be used by the RTPSParticipant (80 by default).
+         * DomainId to be used by the RTPSParticipant (0 by default).
          */
-        uint32_t domainId;
+        uint32_t domainId = 0;
 
         /**
          * Lease Duration of the RTPSParticipant,
          * indicating how much time remote RTPSParticipants should consider this RTPSParticipant alive.
          */
-        Duration_t leaseDuration;
+        Duration_t leaseDuration = { 130, 0 };
 
         /**
          * The period for the RTPSParticipant to send its Discovery Message to all other discovered RTPSParticipants
          * as well as to all Multicast ports.
          */
-        Duration_t leaseDuration_announcementperiod;
+        Duration_t leaseDuration_announcementperiod = { 40, 0 };
 
         //!Initial announcements configuration
         InitialAnnouncementConfig initial_announcements;
@@ -159,29 +159,17 @@ class BuiltinAttributes
         LocatorList_t initialPeersList;
 
         //! Memory policy for builtin readers
-        MemoryManagementPolicy_t readerHistoryMemoryPolicy;
+        MemoryManagementPolicy_t readerHistoryMemoryPolicy = MemoryManagementPolicy_t::PREALLOCATED_MEMORY_MODE;
 
         //! Memory policy for builtin writers
-        MemoryManagementPolicy_t writerHistoryMemoryPolicy;
+        MemoryManagementPolicy_t writerHistoryMemoryPolicy = MemoryManagementPolicy_t::PREALLOCATED_MEMORY_MODE;
 
         //! Mutation tries if the port is being used.
-        uint32_t mutation_tries;
+        uint32_t mutation_tries = 100u;
 
-        BuiltinAttributes()
-        {
-            use_SIMPLE_RTPSParticipantDiscoveryProtocol = true;
-            use_SIMPLE_EndpointDiscoveryProtocol = true;
-            use_STATIC_EndpointDiscoveryProtocol = false;
-            m_staticEndpointXMLFilename = "";
-            domainId = 0;
-            leaseDuration.seconds = 130;
-            leaseDuration_announcementperiod.seconds = 40;
-            use_WriterLivelinessProtocol = true;
-            readerHistoryMemoryPolicy = MemoryManagementPolicy_t::PREALLOCATED_MEMORY_MODE;
-            writerHistoryMemoryPolicy = MemoryManagementPolicy_t::PREALLOCATED_MEMORY_MODE;
-            mutation_tries = 100u;
-        }
-        virtual ~BuiltinAttributes() {}
+        BuiltinAttributes() = default;
+
+        virtual ~BuiltinAttributes() = default;
 
         bool operator==(const BuiltinAttributes& b) const
         {
@@ -218,7 +206,7 @@ class BuiltinAttributes
 
     private:
         //! StaticEDP XML filename, only necessary if use_STATIC_EndpointDiscoveryProtocol=true
-        std::string m_staticEndpointXMLFilename;
+        std::string m_staticEndpointXMLFilename = "";
 
 };
 

--- a/include/fastrtps/rtps/builtin/discovery/participant/PDPSimple.h
+++ b/include/fastrtps/rtps/builtin/discovery/participant/PDPSimple.h
@@ -42,7 +42,7 @@ class ReaderProxyData;
 class WriterProxyData;
 class ParticipantProxyData;
 class PDPSimpleListener;
-
+class EndpointAttributes;
 
 /**
  * Class PDPSimple that implements the SimpleRTPSParticipantDiscoveryProtocol as defined in the RTPS specification.
@@ -188,6 +188,18 @@ class PDPSimple
      * @param kind Kind of endpoint.
      */
     bool newRemoteEndpointStaticallyDiscovered(const GUID_t& pguid, int16_t userDefinedId,EndpointKind_t kind);
+
+    void get_metatraffic_locators(
+            EndpointAttributes& destination,
+            const ParticipantProxyData& origin);
+
+    void get_metatraffic_locators(
+            WriterProxyData& destination,
+            const ParticipantProxyData& origin);
+
+    void get_metatraffic_locators(
+            ReaderProxyData& destination,
+            const ParticipantProxyData& origin);
 
     /**
      * Get the RTPS participant

--- a/src/cpp/rtps/builtin/discovery/endpoint/EDPSimple.cpp
+++ b/src/cpp/rtps/builtin/discovery/endpoint/EDPSimple.cpp
@@ -680,9 +680,7 @@ void EDPSimple::assignRemoteEndpoints(const ParticipantProxyData& pdata)
         watt.guid.guidPrefix = pdata.m_guid.guidPrefix;
         watt.guid.entityId = c_EntityId_SEDPPubWriter;
         watt.endpoint.persistence_guid = watt.guid;
-        watt.endpoint.unicastLocatorList = pdata.m_metatrafficUnicastLocatorList;
-        watt.endpoint.multicastLocatorList = pdata.m_metatrafficMulticastLocatorList;
-        //watt.endpoint.remoteLocatorList = m_discovery.initialPeersList;
+        mp_PDP->get_metatraffic_locators(watt.endpoint, pdata);
         watt.endpoint.reliabilityKind = RELIABLE;
         watt.endpoint.durabilityKind = TRANSIENT_LOCAL;
         publications_reader_.first->matched_writer_add(watt);
@@ -698,9 +696,7 @@ void EDPSimple::assignRemoteEndpoints(const ParticipantProxyData& pdata)
         ratt.expectsInlineQos = false;
         ratt.guid.guidPrefix = pdata.m_guid.guidPrefix;
         ratt.guid.entityId = c_EntityId_SEDPPubReader;
-        ratt.endpoint.unicastLocatorList = pdata.m_metatrafficUnicastLocatorList;
-        ratt.endpoint.multicastLocatorList = pdata.m_metatrafficMulticastLocatorList;
-        //ratt.endpoint.remoteLocatorList = m_discovery.initialPeersList;
+        mp_PDP->get_metatraffic_locators(ratt.endpoint, pdata);
         ratt.endpoint.durabilityKind = TRANSIENT_LOCAL;
         ratt.endpoint.reliabilityKind = RELIABLE;
         publications_writer_.first->matched_reader_add(ratt);
@@ -716,9 +712,7 @@ void EDPSimple::assignRemoteEndpoints(const ParticipantProxyData& pdata)
         watt.guid.guidPrefix = pdata.m_guid.guidPrefix;
         watt.guid.entityId = c_EntityId_SEDPSubWriter;
         watt.endpoint.persistence_guid = watt.guid;
-        watt.endpoint.unicastLocatorList = pdata.m_metatrafficUnicastLocatorList;
-        watt.endpoint.multicastLocatorList = pdata.m_metatrafficMulticastLocatorList;
-        //watt.endpoint.remoteLocatorList = m_discovery.initialPeersList;
+        mp_PDP->get_metatraffic_locators(watt.endpoint, pdata);
         watt.endpoint.reliabilityKind = RELIABLE;
         watt.endpoint.durabilityKind = TRANSIENT_LOCAL;
         subscriptions_reader_.first->matched_writer_add(watt);
@@ -734,9 +728,7 @@ void EDPSimple::assignRemoteEndpoints(const ParticipantProxyData& pdata)
         ratt.expectsInlineQos = false;
         ratt.guid.guidPrefix = pdata.m_guid.guidPrefix;
         ratt.guid.entityId = c_EntityId_SEDPSubReader;
-        ratt.endpoint.unicastLocatorList = pdata.m_metatrafficUnicastLocatorList;
-        ratt.endpoint.multicastLocatorList = pdata.m_metatrafficMulticastLocatorList;
-        //ratt.endpoint.remoteLocatorList = m_discovery.initialPeersList;
+        mp_PDP->get_metatraffic_locators(ratt.endpoint, pdata);
         ratt.endpoint.durabilityKind = TRANSIENT_LOCAL;
         ratt.endpoint.reliabilityKind = RELIABLE;
         subscriptions_writer_.first->matched_reader_add(ratt);
@@ -753,8 +745,7 @@ void EDPSimple::assignRemoteEndpoints(const ParticipantProxyData& pdata)
         watt.guid().guidPrefix = pdata.m_guid.guidPrefix;
         watt.guid().entityId = sedp_builtin_publications_secure_writer;
         watt.persistence_guid(watt.guid());
-        watt.unicastLocatorList(pdata.m_metatrafficUnicastLocatorList);
-        watt.multicastLocatorList(pdata.m_metatrafficMulticastLocatorList);
+        mp_PDP->get_metatraffic_locators(watt, pdata);
         watt.m_qos.m_reliability.kind = RELIABLE_RELIABILITY_QOS;
         watt.m_qos.m_durability.kind = TRANSIENT_LOCAL_DURABILITY_QOS;
         if(!mp_RTPSParticipant->security_manager().discovered_builtin_writer(
@@ -776,8 +767,7 @@ void EDPSimple::assignRemoteEndpoints(const ParticipantProxyData& pdata)
         ratt.m_expectsInlineQos = false;
         ratt.guid().guidPrefix = pdata.m_guid.guidPrefix;
         ratt.guid().entityId = sedp_builtin_publications_secure_reader;
-        ratt.unicastLocatorList(pdata.m_metatrafficUnicastLocatorList);
-        ratt.multicastLocatorList(pdata.m_metatrafficMulticastLocatorList);
+        mp_PDP->get_metatraffic_locators(ratt, pdata);
         ratt.m_qos.m_durability.kind = TRANSIENT_LOCAL_DURABILITY_QOS;
         ratt.m_qos.m_reliability.kind = RELIABLE_RELIABILITY_QOS;
         if(!mp_RTPSParticipant->security_manager().discovered_builtin_reader(
@@ -799,8 +789,7 @@ void EDPSimple::assignRemoteEndpoints(const ParticipantProxyData& pdata)
         watt.guid().guidPrefix = pdata.m_guid.guidPrefix;
         watt.guid().entityId = sedp_builtin_subscriptions_secure_writer;
         watt.persistence_guid(watt.guid());
-        watt.unicastLocatorList(pdata.m_metatrafficUnicastLocatorList);
-        watt.multicastLocatorList(pdata.m_metatrafficMulticastLocatorList);
+        mp_PDP->get_metatraffic_locators(watt, pdata);
         watt.m_qos.m_reliability.kind = RELIABLE_RELIABILITY_QOS;
         watt.m_qos.m_durability.kind = TRANSIENT_LOCAL_DURABILITY_QOS;
         if(!mp_RTPSParticipant->security_manager().discovered_builtin_writer(
@@ -823,8 +812,7 @@ void EDPSimple::assignRemoteEndpoints(const ParticipantProxyData& pdata)
         ratt.m_expectsInlineQos = false;
         ratt.guid().guidPrefix = pdata.m_guid.guidPrefix;
         ratt.guid().entityId = sedp_builtin_subscriptions_secure_reader;
-        ratt.unicastLocatorList(pdata.m_metatrafficUnicastLocatorList);
-        ratt.multicastLocatorList(pdata.m_metatrafficMulticastLocatorList);
+        mp_PDP->get_metatraffic_locators(ratt, pdata);
         ratt.m_qos.m_durability.kind = TRANSIENT_LOCAL_DURABILITY_QOS;
         ratt.m_qos.m_reliability.kind = RELIABLE_RELIABILITY_QOS;
         if(!mp_RTPSParticipant->security_manager().discovered_builtin_reader(
@@ -854,8 +842,7 @@ void EDPSimple::removeRemoteEndpoints(ParticipantProxyData* pdata)
         watt.guid.guidPrefix = pdata->m_guid.guidPrefix;
         watt.guid.entityId = c_EntityId_SEDPPubWriter;
         watt.endpoint.persistence_guid = watt.guid;
-        watt.endpoint.unicastLocatorList = pdata->m_metatrafficUnicastLocatorList;
-        watt.endpoint.multicastLocatorList = pdata->m_metatrafficMulticastLocatorList;
+        mp_PDP->get_metatraffic_locators(watt.endpoint, *pdata);
         //watt.endpoint.remoteLocatorList = m_discovery.initialPeersList;
         watt.endpoint.reliabilityKind = RELIABLE;
         watt.endpoint.durabilityKind = TRANSIENT_LOCAL;
@@ -871,9 +858,7 @@ void EDPSimple::removeRemoteEndpoints(ParticipantProxyData* pdata)
         ratt.expectsInlineQos = false;
         ratt.guid.guidPrefix = pdata->m_guid.guidPrefix;
         ratt.guid.entityId = c_EntityId_SEDPPubReader;
-        ratt.endpoint.unicastLocatorList = pdata->m_metatrafficUnicastLocatorList;
-        ratt.endpoint.multicastLocatorList = pdata->m_metatrafficMulticastLocatorList;
-        //ratt.endpoint.remoteLocatorList = m_discovery.initialPeersList;
+        mp_PDP->get_metatraffic_locators(ratt.endpoint, *pdata);
         ratt.endpoint.durabilityKind = TRANSIENT_LOCAL;
         ratt.endpoint.reliabilityKind = RELIABLE;
         publications_writer_.first->matched_reader_remove(ratt);
@@ -889,9 +874,7 @@ void EDPSimple::removeRemoteEndpoints(ParticipantProxyData* pdata)
         watt.guid.guidPrefix = pdata->m_guid.guidPrefix;
         watt.guid.entityId = c_EntityId_SEDPSubWriter;
         watt.endpoint.persistence_guid = watt.guid;
-        watt.endpoint.unicastLocatorList = pdata->m_metatrafficUnicastLocatorList;
-        watt.endpoint.multicastLocatorList = pdata->m_metatrafficMulticastLocatorList;
-        //watt.endpoint.remoteLocatorList = m_discovery.initialPeersList;
+        mp_PDP->get_metatraffic_locators(watt.endpoint, *pdata);
         watt.endpoint.reliabilityKind = RELIABLE;
         watt.endpoint.durabilityKind = TRANSIENT_LOCAL;
         subscriptions_reader_.first->matched_writer_remove(watt);
@@ -907,9 +890,7 @@ void EDPSimple::removeRemoteEndpoints(ParticipantProxyData* pdata)
         ratt.expectsInlineQos = false;
         ratt.guid.guidPrefix = pdata->m_guid.guidPrefix;
         ratt.guid.entityId = c_EntityId_SEDPSubReader;
-        ratt.endpoint.unicastLocatorList = pdata->m_metatrafficUnicastLocatorList;
-        ratt.endpoint.multicastLocatorList = pdata->m_metatrafficMulticastLocatorList;
-        //ratt.endpoint.remoteLocatorList = m_discovery.initialPeersList;
+        mp_PDP->get_metatraffic_locators(ratt.endpoint, *pdata);
         ratt.endpoint.durabilityKind = TRANSIENT_LOCAL;
         ratt.endpoint.reliabilityKind = RELIABLE;
         subscriptions_writer_.first->matched_reader_remove(ratt);
@@ -926,8 +907,7 @@ void EDPSimple::removeRemoteEndpoints(ParticipantProxyData* pdata)
         watt.guid.guidPrefix = pdata->m_guid.guidPrefix;
         watt.guid.entityId = sedp_builtin_publications_secure_writer;
         watt.endpoint.persistence_guid = watt.guid;
-        watt.endpoint.unicastLocatorList = pdata->m_metatrafficUnicastLocatorList;
-        watt.endpoint.multicastLocatorList = pdata->m_metatrafficMulticastLocatorList;
+        mp_PDP->get_metatraffic_locators(watt.endpoint, *pdata);
         //watt.endpoint.remoteLocatorList = m_discovery.initialPeersList;
         watt.endpoint.reliabilityKind = RELIABLE;
         watt.endpoint.durabilityKind = TRANSIENT_LOCAL;
@@ -947,9 +927,7 @@ void EDPSimple::removeRemoteEndpoints(ParticipantProxyData* pdata)
         RemoteReaderAttributes ratt;
         ratt.guid.guidPrefix = pdata->m_guid.guidPrefix;
         ratt.guid.entityId = sedp_builtin_publications_secure_reader;
-        ratt.endpoint.unicastLocatorList = pdata->m_metatrafficUnicastLocatorList;
-        ratt.endpoint.multicastLocatorList = pdata->m_metatrafficMulticastLocatorList;
-        //ratt.endpoint.remoteLocatorList = m_discovery.initialPeersList;
+        mp_PDP->get_metatraffic_locators(ratt.endpoint, *pdata);
         ratt.endpoint.durabilityKind = TRANSIENT_LOCAL;
         ratt.endpoint.reliabilityKind = RELIABLE;
         if(publications_secure_writer_.first->matched_reader_remove(ratt))
@@ -970,9 +948,7 @@ void EDPSimple::removeRemoteEndpoints(ParticipantProxyData* pdata)
         watt.guid.guidPrefix = pdata->m_guid.guidPrefix;
         watt.guid.entityId = sedp_builtin_subscriptions_secure_writer;
         watt.endpoint.persistence_guid = watt.guid;
-        watt.endpoint.unicastLocatorList = pdata->m_metatrafficUnicastLocatorList;
-        watt.endpoint.multicastLocatorList = pdata->m_metatrafficMulticastLocatorList;
-        //watt.endpoint.remoteLocatorList = m_discovery.initialPeersList;
+        mp_PDP->get_metatraffic_locators(watt.endpoint, *pdata);
         watt.endpoint.reliabilityKind = RELIABLE;
         watt.endpoint.durabilityKind = TRANSIENT_LOCAL;
         if(subscriptions_secure_reader_.first->matched_writer_remove(watt))
@@ -991,9 +967,7 @@ void EDPSimple::removeRemoteEndpoints(ParticipantProxyData* pdata)
         RemoteReaderAttributes ratt;
         ratt.guid.guidPrefix = pdata->m_guid.guidPrefix;
         ratt.guid.entityId = sedp_builtin_subscriptions_secure_reader;
-        ratt.endpoint.unicastLocatorList = pdata->m_metatrafficUnicastLocatorList;
-        ratt.endpoint.multicastLocatorList = pdata->m_metatrafficMulticastLocatorList;
-        //ratt.endpoint.remoteLocatorList = m_discovery.initialPeersList;
+        mp_PDP->get_metatraffic_locators(ratt.endpoint, *pdata);
         ratt.endpoint.durabilityKind = TRANSIENT_LOCAL;
         ratt.endpoint.reliabilityKind = RELIABLE;
         if(subscriptions_secure_writer_.first->matched_reader_remove(ratt))

--- a/src/cpp/rtps/builtin/discovery/participant/PDPSimple.cpp
+++ b/src/cpp/rtps/builtin/discovery/participant/PDPSimple.cpp
@@ -176,9 +176,11 @@ void PDPSimple::initializeParticipantProxyData(ParticipantProxyData* participant
             participant_data->m_key.value[i] = participant_data->m_guid.entityId.value[i - 12];
     }
 
-
-    participant_data->m_metatrafficMulticastLocatorList = this->mp_builtin->m_metatrafficMulticastLocatorList;
-    participant_data->m_metatrafficUnicastLocatorList = this->mp_builtin->m_metatrafficUnicastLocatorList;
+    participant_data->m_metatrafficUnicastLocatorList = mp_builtin->m_metatrafficUnicastLocatorList;
+    if (!m_discovery.avoid_builtin_multicast || participant_data->m_metatrafficUnicastLocatorList.empty())
+    {
+        participant_data->m_metatrafficMulticastLocatorList = mp_builtin->m_metatrafficMulticastLocatorList;
+    }
 
     participant_data->m_participantName = std::string(mp_RTPSParticipant->getAttributes().getName());
 
@@ -260,6 +262,39 @@ bool PDPSimple::initPDP(RTPSParticipantImpl* part)
     mp_resendParticipantTimer = new ResendParticipantProxyDataPeriod(this, m_discovery);
 
     return true;
+}
+
+void PDPSimple::get_metatraffic_locators(
+        EndpointAttributes& destination,
+        const ParticipantProxyData& origin)
+{
+    destination.unicastLocatorList = origin.m_metatrafficUnicastLocatorList;
+    if (!m_discovery.avoid_builtin_multicast || destination.unicastLocatorList.empty())
+    {
+        destination.multicastLocatorList = origin.m_metatrafficMulticastLocatorList;
+    }
+}
+
+void PDPSimple::get_metatraffic_locators(
+        ReaderProxyData& destination,
+        const ParticipantProxyData& origin)
+{
+    destination.unicastLocatorList(origin.m_metatrafficUnicastLocatorList);
+    if (!m_discovery.avoid_builtin_multicast || destination.unicastLocatorList().empty())
+    {
+        destination.multicastLocatorList(origin.m_metatrafficMulticastLocatorList);
+    }
+}
+
+void PDPSimple::get_metatraffic_locators(
+        WriterProxyData& destination,
+        const ParticipantProxyData& origin)
+{
+    destination.unicastLocatorList(origin.m_metatrafficUnicastLocatorList);
+    if (!m_discovery.avoid_builtin_multicast || destination.unicastLocatorList().empty())
+    {
+        destination.multicastLocatorList(origin.m_metatrafficMulticastLocatorList);
+    }
 }
 
 void PDPSimple::stopParticipantAnnouncement()

--- a/src/cpp/rtps/security/SecurityManager.cpp
+++ b/src/cpp/rtps/security/SecurityManager.cpp
@@ -909,7 +909,10 @@ bool SecurityManager::create_participant_stateless_message_reader()
     ReaderAttributes ratt;
     ratt.endpoint.topicKind = NO_KEY;
     ratt.endpoint.reliabilityKind = BEST_EFFORT;
-    ratt.endpoint.multicastLocatorList = participant_->getRTPSParticipantAttributes().builtin.metatrafficMulticastLocatorList;
+    if (!participant_->getRTPSParticipantAttributes().builtin.avoid_builtin_multicast)
+    {
+        ratt.endpoint.multicastLocatorList = participant_->getRTPSParticipantAttributes().builtin.metatrafficMulticastLocatorList;
+    }
     ratt.endpoint.unicastLocatorList = participant_->getRTPSParticipantAttributes().builtin.metatrafficUnicastLocatorList;
     ratt.endpoint.remoteLocatorList = participant_->getRTPSParticipantAttributes().builtin.initialPeersList;
 


### PR DESCRIPTION
This PR addresses ros2/rmw_fastrtps#315 by allowing the user to disable multicast traffic for builtin endpoints.