### PR TITLE
Fixing fastrtps installation [6487]

### DIFF
--- a/src/cpp/CMakeLists.txt
+++ b/src/cpp/CMakeLists.txt
@@ -380,6 +380,11 @@ set_public_headers_directory(${PROJECT_SOURCE_DIR}/include ${PROJECT_NAME}
     COMPONENT headers
     INSTALL
     )
+set_public_headers_directory(${PROJECT_SOURCE_DIR}/include fastdds
+    DESTINATION ${INCLUDE_INSTALL_DIR}
+    COMPONENT headers
+    INSTALL
+    )
 
 # Install config.h header
 set_public_header(${PROJECT_BINARY_DIR}/include ${PROJECT_NAME} config.h
@@ -406,6 +411,7 @@ set(CPACK_COMPONENT_HEADERS_DISPLAY_NAME "C++ Headers" PARENT_SCOPE)
 set(CPACK_COMPONENT_HEADERS_DESCRIPTION "eProsima ${PROJECT_NAME_LARGE} C++ Headers" PARENT_SCOPE)
 
 # Install sources
+
 if(UNIX AND EPROSIMA_INSTALLER)
     install(DIRECTORY ${PROJECT_SOURCE_DIR}/src/cpp
         DESTINATION src


### PR DESCRIPTION
Fixes #751 

To test this PR:

* Revert changes in this PR
* Install fastrtps in a local directory: `mkdir build && cd build && cmake ../ -DCMAKE_INSTALL_PREFIX=install/ && make install`
* Navigate to the source directory of one of the examples, for instance the `HelloWorld`, and build it: `mkdir build && cd build && cmake -DCMAKE_PREFIX_PATH=<dir>/install .. && make`

You should get errors about include files not being found.

Repeat the same steps with changes in this PR. You should now be able to build the `HelloWorld`.