### PR TITLE
Improvements on check_acked_status [6612]

### DIFF
--- a/src/cpp/rtps/writer/StatefulWriter.cpp
+++ b/src/cpp/rtps/writer/StatefulWriter.cpp
@@ -901,13 +901,15 @@ void StatefulWriter::check_acked_status()
     std::unique_lock<RecursiveTimedMutex> lock(mp_mutex);
 
     bool all_acked = true;
+    bool has_min_low_mark = false;
     SequenceNumber_t min_low_mark;
 
     for(const ReaderProxy* it : matched_readers_)
     {
         SequenceNumber_t reader_low_mark = it->changes_low_mark();
-        if(min_low_mark == SequenceNumber_t() || reader_low_mark < min_low_mark)
+        if(reader_low_mark < min_low_mark || !has_min_low_mark)
         {
+            has_min_low_mark = true;
             min_low_mark = reader_low_mark;
         }
 

--- a/src/cpp/rtps/writer/StatefulWriter.cpp
+++ b/src/cpp/rtps/writer/StatefulWriter.cpp
@@ -924,21 +924,29 @@ void StatefulWriter::check_acked_status()
         // Inform of samples acked.
         if(mp_listener != nullptr)
         {
-            for(SequenceNumber_t current_seq = next_all_acked_notify_sequence_; current_seq <= min_low_mark; ++current_seq)
+            // In the case where we haven't received an acknack from a recently matched reader,
+            // min_low_mark will be zero, and no change will be notified as received by all
+            SequenceNumber_t current_seq;
+            for(current_seq = next_all_acked_notify_sequence_; current_seq <= min_low_mark; ++current_seq)
             {
                 std::vector<CacheChange_t*>::iterator history_end = mp_history->changesEnd();
-                std::vector<CacheChange_t*>::iterator cit = std::lower_bound(mp_history->changesBegin(), history_end, current_seq,
-                    [](const CacheChange_t* change, const SequenceNumber_t& seq)
-                    {
-                        return change->sequenceNumber < seq;
-                    });
+                std::vector<CacheChange_t*>::iterator cit =
+                    std::lower_bound(mp_history->changesBegin(), history_end, current_seq,
+                        [](
+                                const CacheChange_t* change,
+                                const SequenceNumber_t& seq)
+                        {
+                            return change->sequenceNumber < seq;
+                        });
                 if(cit != history_end && (*cit)->sequenceNumber == current_seq)
                 {
                     mp_listener->onWriterChangeReceivedByAll(this, *cit);
                 }
             }
 
-            next_all_acked_notify_sequence_ = min_low_mark + 1;
+            // This will change next_all_acked_notify_sequence_ to min_low_mark + 1 on the most usual case.
+            // On the special case where an acknack has not been received for a reader, it will remain unchanged.
+            next_all_acked_notify_sequence_ = current_seq;
         }
 
         SequenceNumber_t calc = min_low_mark < get_seq_num_min() ? SequenceNumber_t() :

--- a/src/cpp/rtps/writer/StatefulWriter.cpp
+++ b/src/cpp/rtps/writer/StatefulWriter.cpp
@@ -949,9 +949,7 @@ void StatefulWriter::check_acked_status()
             next_all_acked_notify_sequence_ = current_seq;
         }
 
-        SequenceNumber_t calc = min_low_mark < get_seq_num_min() ? SequenceNumber_t() :
-            (min_low_mark - get_seq_num_min()) + 1;
-        if (calc > SequenceNumber_t())
+        if (min_low_mark >= get_seq_num_min())
         {
             may_remove_change_ = 1;
             may_remove_change_cond_.notify_one();


### PR DESCRIPTION
This should fix #747 improving the edge case where check_acked_status is called between a reader being matched and reception of its acknack message