### PR TITLE
Hotfix/member ref [6508]

### DIFF
--- a/include/fastrtps/publisher/PublisherHistory.h
+++ b/include/fastrtps/publisher/PublisherHistory.h
@@ -26,11 +26,10 @@
 #include <fastdds/rtps/history/WriterHistory.h>
 #include <fastrtps/qos/QosPolicies.h>
 #include <fastrtps/common/KeyedChanges.h>
+#include <fastrtps/attributes/TopicAttributes.h>
 
 namespace eprosima {
 namespace fastrtps {
-
-class TopicAttributes;
 
 /**
  * Class PublisherHistory, implementing a WriterHistory with support for keyed topics and HistoryQOS.
@@ -122,7 +121,7 @@ private:
     //!ResourceLimitsQosPolicy values.
     ResourceLimitsQosPolicy resource_limited_qos_;
     //!Topic Attributes
-    const TopicAttributes& topic_att_;
+    TopicAttributes topic_att_;
 
     /**
      * @brief Method that finds a key in m_keyedChanges or tries to add it if not found

--- a/include/fastrtps/subscriber/SubscriberHistory.h
+++ b/include/fastrtps/subscriber/SubscriberHistory.h
@@ -28,18 +28,13 @@
 #include <fastrtps/qos/QosPolicies.h>
 #include <fastrtps/common/KeyedChanges.h>
 #include <fastrtps/subscriber/SampleInfo.h>
+#include <fastrtps/attributes/TopicAttributes.h>
 
 #include <chrono>
 #include <functional>
 
 namespace eprosima {
 namespace fastrtps {
-
-namespace rtps{
-class WriterProxy;
-}
-
-class TopicAttributes;
 
 /**
  * Class SubscriberHistory, container of the different CacheChanges of a subscriber
@@ -137,11 +132,11 @@ class SubscriberHistory: public rtps::ReaderHistory
         //!ResourceLimitsQosPolicy values.
         ResourceLimitsQosPolicy resource_limited_qos_;
         //!Topic Attributes
-        const TopicAttributes& topic_att_;
+        TopicAttributes topic_att_;
         //!TopicDataType
         fastdds::dds::TopicDataType* type_;
         //!ReaderQos
-        const fastrtps::ReaderQos& qos_;
+        fastrtps::ReaderQos qos_;
 
         //!Type object to deserialize Key
         void* get_key_object_;
@@ -170,7 +165,7 @@ class SubscriberHistory: public rtps::ReaderHistory
                 t_m_Inst_Caches::iterator& map_it);
 
         /**
-         * @name Variants of incoming change processing. 
+         * @name Variants of incoming change processing.
          *       Will be called with the history mutex taken.
          * @param[in] change The received change
          * @param unknown_missing_changes_up_to Number of missing changes before this one

--- a/test/blackbox/PubSubReader.hpp
+++ b/test/blackbox/PubSubReader.hpp
@@ -253,7 +253,14 @@ public:
     void init()
     {
         participant_attr_.rtps.builtin.domainId = (uint32_t)GET_PID() % 230;
-        participant_ = eprosima::fastrtps::Domain::createParticipant(participant_attr_, &participant_listener_);
+
+        // Use local copies of attributes to catch #6507 issues with valgrind
+        eprosima::fastrtps::ParticipantAttributes participant_attr;
+        eprosima::fastrtps::SubscriberAttributes subscriber_attr;
+        participant_attr = participant_attr_;
+        subscriber_attr = subscriber_attr_;
+
+        participant_ = eprosima::fastrtps::Domain::createParticipant(participant_attr, &participant_listener_);
 
         ASSERT_NE(participant_, nullptr);
 
@@ -263,7 +270,7 @@ public:
         ASSERT_EQ(eprosima::fastrtps::Domain::registerType(participant_, &type_), true);
 
         //Create subscribe r
-        subscriber_ = eprosima::fastrtps::Domain::createSubscriber(participant_, subscriber_attr_, &listener_);
+        subscriber_ = eprosima::fastrtps::Domain::createSubscriber(participant_, subscriber_attr, &listener_);
         ASSERT_NE(subscriber_, nullptr);
 
         std::cout << "Created subscriber " << subscriber_->getGuid() << " for topic " <<

--- a/test/blackbox/PubSubWriter.hpp
+++ b/test/blackbox/PubSubWriter.hpp
@@ -260,7 +260,14 @@ class PubSubWriter
     {
         //Create participant
         participant_attr_.rtps.builtin.domainId = (uint32_t)GET_PID() % 230;
-        participant_ = eprosima::fastrtps::Domain::createParticipant(participant_attr_, &participant_listener_);
+
+        // Use local copies of attributes to catch #6507 issues with valgrind
+        eprosima::fastrtps::ParticipantAttributes participant_attr;
+        eprosima::fastrtps::PublisherAttributes publisher_attr;
+        participant_attr = participant_attr_;
+        publisher_attr = publisher_attr_;
+
+        participant_ = eprosima::fastrtps::Domain::createParticipant(participant_attr, &participant_listener_);
 
         if(participant_ != nullptr)
         {
@@ -270,7 +277,7 @@ class PubSubWriter
             eprosima::fastrtps::Domain::registerType(participant_, &type_);
 
             //Create publisher
-            publisher_ = eprosima::fastrtps::Domain::createPublisher(participant_, publisher_attr_, &listener_);
+            publisher_ = eprosima::fastrtps::Domain::createPublisher(participant_, publisher_attr, &listener_);
 
             if(publisher_ != nullptr)
             {


### PR DESCRIPTION
* This PR modifies the Blackbox tests to provide local copies of Participant, Subscriber, and Publisher attributes, to reproduce the issue and catch it with valgrind checks.
* Removes the `const reference` members in `PublisherHistory` and `SubscriberHistory` that caused the issue when these attributes went out of scope.

Fixes #758 