### PR TITLE
Refs #6451 Added XML config option for avoid_builtin_multicast flag. [6452]

### DIFF
--- a/include/fastrtps/xmlparser/XMLParserCommon.h
+++ b/include/fastrtps/xmlparser/XMLParserCommon.h
@@ -226,6 +226,7 @@ extern const char* DOMAIN_ID;
 extern const char* LEASEDURATION;
 extern const char* LEASE_ANNOUNCE;
 extern const char* INITIAL_ANNOUNCEMENTS;
+extern const char* AVOID_BUILTIN_MULTICAST;
 extern const char* SIMPLE_EDP;
 extern const char* META_UNI_LOC_LIST;
 extern const char* META_MULTI_LOC_LIST;

--- a/resources/xsd/fastRTPS_profiles.xsd
+++ b/resources/xsd/fastRTPS_profiles.xsd
@@ -283,6 +283,7 @@
             <xs:element name="leaseDuration" type="durationType" minOccurs="0"/>
             <xs:element name="leaseAnnouncement" type="durationType" minOccurs="0"/>
             <xs:element name="initialAnnouncements" type="initialAnnouncementsType" minOccurs="0"/>
+            <xs:element name="avoid_builtin_multicast" type="boolType" minOccurs="0"/>
             <xs:element name="simpleEDP" type="simpleEDPType" minOccurs="0"/>
             <xs:element name="metatrafficUnicastLocatorList" type="locatorListType" minOccurs="0"/>
             <xs:element name="metatrafficMulticastLocatorList" type="locatorListType" minOccurs="0"/>

--- a/src/cpp/xmlparser/XMLElementParser.cpp
+++ b/src/cpp/xmlparser/XMLElementParser.cpp
@@ -121,6 +121,14 @@ XMLP_ret XMLParser::getXMLBuiltinAttributes(tinyxml2::XMLElement *elem, BuiltinA
             if (XMLP_ret::XML_OK != getXMLInitialAnnouncementsConfig(p_aux0, builtin.initial_announcements, ident))
                 return XMLP_ret::XML_ERROR;
         }
+        else if (strcmp(name, AVOID_BUILTIN_MULTICAST) == 0)
+        {
+            // avoid_builtin_multicast - boolType
+            if (XMLP_ret::XML_OK != getXMLBool(p_aux0, &builtin.avoid_builtin_multicast, ident))
+            {
+                return XMLP_ret::XML_ERROR;
+            }
+        }
         else if (strcmp(name, SIMPLE_EDP) == 0)
         {
             // simpleEDP
@@ -576,7 +584,7 @@ XMLP_ret XMLParser::getXMLContainerAllocationConfig(
             // maximum - uint32Type
             if (XMLP_ret::XML_OK != getXMLUint(p_aux0, &aux_value, ident))
                 return XMLP_ret::XML_ERROR;
-            allocation_config.maximum = (aux_value == 0u) ? 
+            allocation_config.maximum = (aux_value == 0u) ?
                 std::numeric_limits<size_t>::max() : static_cast<size_t>(aux_value);
         }
         else if (strcmp(name, INCREMENT) == 0)

--- a/src/cpp/xmlparser/XMLParserCommon.cpp
+++ b/src/cpp/xmlparser/XMLParserCommon.cpp
@@ -209,6 +209,7 @@ const char* DOMAIN_ID = "domainId";
 const char* LEASEDURATION = "leaseDuration";
 const char* LEASE_ANNOUNCE = "leaseAnnouncement";
 const char* INITIAL_ANNOUNCEMENTS = "initialAnnouncements";
+const char* AVOID_BUILTIN_MULTICAST = "avoid_builtin_multicast";
 const char* SIMPLE_EDP = "simpleEDP";
 const char* META_UNI_LOC_LIST = "metatrafficUnicastLocatorList";
 const char* META_MULTI_LOC_LIST = "metatrafficMulticastLocatorList";

--- a/test/unittest/xmlparser/XMLProfileParserTests.cpp
+++ b/test/unittest/xmlparser/XMLProfileParserTests.cpp
@@ -113,6 +113,7 @@ TEST_F(XMLProfileParserTests, XMLParserParcipant)
     EXPECT_EQ(builtin.initial_announcements.count, 2u);
     EXPECT_EQ(builtin.initial_announcements.period.seconds, 1);
     EXPECT_EQ(builtin.initial_announcements.period.nanosec, 827u);
+    EXPECT_FALSE(builtin.avoid_builtin_multicast);
     EXPECT_EQ(builtin.m_simpleEDP.use_PublicationWriterANDSubscriptionReader, false);
     EXPECT_EQ(builtin.m_simpleEDP.use_PublicationReaderANDSubscriptionWriter, true);
     IPLocator::setIPv4(locator, 192, 168, 1, 5);
@@ -182,6 +183,7 @@ TEST_F(XMLProfileParserTests, XMLParserDefaultParcipantProfile)
     EXPECT_EQ(builtin.leaseDuration, c_TimeInfinite);
     EXPECT_EQ(builtin.leaseDuration_announcementperiod.seconds, 10);
     EXPECT_EQ(builtin.leaseDuration_announcementperiod.nanosec, 333u);
+    EXPECT_FALSE(builtin.avoid_builtin_multicast);
     EXPECT_EQ(builtin.m_simpleEDP.use_PublicationWriterANDSubscriptionReader, false);
     EXPECT_EQ(builtin.m_simpleEDP.use_PublicationReaderANDSubscriptionWriter, true);
     IPLocator::setIPv4(locator, 192, 168, 1, 5);

--- a/test/unittest/xmlparser/test_xml_profiles.xml
+++ b/test/unittest/xmlparser/test_xml_profiles.xml
@@ -40,6 +40,7 @@
                         <nanosec>827</nanosec>
                     </period>
                 </initialAnnouncements>
+                <avoid_builtin_multicast>false</avoid_builtin_multicast>
                 <simpleEDP>
                     <PUBWRITER_SUBREADER>false</PUBWRITER_SUBREADER>
                     <PUBREADER_SUBWRITER>true</PUBREADER_SUBWRITER>

--- a/test/unittest/xmlparser/test_xml_profiles_rooted.xml
+++ b/test/unittest/xmlparser/test_xml_profiles_rooted.xml
@@ -34,6 +34,7 @@
                         <sec>10</sec>
                         <nanosec>333</nanosec>
                     </leaseAnnouncement>
+                    <avoid_builtin_multicast>false</avoid_builtin_multicast>
                     <simpleEDP>
                         <PUBWRITER_SUBREADER>false</PUBWRITER_SUBREADER>
                         <PUBREADER_SUBWRITER>true</PUBREADER_SUBWRITER>


### PR DESCRIPTION
This PR allows the user to disable the new flag to avoid choose multicast locators from the list received from remote participants.

* Updated *fastRTPS_profiles.xsd* reference file.
* Added parser logic for the new flag.
* Added the option and checks in `XMLParserTests`.