### PR TITLE
DDS::SampleInfo Implementation. [6617]

### DIFF
--- a/examples/C++/DDS/DynamicHelloWorldExample/HelloWorldSubscriber.cpp
+++ b/examples/C++/DDS/DynamicHelloWorldExample/HelloWorldSubscriber.cpp
@@ -89,9 +89,9 @@ void HelloWorldSubscriber::SubListener::on_data_available(
     if (dit != subscriber_->datas_.end())
     {
         eprosima::fastrtps::types::DynamicData_ptr data = dit->second;
-        if (reader->take_next_sample(data.get(), &m_info))
+        if (reader->take_next_sample(data.get(), &info_))
         {
-            if (m_info.sampleKind == eprosima::fastrtps::rtps::ALIVE)
+            if (info_.instance_state == ::dds::sub::status::InstanceState::alive())
             {
                 eprosima::fastrtps::types::DynamicType_ptr type = subscriber_->readers_[reader];
                 this->n_samples++;

--- a/examples/C++/DDS/DynamicHelloWorldExample/HelloWorldSubscriber.h
+++ b/examples/C++/DDS/DynamicHelloWorldExample/HelloWorldSubscriber.h
@@ -24,8 +24,8 @@
 #include <fastdds/dds/domain/DomainParticipantListener.hpp>
 #include <fastdds/dds/topic/DataReader.hpp>
 #include <fastdds/dds/topic/DataReaderListener.hpp>
+#include <fastdds/dds/subscriber/SampleInfo.hpp>
 #include <fastrtps/fastrtps_fwd.h>
-#include <fastrtps/subscriber/SampleInfo.h>
 #include <fastrtps/rtps/common/Types.h>
 
 #include <fastrtps/types/DynamicPubSubType.h>
@@ -82,7 +82,7 @@ public:
                 const eprosima::fastrtps::types::TypeObject* object,
                 eprosima::fastrtps::types::DynamicType_ptr dyn_type) override;
 
-        eprosima::fastrtps::SampleInfo_t m_info;
+        eprosima::fastdds::dds::SampleInfo_t info_;
         int n_matched;
         uint32_t n_samples;
         HelloWorldSubscriber* subscriber_;

--- a/examples/C++/DDS/HelloWorldExample/HelloWorldSubscriber.cpp
+++ b/examples/C++/DDS/HelloWorldExample/HelloWorldSubscriber.cpp
@@ -104,7 +104,7 @@ void HelloWorldSubscriber::SubListener::on_data_available(
 {
     if (reader->take_next_sample(&hello_, &info_))
     {
-        if (info_.sampleKind == eprosima::fastrtps::rtps::ALIVE)
+        if (info_.instance_state == ::dds::sub::status::InstanceState::alive())
         {
             samples_++;
             // Print your structure data here.

--- a/examples/C++/DDS/HelloWorldExample/HelloWorldSubscriber.h
+++ b/examples/C++/DDS/HelloWorldExample/HelloWorldSubscriber.h
@@ -24,7 +24,7 @@
 
 #include <fastdds/dds/domain/DomainParticipant.hpp>
 #include <fastdds/dds/topic/DataReaderListener.hpp>
-#include <fastrtps/subscriber/SampleInfo.h>
+#include <fastdds/dds/subscriber/SampleInfo.hpp>
 #include <fastdds/dds/core/status/SubscriptionMatchedStatus.hpp>
 
 class HelloWorldSubscriber
@@ -72,7 +72,7 @@ private:
 
         HelloWorld hello_;
 
-        eprosima::fastrtps::SampleInfo_t info_;
+        eprosima::fastdds::dds::SampleInfo_t info_;
 
         int matched_;
 

--- a/include/dds/core/detail/macros.hpp
+++ b/include/dds/core/detail/macros.hpp
@@ -18,6 +18,8 @@
 #ifndef EPROSIMA_DDS_CORE_DETAIL_MACROS_HPP_
 #define EPROSIMA_DDS_CORE_DETAIL_MACROS_HPP_
 
+#include <fastrtps/fastrtps_dll.h>
+
 #include <iostream>
 
 // Constants
@@ -35,12 +37,7 @@
 // ==========================================================================
 
 
-// DLL Export Macros
-#ifdef _WIN32 // This is defined for 32/64 bit Windows
-#define OMG_DDS_API_DETAIL __declspec(dllexport)
-#else
-#define OMG_DDS_API_DETAIL
-#endif
+#define OMG_DDS_API_DETAIL RTPS_DllAPI
 // ==========================================================================
 
 

--- a/include/dds/sub/status/DataState.hpp
+++ b/include/dds/sub/status/DataState.hpp
@@ -62,7 +62,10 @@ public:
     /**
      * Construct a SampleState with default MaskType.
      */
-    SampleState();
+    SampleState()
+        : std::bitset<OMG_DDS_STATE_BIT_COUNT>()
+    {
+    }
 
     /**
      * Construct a SampleState with MaskType of i.
@@ -70,7 +73,10 @@ public:
      * @param i MaskType
      */
     explicit SampleState(
-            uint32_t i);
+            uint32_t i)
+        : std::bitset<OMG_DDS_STATE_BIT_COUNT>(i)
+    {
+    }
 
     /**
      * Copy constructor.
@@ -79,7 +85,10 @@ public:
      * @param src the SampleState to copy from
      */
     SampleState(
-            const SampleState& src);
+            const SampleState& src)
+        : std::bitset<OMG_DDS_STATE_BIT_COUNT>(src)
+    {
+    }
 
     /**
      * Construct a SampleState with existing MaskType.
@@ -87,7 +96,10 @@ public:
      * @param src the MaskType to copy from
      */
     SampleState(
-            const MaskType& src);
+            const MaskType& src)
+        : std::bitset<OMG_DDS_STATE_BIT_COUNT>(src)
+    {
+    }
 
     /**
      * Get the READ_SAMPLE_STATE.
@@ -99,7 +111,10 @@ public:
      *
      * @return the read SampleState
      */
-    inline static const SampleState read();
+    inline static const SampleState read()
+    {
+        return SampleState(0x0001 << 0u);
+    }
 
     /**
      * Get the NOT_READ_SAMPLE_STATE.
@@ -109,7 +124,10 @@ public:
      *
      * @return the not_read SampleState
      */
-    inline static const SampleState not_read();
+    inline static const SampleState not_read()
+    {
+        return SampleState(0x0001 << 1u);
+    }
 
     /**
      * Get any SampleState.
@@ -118,7 +136,10 @@ public:
      *
      * @return any SampleState
      */
-    inline static const SampleState any();
+    inline static const SampleState any()
+    {
+        return SampleState(0xffff);
+    }
 };
 
 /**
@@ -150,7 +171,10 @@ public:
     /**
      * Construct a ViewState with default MaskType.
      */
-    ViewState();
+    ViewState()
+        : std::bitset<OMG_DDS_STATE_BIT_COUNT>()
+    {
+    }
 
     /**
      * Construct a ViewState with MaskType of i.
@@ -158,7 +182,10 @@ public:
      * @param m the MaskType
      */
     explicit ViewState(
-            uint32_t m);
+            uint32_t m)
+        : std::bitset<OMG_DDS_STATE_BIT_COUNT>(m)
+    {
+    }
 
     /**
      * Copy constructor.
@@ -168,7 +195,10 @@ public:
      * @param src the ViewState to copy from
      */
     ViewState(
-            const ViewState& src);
+            const ViewState& src)
+        : std::bitset<OMG_DDS_STATE_BIT_COUNT>(src)
+    {
+    }
 
     /**
      * Construct a ViewState with existing MaskType.
@@ -176,7 +206,10 @@ public:
      * @param src the MaskType to copy from
      */
     ViewState(
-            const MaskType& src);
+            const MaskType& src)
+        : std::bitset<OMG_DDS_STATE_BIT_COUNT>(src)
+    {
+    }
 
     /**
      * Get the NEW_VIEW_STATE.
@@ -189,7 +222,10 @@ public:
      *
      * @return the new_view ViewState
      */
-    inline static const ViewState new_view();
+    inline static const ViewState new_view()
+    {
+        return ViewState(0x0001 << 0u);
+    }
 
     /**
      * Get the NOT_NEW_VIEW_STATE.
@@ -200,7 +236,10 @@ public:
      *
      * @return the not_new_view ViewState
      */
-    inline static const ViewState not_new_view();
+    inline static const ViewState not_new_view()
+    {
+        return ViewState(0x0001 << 1u);
+    }
 
     /**
      * Get any ViewState.
@@ -209,7 +248,10 @@ public:
      *
      * @return the any ViewState
      */
-    inline static const ViewState any();
+    inline static const ViewState any()
+    {
+        return ViewState(0xffff);
+    }
 
 };
 
@@ -250,7 +292,10 @@ public:
     /**
      * Construct an InstanceState with no state flags set.
      */
-    InstanceState();
+    InstanceState()
+        : std::bitset<OMG_DDS_STATE_BIT_COUNT>()
+    {
+    }
 
     /**
      * Construct an InstanceState with an uint32_t m, representing a bit array.
@@ -258,7 +303,10 @@ public:
      * @param m the bit array to initialize the bitset with
      */
     explicit InstanceState(
-            uint32_t m);
+            uint32_t m)
+        : std::bitset<OMG_DDS_STATE_BIT_COUNT>(m)
+    {
+    }
 
     /**
      * Copy constructor.
@@ -268,7 +316,10 @@ public:
      * @param src the InstanceState to copy from
      */
     InstanceState(
-            const InstanceState& src);
+            const InstanceState& src)
+        : std::bitset<OMG_DDS_STATE_BIT_COUNT>(src)
+    {
+    }
 
     /**
      * Construct an InstanceState with existing MaskType.
@@ -276,7 +327,10 @@ public:
      * @param src the bitset to copy from
      */
     InstanceState(
-            const MaskType& src);
+            const MaskType& src)
+        : std::bitset<OMG_DDS_STATE_BIT_COUNT>(src)
+    {
+    }
 
     /**
      * Get ALIVE_INSTANCE_STATE.
@@ -289,7 +343,10 @@ public:
      *
      * @return the alive InstanceState
      */
-    inline static const InstanceState alive();
+    inline static const InstanceState alive()
+    {
+        return InstanceState(0x0001 << 0u);
+    }
 
     /**
      * Get NOT_ALIVE_DISPOSED_INSTANCE_STATE.
@@ -304,7 +361,10 @@ public:
      *
      * @return the not_alive_disposed InstanceState
      */
-    inline static const InstanceState not_alive_disposed();
+    inline static const InstanceState not_alive_disposed()
+    {
+        return InstanceState(0x0001 << 1u);
+    }
 
     /**
      * Get NOT_ALIVE_NO_WRITERS_INSTANCE_STATE.
@@ -316,7 +376,10 @@ public:
      *
      * @return the not_alive_no_writers InstanceState
      */
-    inline static const InstanceState not_alive_no_writers();
+    inline static const InstanceState not_alive_no_writers()
+    {
+        return InstanceState(0x0001 << 2u);
+    }
 
     /**
      * Get not_alive mask
@@ -336,7 +399,10 @@ public:
      *
      * @return the not_alive_mask InstanceState
      */
-    inline static const InstanceState not_alive_mask();
+    inline static const InstanceState not_alive_mask()
+    {
+        return not_alive_disposed() | not_alive_no_writers();
+    }
 
     /**
      * Get any InstanceState.
@@ -345,7 +411,10 @@ public:
      *
      * @return the any InstanceState
      */
-    inline static const InstanceState any();
+    inline static const InstanceState any()
+    {
+        return InstanceState(0xffff);
+    }
 
 };
 

--- a/include/fastdds/dds/subscriber/SampleInfo.hpp
+++ b/include/fastdds/dds/subscriber/SampleInfo.hpp
@@ -1,0 +1,90 @@
+// Copyright 2019 Proyectos y Sistemas de Mantenimiento SL (eProsima).
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+/**
+ * @file SampleInfo.hpp
+ */
+
+#ifndef _FASTDDS_SAMPLEINFO_HPP_
+#define _FASTDDS_SAMPLEINFO_HPP_
+
+#include <cstdint>
+
+#include <fastrtps/fastrtps_dll.h>
+
+#include <fastdds/rtps/common/Time_t.h>
+#include <fastdds/rtps/common/InstanceHandle.h>
+
+#include <dds/sub/status/DataState.hpp>
+
+namespace eprosima {
+namespace fastdds {
+namespace dds {
+
+/**
+ * Class SampleInfo_t with information that is provided along a sample when reading data from a Subscriber.
+ * @ingroup FASTDDS_MODULE
+ */
+class RTPS_DllAPI SampleInfo_t
+{
+public:
+
+    SampleInfo_t()
+    {
+    }
+
+    virtual ~SampleInfo_t()
+    {
+    }
+
+    //!READ/NOT_READ.
+    ::dds::sub::status::SampleState sample_state;
+
+    //!NEW/NOT_NEW.
+    ::dds::sub::status::ViewState view_state;
+
+    //!ALIVE/NOT_ALIVE_DISPOSED/NOT_ALIVE_NO_WRITERS.
+    ::dds::sub::status::InstanceState instance_state;
+
+    //!Times sample become ALIVE when it was received.
+    int32_t disposed_generation_count = 0;
+
+    //!Times sample become ALIVE when it was received.
+    int32_t no_writers_generation_count = 0;
+
+    //!Preview of the samples that follow within the sequence returned by the read or take operations.
+    int32_t sample_rank = 0;
+
+    //!Preview of the samples that follow within the sequence returned by the read or take operations.
+    int32_t generation_rank = 0;
+
+    //!Preview of what is available within DataReader.
+    int32_t absolute_generation_rank = 0;
+
+    //!Timestamp provided by the DataWriter at the time the sample was produced.
+    fastrtps::Time_t source_timestamp;
+
+    fastrtps::rtps::InstanceHandle_t instance_handle;
+
+    fastrtps::rtps::InstanceHandle_t publication_handle;
+
+    // The sample has data associated.
+    bool valid_data = false;
+};
+
+} /* namespace dds */
+} /* namespace fastdds */
+} /* namespace eprosima */
+
+#endif /* _FASTDDS_SAMPLEINFO_HPP_ */

--- a/include/fastdds/dds/topic/DataReader.hpp
+++ b/include/fastdds/dds/topic/DataReader.hpp
@@ -41,8 +41,6 @@ struct GUID_t;
 struct InstanceHandle_t;
 } // namespace rtps
 
-class SampleInfo_t;
-
 } // namespace fastrtps
 
 namespace fastdds {
@@ -55,6 +53,7 @@ class DataReaderListener;
 class TypeSupport;
 class ReaderQos;
 struct LivelinessChangedStatus;
+class SampleInfo_t;
 
 /**
  * Class DataReader, contains the actual implementation of the behaviour of the Subscriber.
@@ -90,24 +89,24 @@ public:
     /* TODO
        bool read(
             std::vector<void*>& data_values,
-            std::vector<fastrtps::SampleInfo_t>& sample_infos,
+            std::vector<SampleInfo_t>& sample_infos,
             uint32_t max_samples);
      */
 
     ReturnCode_t read_next_sample(
             void* data,
-            fastrtps::SampleInfo_t* info);
+            SampleInfo_t* info);
 
     /* TODO
        bool take(
             std::vector<void*>& data_values,
-            std::vector<fastrtps::SampleInfo_t>& sample_infos,
+            std::vector<SampleInfo_t>& sample_infos,
             uint32_t max_samples);
      */
 
     ReturnCode_t take_next_sample(
             void* data,
-            fastrtps::SampleInfo_t* info);
+            SampleInfo_t* info);
 
     ///@}
 

--- a/src/cpp/dds/topic/DataReader.cpp
+++ b/src/cpp/dds/topic/DataReader.cpp
@@ -20,7 +20,6 @@
 #include <fastdds/dds/topic/DataReader.hpp>
 #include <dds/topic/DataReaderImpl.hpp>
 
-
 namespace eprosima {
 
 using namespace fastrtps;

--- a/src/cpp/dds/topic/DataReaderImpl.hpp
+++ b/src/cpp/dds/topic/DataReaderImpl.hpp
@@ -46,8 +46,6 @@ class TimedEvent;
 
 } // namespace rtps
 
-class SampleInfo_t;
-
 } // namespace fastrtps
 
 namespace fastdds {
@@ -55,6 +53,7 @@ namespace dds {
 
 class Subscriber;
 class SubscriberImpl;
+class SampleInfo_t;
 
 /**
  * Class DataReader, contains the actual implementation of the behaviour of the Subscriber.
@@ -94,24 +93,24 @@ public:
     /* TODO
     bool read(
             std::vector<void*>& data_values,
-            std::vector<fastrtps::SampleInfo_t>& sample_infos,
+            std::vector<SampleInfo_t>& sample_infos,
             uint32_t max_samples);
     */
 
     ReturnCode_t read_next_sample(
             void* data,
-            fastrtps::SampleInfo_t* info);
+            SampleInfo_t* info);
 
     /* TODO
     bool take(
             std::vector<void*>& data_values,
-            std::vector<fastrtps::SampleInfo_t>& sample_infos,
+            std::vector<SampleInfo_t>& sample_infos,
             uint32_t max_samples);
     */
 
     ReturnCode_t take_next_sample(
             void* data,
-            fastrtps::SampleInfo_t* info);
+            SampleInfo_t* info);
 
     ///@}
 

--- a/test/xtypes/TestSubscriber.cpp
+++ b/test/xtypes/TestSubscriber.cpp
@@ -218,9 +218,9 @@ void TestSubscriber::SubListener::on_subscription_matched(
 void TestSubscriber::SubListener::on_data_available(
         eprosima::fastdds::dds::DataReader* reader)
 {
-    if (reader->take_next_sample(mParent->m_Data, &m_info))
+    if (reader->take_next_sample(mParent->m_Data, &info_))
     {
-        if (m_info.sampleKind == ALIVE)
+        if (info_.instance_state == ::dds::sub::status::InstanceState::alive())
         {
             ++n_samples;
             mParent->cv_.notify_one();

--- a/test/xtypes/TestSubscriber.h
+++ b/test/xtypes/TestSubscriber.h
@@ -27,7 +27,7 @@
 #include <fastdds/dds/topic/DataReaderListener.hpp>
 #include <fastdds/dds/topic/DataReader.hpp>
 #include <fastdds/dds/topic/TypeSupport.hpp>
-#include <fastrtps/subscriber/SampleInfo.h>
+#include <fastdds/dds/subscriber/SampleInfo.hpp>
 #include <fastrtps/types/TypeObjectFactory.h>
 #include <fastrtps/rtps/common/Types.h>
 
@@ -142,7 +142,7 @@ public:
         void on_data_available(eprosima::fastdds::dds::DataReader* reader) override;
 
         TestSubscriber* mParent;
-        eprosima::fastrtps::SampleInfo_t m_info;
+        eprosima::fastdds::dds::SampleInfo_t info_;
         int n_matched;
         uint32_t n_samples;
     }m_subListener;


### PR DESCRIPTION
Implementation of SampleInfo_t.
Includes an example conversion between both SampleInfo_t structs, that must be refined once SubscriberHistory migrates.