### PR TITLE
Fixing memory leaks in some C++ examples [6485]

### DIFF
--- a/examples/C++/Configurability/UseCasePublisher.cpp
+++ b/examples/C++/Configurability/UseCasePublisher.cpp
@@ -299,5 +299,7 @@ int main(){
         }
     }
 
+    Domain::stopAll();
+
     return 0;
 }

--- a/examples/C++/Configurability/UseCaseSubscriber.cpp
+++ b/examples/C++/Configurability/UseCaseSubscriber.cpp
@@ -288,5 +288,7 @@ int main(){
         }
     }
 
+    Domain::stopAll();
+
     return 0;
 }

--- a/examples/C++/Keys/keys.cpp
+++ b/examples/C++/Keys/keys.cpp
@@ -252,6 +252,8 @@ void keys()
         std::cout << std::endl;
     }
     std::cout << std::endl;
+
+    Domain::stopAll();
 }
 
 void publisherKeys()

--- a/examples/C++/LateJoiners/latejoiners.cpp
+++ b/examples/C++/LateJoiners/latejoiners.cpp
@@ -131,4 +131,6 @@ void latejoiners(){
         std::cout << std::to_string(my_sample.index()) << " ";
     }
     std::cout << std::endl;
+
+    Domain::stopAll();
 }

--- a/examples/C++/SampleConfig_Controller/sampleconfig_safest.cpp
+++ b/examples/C++/SampleConfig_Controller/sampleconfig_safest.cpp
@@ -114,4 +114,5 @@ void safest(){
     }
     std::cout << std::endl;
 
+    Domain::stopAll();
 }

--- a/examples/C++/SampleConfig_Events/sampleconfig_triggers.cpp
+++ b/examples/C++/SampleConfig_Events/sampleconfig_triggers.cpp
@@ -113,4 +113,6 @@ void triggers(){
         std::cout << std::to_string(my_sample.index()) << " ";
     }
     std::cout << std::endl;
+
+    Domain::stopAll();
 }

--- a/examples/C++/SampleConfig_Multimedia/sampleconfig_fastest.cpp
+++ b/examples/C++/SampleConfig_Multimedia/sampleconfig_fastest.cpp
@@ -105,7 +105,5 @@ void fastest(){
     }
     std::cout << std::endl;
 
-
-
-
+    Domain::stopAll();
 }


### PR DESCRIPTION
I identified that the following C++ examples had memory leaks:

- Configurability
- Keys
- LateJoiners
- SampleConfig_Controller
- SampleConfig_Events
- SampleConfig_Multimedia