### PR TITLE
Refs #6557 Fixing helgrind issues.

### DIFF
--- a/include/fastdds/rtps/builtin/discovery/participant/PDP.h
+++ b/include/fastdds/rtps/builtin/discovery/participant/PDP.h
@@ -348,6 +348,8 @@ protected:
     std::mutex temp_data_lock_;
     //!Participant data atomic access assurance
     std::recursive_mutex* mp_mutex;
+    //!To protect callbacks (ParticipantProxyData&)
+    std::mutex callback_mtx_;
 
     /**
      * Adds an entry to the collection of participant proxy information.

--- a/src/cpp/rtps/builtin/discovery/participant/PDP.cpp
+++ b/src/cpp/rtps/builtin/discovery/participant/PDP.cpp
@@ -928,6 +928,7 @@ bool PDP::remove_remote_participant(
         auto listener =  mp_RTPSParticipant->getListener();
         if (listener != nullptr)
         {
+            std::lock_guard<std::mutex> lock(callback_mtx_);
             ParticipantDiscoveryInfo info(*pdata);
             info.status = reason;
             listener->onParticipantDiscovery(mp_RTPSParticipant->getUserRTPSParticipant(), std::move(info));

--- a/src/cpp/rtps/builtin/discovery/participant/PDPListener.cpp
+++ b/src/cpp/rtps/builtin/discovery/participant/PDPListener.cpp
@@ -149,6 +149,7 @@ void PDPListener::onNewCacheChangeAdded(
                 RTPSParticipantListener* listener = parent_pdp_->getRTPSParticipant()->getListener();
                 if (listener != nullptr)
                 {
+                    std::lock_guard<std::mutex> lock(parent_pdp_->callback_mtx_);
                     ParticipantDiscoveryInfo info(*pdata);
                     info.status = status;
 
@@ -164,10 +165,13 @@ void PDPListener::onNewCacheChangeAdded(
     }
     else
     {
+        reader->getMutex().unlock();
         if (parent_pdp_->remove_remote_participant(guid, ParticipantDiscoveryInfo::REMOVED_PARTICIPANT))
         {
+            reader->getMutex().lock();
             return; // all changes related with this participant have been removed from history by remove_remote_participant
         }
+        reader->getMutex().lock();
     }
 
     //Remove change form history.

--- a/src/cpp/rtps/builtin/discovery/participant/PDPListener.cpp
+++ b/src/cpp/rtps/builtin/discovery/participant/PDPListener.cpp
@@ -149,7 +149,7 @@ void PDPListener::onNewCacheChangeAdded(
                 RTPSParticipantListener* listener = parent_pdp_->getRTPSParticipant()->getListener();
                 if (listener != nullptr)
                 {
-                    std::lock_guard<std::mutex> lock(parent_pdp_->callback_mtx_);
+                    std::lock_guard<std::mutex> cb_lock(parent_pdp_->callback_mtx_);
                     ParticipantDiscoveryInfo info(*pdata);
                     info.status = status;
 

--- a/src/cpp/rtps/builtin/discovery/participant/PDPServerListener.cpp
+++ b/src/cpp/rtps/builtin/discovery/participant/PDPServerListener.cpp
@@ -152,6 +152,7 @@ void PDPServerListener::onNewCacheChangeAdded(
                 RTPSParticipantListener* listener = parent_pdp_->getRTPSParticipant()->getListener();
                 if (listener != nullptr)
                 {
+                    std::lock_guard<std::mutex> lock(parent_pdp_->callback_mtx_);
                     ParticipantDiscoveryInfo info(*pdata);
                     info.status = status;
 

--- a/src/cpp/rtps/builtin/discovery/participant/PDPServerListener.cpp
+++ b/src/cpp/rtps/builtin/discovery/participant/PDPServerListener.cpp
@@ -152,7 +152,7 @@ void PDPServerListener::onNewCacheChangeAdded(
                 RTPSParticipantListener* listener = parent_pdp_->getRTPSParticipant()->getListener();
                 if (listener != nullptr)
                 {
-                    std::lock_guard<std::mutex> lock(parent_pdp_->callback_mtx_);
+                    std::lock_guard<std::mutex> cb_lock(parent_pdp_->callback_mtx_);
                     ParticipantDiscoveryInfo info(*pdata);
                     info.status = status;
 

--- a/src/cpp/rtps/builtin/liveliness/WLPListener.cpp
+++ b/src/cpp/rtps/builtin/liveliness/WLPListener.cpp
@@ -109,6 +109,7 @@ void WLPListener::onNewCacheChangeAdded(
         return;
     }
 
+    history->getMutex()->unlock();
     if (mp_WLP->automatic_readers_)
     {
         mp_WLP->sub_liveliness_manager_->assert_liveliness(AUTOMATIC_LIVELINESS_QOS);
@@ -117,6 +118,9 @@ void WLPListener::onNewCacheChangeAdded(
     {
         mp_WLP->sub_liveliness_manager_->assert_liveliness(MANUAL_BY_PARTICIPANT_LIVELINESS_QOS);
     }
+    mp_WLP->mp_builtinProtocols->mp_PDP->getMutex()->unlock();
+    history->getMutex()->lock();
+    mp_WLP->mp_builtinProtocols->mp_PDP->getMutex()->lock();
     return;
 }
 

--- a/src/cpp/rtps/resources/ResourceEvent.cpp
+++ b/src/cpp/rtps/resources/ResourceEvent.cpp
@@ -54,7 +54,7 @@ ResourceEvent::~ResourceEvent()
     assert(back_ == nullptr);
 
     logInfo(RTPS_PARTICIPANT,"Removing event thread");
-    stop_ = true,
+    stop_.store(true);
     io_service_.stop();
 
     if (thread_.joinable())
@@ -94,7 +94,7 @@ bool ResourceEvent::register_timer_nts(TimedEventImpl* event)
 
 void ResourceEvent::unregister_timer(TimedEventImpl* event)
 {
-    assert(!stop_);
+    assert(!stop_.load());
 
     std::unique_lock<TimedMutex> lock(mutex_);
 
@@ -158,7 +158,7 @@ void ResourceEvent::notify(TimedEventImpl* event, const std::chrono::steady_cloc
 
 void ResourceEvent::run_io_service()
 {
-    while (!stop_)
+    while (!stop_.load())
     {
 #if ASIO_VERSION >= 101200
         io_service_.restart();

--- a/src/cpp/rtps/writer/StatefulWriter.cpp
+++ b/src/cpp/rtps/writer/StatefulWriter.cpp
@@ -800,13 +800,12 @@ bool StatefulWriter::matched_reader_remove(const GUID_t& reader_guid)
         periodic_hb_event_->cancel_timer();
     }
 
-    lock.unlock();
-
     if(rproxy != nullptr)
     {
         rproxy->stop();
         matched_readers_pool_.push_back(rproxy);
 
+        lock.unlock();
         check_acked_status();
 
         return true;

--- a/test/communication/Publisher.cpp
+++ b/test/communication/Publisher.cpp
@@ -36,13 +36,13 @@
 using namespace eprosima::fastrtps;
 using namespace eprosima::fastrtps::rtps;
 
-bool run = true;
+static bool run = true;
 
 class ParListener : public ParticipantListener
 {
     public:
-        ParListener(bool exit_on_lost_liveliness) : exit_on_lost_liveliness_(exit_on_lost_liveliness) {};
-        virtual ~ParListener(){};
+        ParListener(bool exit_on_lost_liveliness) : exit_on_lost_liveliness_(exit_on_lost_liveliness) {}
+        virtual ~ParListener() override {}
 
         /**
          * This method is called when a new Participant is discovered, or a previously discovered participant


### PR DESCRIPTION
This PR fixes most data races and ABBA locks reported by *helgrind*.

There exists a detected ABBA lock between reader's and WLP's mutexes that can be solved by commenting out the line 976 of WLP.cpp, but then some liveliness tests time out or fail.
We will address a better solution for that issue in the future.