### PR TITLE
Refs #6569: Re-work throughput test to properly time [6575]

### DIFF
--- a/test/performance/ThroughputPublisher.h
+++ b/test/performance/ThroughputPublisher.h
@@ -131,8 +131,8 @@ class ThroughputPublisher
         bool dynamic_data = false;
         int m_forced_domain;
         // Static Data
-        ThroughputDataType* latency_t;
-        ThroughputType* latency;
+        ThroughputDataType* throughput_t;
+        ThroughputType* throughput;
         // Dynamic Data
         eprosima::fastrtps::types::DynamicData* m_DynData;
         eprosima::fastrtps::types::DynamicPubSubType m_DynType;


### PR DESCRIPTION
* ThroughputPublisher:
    * Members latency_t and latency renamed to throughput_t and throughput
    * The time spent recovering in included in the time measurements
    * If the subscriber does not acknowledge the TEST_ENDS, we return true, finishing the experiments.
    * Style compliance
* ThroughputSubscriber:
    * Style compliance
    * Move default in switch to the end
    * couts for improving console output readability
    * t_start_ after cout to avoid timing a time consuming operation
    * On TEST_ENDS, wait for data publisher removal