### PR TITLE
Adding avoid_multicast to PDP and WLP [6467]

### DIFF
--- a/src/cpp/rtps/builtin/discovery/participant/PDPSimple.cpp
+++ b/src/cpp/rtps/builtin/discovery/participant/PDPSimple.cpp
@@ -758,8 +758,7 @@ void PDPSimple::assignRemoteEndpoints(ParticipantProxyData* pdata)
         watt.guid.guidPrefix = pdata->m_guid.guidPrefix;
         watt.guid.entityId = c_EntityId_SPDPWriter;
         watt.endpoint.persistence_guid = watt.guid;
-        watt.endpoint.unicastLocatorList = pdata->m_metatrafficUnicastLocatorList;
-        watt.endpoint.multicastLocatorList = pdata->m_metatrafficMulticastLocatorList;
+        get_metatraffic_locators(watt.endpoint, *pdata);
         watt.endpoint.reliabilityKind = BEST_EFFORT;
         watt.endpoint.durabilityKind = TRANSIENT_LOCAL;
         mp_SPDPReader->matched_writer_add(watt);
@@ -772,8 +771,7 @@ void PDPSimple::assignRemoteEndpoints(ParticipantProxyData* pdata)
         ratt.expectsInlineQos = false;
         ratt.guid.guidPrefix = pdata->m_guid.guidPrefix;
         ratt.guid.entityId = c_EntityId_SPDPReader;
-        ratt.endpoint.unicastLocatorList = pdata->m_metatrafficUnicastLocatorList;
-        ratt.endpoint.multicastLocatorList = pdata->m_metatrafficMulticastLocatorList;
+        get_metatraffic_locators(ratt.endpoint, *pdata);
         ratt.endpoint.reliabilityKind = BEST_EFFORT;
         ratt.endpoint.durabilityKind = TRANSIENT_LOCAL;
         mp_SPDPWriter->matched_reader_add(ratt);

--- a/src/cpp/rtps/builtin/liveliness/WLP.cpp
+++ b/src/cpp/rtps/builtin/liveliness/WLP.cpp
@@ -383,8 +383,7 @@ bool WLP::assignRemoteEndpoints(const ParticipantProxyData& pdata)
         watt.guid.guidPrefix = pdata.m_guid.guidPrefix;
         watt.guid.entityId = c_EntityId_WriterLiveliness;
         watt.endpoint.persistence_guid = watt.guid;
-        watt.endpoint.unicastLocatorList = pdata.m_metatrafficUnicastLocatorList;
-        watt.endpoint.multicastLocatorList = pdata.m_metatrafficMulticastLocatorList;
+        mp_builtinProtocols->mp_PDP->get_metatraffic_locators(watt.endpoint, pdata);
         watt.endpoint.topicKind = WITH_KEY;
         watt.endpoint.durabilityKind = TRANSIENT_LOCAL;
         watt.endpoint.reliabilityKind = RELIABLE;
@@ -399,8 +398,7 @@ bool WLP::assignRemoteEndpoints(const ParticipantProxyData& pdata)
         ratt.expectsInlineQos = false;
         ratt.guid.guidPrefix = pdata.m_guid.guidPrefix;
         ratt.guid.entityId = c_EntityId_ReaderLiveliness;
-        ratt.endpoint.unicastLocatorList = pdata.m_metatrafficUnicastLocatorList;
-        ratt.endpoint.multicastLocatorList = pdata.m_metatrafficMulticastLocatorList;
+        mp_builtinProtocols->mp_PDP->get_metatraffic_locators(ratt.endpoint, pdata);
         ratt.endpoint.topicKind = WITH_KEY;
         ratt.endpoint.durabilityKind = TRANSIENT_LOCAL;
         ratt.endpoint.reliabilityKind = RELIABLE;
@@ -417,8 +415,7 @@ bool WLP::assignRemoteEndpoints(const ParticipantProxyData& pdata)
         watt.guid().guidPrefix = pdata.m_guid.guidPrefix;
         watt.guid().entityId = c_EntityId_WriterLivelinessSecure;
         watt.persistence_guid(watt.guid());
-        watt.unicastLocatorList(pdata.m_metatrafficUnicastLocatorList);
-        watt.multicastLocatorList(pdata.m_metatrafficMulticastLocatorList);
+        mp_builtinProtocols->mp_PDP->get_metatraffic_locators(watt, pdata);
         watt.topicKind(WITH_KEY);
         watt.m_qos.m_durability.kind = TRANSIENT_LOCAL_DURABILITY_QOS;
         watt.m_qos.m_reliability.kind = RELIABLE_RELIABILITY_QOS;
@@ -439,8 +436,7 @@ bool WLP::assignRemoteEndpoints(const ParticipantProxyData& pdata)
         ratt.m_expectsInlineQos = false;
         ratt.guid().guidPrefix = pdata.m_guid.guidPrefix;
         ratt.guid().entityId = c_EntityId_ReaderLivelinessSecure;
-        ratt.unicastLocatorList(pdata.m_metatrafficUnicastLocatorList);
-        ratt.multicastLocatorList(pdata.m_metatrafficMulticastLocatorList);
+        mp_builtinProtocols->mp_PDP->get_metatraffic_locators(ratt, pdata);
         ratt.m_qos.m_durability.kind = TRANSIENT_LOCAL_DURABILITY_QOS;
         ratt.m_qos.m_reliability.kind = RELIABLE_RELIABILITY_QOS;
         ratt.topicKind(WITH_KEY);

--- a/test/unittest/xmlparser/XMLProfileParserTests.cpp
+++ b/test/unittest/xmlparser/XMLProfileParserTests.cpp
@@ -183,6 +183,9 @@ TEST_F(XMLProfileParserTests, XMLParserDefaultParcipantProfile)
     EXPECT_EQ(builtin.leaseDuration, c_TimeInfinite);
     EXPECT_EQ(builtin.leaseDuration_announcementperiod.seconds, 10);
     EXPECT_EQ(builtin.leaseDuration_announcementperiod.nanosec, 333u);
+    EXPECT_EQ(builtin.initial_announcements.count, 2u);
+    EXPECT_EQ(builtin.initial_announcements.period.seconds, 1);
+    EXPECT_EQ(builtin.initial_announcements.period.nanosec, 827u);
     EXPECT_FALSE(builtin.avoid_builtin_multicast);
     EXPECT_EQ(builtin.m_simpleEDP.use_PublicationWriterANDSubscriptionReader, false);
     EXPECT_EQ(builtin.m_simpleEDP.use_PublicationReaderANDSubscriptionWriter, true);

--- a/test/unittest/xmlparser/test_xml_profiles_rooted.xml
+++ b/test/unittest/xmlparser/test_xml_profiles_rooted.xml
@@ -34,7 +34,14 @@
                         <sec>10</sec>
                         <nanosec>333</nanosec>
                     </leaseAnnouncement>
-                    <avoid_builtin_multicast>false</avoid_builtin_multicast>
+                  <initialAnnouncements>
+                    <count>2</count>
+                    <period>
+                      <sec>1</sec>
+                      <nanosec>827</nanosec>
+                    </period>
+                  </initialAnnouncements>
+                  <avoid_builtin_multicast>false</avoid_builtin_multicast>
                     <simpleEDP>
                         <PUBWRITER_SUBREADER>false</PUBWRITER_SUBREADER>
                         <PUBREADER_SUBWRITER>true</PUBREADER_SUBWRITER>


### PR DESCRIPTION
This will improve the communications between a participant without the avoid_multicast flag set and another participant with it.