### PR TITLE
Remove fragment state vector on CacheChange_t [6623]

### DIFF
--- a/include/fastdds/rtps/common/CacheChange.h
+++ b/include/fastdds/rtps/common/CacheChange.h
@@ -28,462 +28,492 @@
 
 #include <vector>
 
-namespace eprosima
-{
-    namespace fastrtps
-    {
-        namespace rtps
-        {
-            /**
-             * @enum ChangeKind_t, different types of CacheChange_t.
-             * @ingroup COMMON_MODULE
-             */
+namespace eprosima {
+namespace fastrtps {
+namespace rtps {
+/**
+ * @enum ChangeKind_t, different types of CacheChange_t.
+ * @ingroup COMMON_MODULE
+ */
 #if defined(_WIN32)
-            enum RTPS_DllAPI ChangeKind_t{
+enum RTPS_DllAPI ChangeKind_t
+{
 #else
-            enum ChangeKind_t{
+enum ChangeKind_t
+{
 #endif
-                ALIVE,                //!< ALIVE
-                NOT_ALIVE_DISPOSED,   //!< NOT_ALIVE_DISPOSED
-                NOT_ALIVE_UNREGISTERED,//!< NOT_ALIVE_UNREGISTERED
-                NOT_ALIVE_DISPOSED_UNREGISTERED //!<NOT_ALIVE_DISPOSED_UNREGISTERED
-            };
+    ALIVE,                            //!< ALIVE
+    NOT_ALIVE_DISPOSED,               //!< NOT_ALIVE_DISPOSED
+    NOT_ALIVE_UNREGISTERED,            //!< NOT_ALIVE_UNREGISTERED
+    NOT_ALIVE_DISPOSED_UNREGISTERED             //!<NOT_ALIVE_DISPOSED_UNREGISTERED
+};
 
-            enum ChangeFragmentStatus_t
-            {
-                NOT_PRESENT = 0,
-                PRESENT = 1
-            };
+enum ChangeFragmentStatus_t
+{
+    NOT_PRESENT = 0,
+    PRESENT = 1
+};
 
-            /**
-             * Structure CacheChange_t, contains information on a specific CacheChange.
-             * @ingroup COMMON_MODULE
-             */
-            struct RTPS_DllAPI CacheChange_t
-            {
-                //!Kind of change, default value ALIVE.
-                ChangeKind_t kind;
-                //!GUID_t of the writer that generated this change.
-                GUID_t writerGUID;
-                //!Handle of the data associated wiht this change.
-                InstanceHandle_t instanceHandle;
-                //!SequenceNumber of the change
-                SequenceNumber_t sequenceNumber;
-                //!Serialized Payload associated with the change.
-                SerializedPayload_t serializedPayload;
-                //!Indicates if the cache has been read (only used in READERS)
-                bool isRead;
-                //!Source TimeStamp (only used in Readers)
-                Time_t sourceTimestamp;
+/**
+ * Structure CacheChange_t, contains information on a specific CacheChange.
+ * @ingroup COMMON_MODULE
+ */
+struct RTPS_DllAPI CacheChange_t
+{
+    //!Kind of change, default value ALIVE.
+    ChangeKind_t kind;
+    //!GUID_t of the writer that generated this change.
+    GUID_t writerGUID;
+    //!Handle of the data associated wiht this change.
+    InstanceHandle_t instanceHandle;
+    //!SequenceNumber of the change
+    SequenceNumber_t sequenceNumber;
+    //!Serialized Payload associated with the change.
+    SerializedPayload_t serializedPayload;
+    //!Indicates if the cache has been read (only used in READERS)
+    bool isRead;
+    //!Source TimeStamp (only used in Readers)
+    Time_t sourceTimestamp;
 
-                WriteParams write_params;
-                bool is_untyped_;
+    WriteParams write_params;
+    bool is_untyped_;
 
-                /*!
-                 * @brief Default constructor.
-                 * Creates an empty CacheChange_t.
-                 */
-                CacheChange_t():
-                    kind(ALIVE),
-                    isRead(false),
-                    is_untyped_(true),
-                    dataFragments_(new std::vector<uint32_t>()),
-                    fragment_size_(0)
-                {
-                }
+    /*!
+     * @brief Default constructor.
+     * Creates an empty CacheChange_t.
+     */
+    CacheChange_t()
+        : kind(ALIVE)
+        , isRead(false)
+        , is_untyped_(true)
+        , dataFragments_(new std::vector<uint32_t>())
+        , fragment_size_(0)
+    {
+    }
 
-                CacheChange_t(const CacheChange_t&) = delete;
-                const CacheChange_t& operator=(const CacheChange_t&) = delete;
+    CacheChange_t(
+            const CacheChange_t&) = delete;
+    const CacheChange_t& operator=(
+            const CacheChange_t&) = delete;
 
-                /**
-                 * Constructor with payload size
-                 * @param payload_size Serialized payload size
-                 * @param is_untyped Flag to mark the change as untyped.
-                 */
-                // TODO Check pass uint32_t to serializedPayload that needs int16_t.
-                CacheChange_t(
-                        uint32_t payload_size,
-                        bool is_untyped = false):
-                    kind(ALIVE),
-                    serializedPayload(payload_size),
-                    isRead(false),
-                    is_untyped_(is_untyped),
-                    dataFragments_(new std::vector<uint32_t>()),
-                    fragment_size_(0)
-                {
-                }
+    /**
+     * Constructor with payload size
+     * @param payload_size Serialized payload size
+     * @param is_untyped Flag to mark the change as untyped.
+     */
+    // TODO Check pass uint32_t to serializedPayload that needs int16_t.
+    CacheChange_t(
+            uint32_t payload_size,
+            bool is_untyped = false)
+        : kind(ALIVE)
+        , serializedPayload(payload_size)
+        , isRead(false)
+        , is_untyped_(is_untyped)
+        , dataFragments_(new std::vector<uint32_t>())
+        , fragment_size_(0)
+    {
+    }
 
-                /*!
-                 * Copy a different change into this one. All the elements are copied, included the data, allocating new memory.
-                 * @param[in] ch_ptr Pointer to the change.
-                 * @return True if correct.
-                 */
-                bool copy(const CacheChange_t* ch_ptr)
-                {
-                    kind = ch_ptr->kind;
-                    writerGUID = ch_ptr->writerGUID;
-                    instanceHandle = ch_ptr->instanceHandle;
-                    sequenceNumber = ch_ptr->sequenceNumber;
-                    sourceTimestamp = ch_ptr->sourceTimestamp;
-                    write_params = ch_ptr->write_params;
+    /*!
+     * Copy a different change into this one. All the elements are copied, included the data, allocating new memory.
+     * @param[in] ch_ptr Pointer to the change.
+     * @return True if correct.
+     */
+    bool copy(
+            const CacheChange_t* ch_ptr)
+    {
+        kind = ch_ptr->kind;
+        writerGUID = ch_ptr->writerGUID;
+        instanceHandle = ch_ptr->instanceHandle;
+        sequenceNumber = ch_ptr->sequenceNumber;
+        sourceTimestamp = ch_ptr->sourceTimestamp;
+        write_params = ch_ptr->write_params;
 
-                    bool ret = serializedPayload.copy(&ch_ptr->serializedPayload, (ch_ptr->is_untyped_ ? false : true));
+        bool ret = serializedPayload.copy(&ch_ptr->serializedPayload, (ch_ptr->is_untyped_ ? false : true));
 
-                    setFragmentSize(ch_ptr->fragment_size_);
-                    dataFragments_->assign(ch_ptr->dataFragments_->begin(), ch_ptr->dataFragments_->end());
+        setFragmentSize(ch_ptr->fragment_size_);
+        dataFragments_->assign(ch_ptr->dataFragments_->begin(), ch_ptr->dataFragments_->end());
 
-                    isRead = ch_ptr->isRead;
+        isRead = ch_ptr->isRead;
 
-                    return ret;
-                }
+        return ret;
+    }
 
-                void copy_not_memcpy(const CacheChange_t* ch_ptr)
-                {
-                    kind = ch_ptr->kind;
-                    writerGUID = ch_ptr->writerGUID;
-                    instanceHandle = ch_ptr->instanceHandle;
-                    sequenceNumber = ch_ptr->sequenceNumber;
-                    sourceTimestamp = ch_ptr->sourceTimestamp;
-                    write_params = ch_ptr->write_params;
+    void copy_not_memcpy(
+            const CacheChange_t* ch_ptr)
+    {
+        kind = ch_ptr->kind;
+        writerGUID = ch_ptr->writerGUID;
+        instanceHandle = ch_ptr->instanceHandle;
+        sequenceNumber = ch_ptr->sequenceNumber;
+        sourceTimestamp = ch_ptr->sourceTimestamp;
+        write_params = ch_ptr->write_params;
 
-                    // Copy certain values from serializedPayload
-                    serializedPayload.encapsulation = ch_ptr->serializedPayload.encapsulation;
+        // Copy certain values from serializedPayload
+        serializedPayload.encapsulation = ch_ptr->serializedPayload.encapsulation;
 
-                    setFragmentSize(ch_ptr->fragment_size_);
-                    dataFragments_->assign(ch_ptr->dataFragments_->begin(), ch_ptr->dataFragments_->end());
+        setFragmentSize(ch_ptr->fragment_size_);
+        dataFragments_->assign(ch_ptr->dataFragments_->begin(), ch_ptr->dataFragments_->end());
 
-                    isRead = ch_ptr->isRead;
-                }
+        isRead = ch_ptr->isRead;
+    }
 
-                ~CacheChange_t()
-                {
-                    if (dataFragments_)
-                        delete dataFragments_;
-                }
+    ~CacheChange_t()
+    {
+        if (dataFragments_)
+        {
+            delete dataFragments_;
+        }
+    }
 
-                uint32_t getFragmentCount() const
-                {
-                    return (uint32_t)dataFragments_->size();
-                }
+    uint32_t getFragmentCount() const
+    {
+        return (uint32_t)dataFragments_->size();
+    }
 
-                std::vector<uint32_t>* getDataFragments() { return dataFragments_; }
+    std::vector<uint32_t>* getDataFragments() { return dataFragments_; }
 
-                uint16_t getFragmentSize() const { return fragment_size_; }
+    uint16_t getFragmentSize() const { return fragment_size_; }
 
-                void setFragmentSize(uint16_t fragment_size)
-                {
-                    this->fragment_size_ = fragment_size;
+    void setFragmentSize(
+            uint16_t fragment_size)
+    {
+        this->fragment_size_ = fragment_size;
 
-                    if (fragment_size == 0) {
-                        dataFragments_->clear();
-                    }
-                    else
-                    {
-                        //TODO Mirar si cuando se compatibilice con RTI funciona el calculo, porque ellos
-                        //en el sampleSize incluyen el padding.
-                        uint32_t size = (serializedPayload.length + fragment_size - 1) / fragment_size;
-                        dataFragments_->assign(size, ChangeFragmentStatus_t::NOT_PRESENT);
-                    }
-                }
+        if (fragment_size == 0)
+        {
+            dataFragments_->clear();
+        }
+        else
+        {
+            //TODO Mirar si cuando se compatibilice con RTI funciona el calculo, porque ellos
+            //en el sampleSize incluyen el padding.
+            uint32_t size = (serializedPayload.length + fragment_size - 1) / fragment_size;
+            dataFragments_->assign(size, ChangeFragmentStatus_t::NOT_PRESENT);
+        }
+    }
 
+private:
 
-                private:
+    // Data fragments
+    std::vector<uint32_t>* dataFragments_;
 
-                // Data fragments
-                std::vector<uint32_t>* dataFragments_;
-
-                // Fragment size
-                uint16_t fragment_size_;
-            };
+    // Fragment size
+    uint16_t fragment_size_;
+};
 
 #ifndef DOXYGEN_SHOULD_SKIP_THIS_PUBLIC
 
-            /**
-             * Enum ChangeForReaderStatus_t, possible states for a CacheChange_t in a ReaderProxy.
-             *  @ingroup COMMON_MODULE
-             */
-            enum ChangeForReaderStatus_t{
-                UNSENT = 0,        //!< UNSENT
-                REQUESTED = 1,     //!< REQUESTED
-                UNACKNOWLEDGED = 2,//!< UNACKNOWLEDGED
-                ACKNOWLEDGED = 3,  //!< ACKNOWLEDGED
-                UNDERWAY = 4       //!< UNDERWAY
-            };
+/**
+ * Enum ChangeForReaderStatus_t, possible states for a CacheChange_t in a ReaderProxy.
+ *  @ingroup COMMON_MODULE
+ */
+enum ChangeForReaderStatus_t
+{
+    UNSENT = 0,                    //!< UNSENT
+    REQUESTED = 1,                 //!< REQUESTED
+    UNACKNOWLEDGED = 2,            //!< UNACKNOWLEDGED
+    ACKNOWLEDGED = 3,              //!< ACKNOWLEDGED
+    UNDERWAY = 4                   //!< UNDERWAY
+};
 
-            /**
-             * Enum ChangeFromWriterStatus_t, possible states for a CacheChange_t in a WriterProxy.
-             *  @ingroup COMMON_MODULE
-             */
-            enum ChangeFromWriterStatus_t{
-                UNKNOWN = 0,
-                MISSING = 1,
-                //REQUESTED_WITH_NACK,
-                RECEIVED = 2,
-                LOST = 3
-            };
+/**
+ * Enum ChangeFromWriterStatus_t, possible states for a CacheChange_t in a WriterProxy.
+ *  @ingroup COMMON_MODULE
+ */
+enum ChangeFromWriterStatus_t
+{
+    UNKNOWN = 0,
+    MISSING = 1,
+    //REQUESTED_WITH_NACK,
+    RECEIVED = 2,
+    LOST = 3
+};
 
-            /**
-             * Struct ChangeForReader_t used to represent the state of a specific change with respect to a specific reader, as well as its relevance.
-             *  @ingroup COMMON_MODULE
-             */
-            class ChangeForReader_t
+/**
+ * Struct ChangeForReader_t used to represent the state of a specific change with respect to a specific reader, as well as its relevance.
+ *  @ingroup COMMON_MODULE
+ */
+class ChangeForReader_t
+{
+    friend struct ChangeForReaderCmp;
+
+public:
+
+    ChangeForReader_t()
+        : status_(UNSENT)
+        , is_relevant_(true)
+        , change_(nullptr)
+    {
+    }
+
+    ChangeForReader_t(
+            const ChangeForReader_t& ch)
+        : status_(ch.status_)
+        , is_relevant_(ch.is_relevant_)
+        , seq_num_(ch.seq_num_)
+        , change_(ch.change_)
+        , unsent_fragments_(ch.unsent_fragments_)
+    {
+    }
+
+    //TODO(Ricardo) Temporal
+    //ChangeForReader_t(const CacheChange_t* change) : status_(UNSENT),
+    ChangeForReader_t(
+            CacheChange_t* change)
+        : status_(UNSENT)
+        , is_relevant_(true)
+        , seq_num_(change->sequenceNumber)
+        , change_(change)
+    {
+        if (change->getFragmentSize() != 0)
+        {
+            for (uint32_t i = 1; i != change->getFragmentCount() + 1; i++)
             {
-                friend struct ChangeForReaderCmp;
+                unsent_fragments_.insert(i);             // Indexed on 1
+            }
+        }
+    }
 
-                public:
+    ChangeForReader_t(
+            const SequenceNumber_t& seq_num)
+        : status_(UNSENT)
+        , is_relevant_(true)
+        , seq_num_(seq_num)
+        , change_(nullptr)
+    {
+    }
 
-                ChangeForReader_t()
-                    : status_(UNSENT)
-                    , is_relevant_(true)
-                    , change_(nullptr)
-                {
-                }
+    ~ChangeForReader_t(){}
 
-                ChangeForReader_t(const ChangeForReader_t& ch)
-                    : status_(ch.status_)
-                    , is_relevant_(ch.is_relevant_)
-                    , seq_num_(ch.seq_num_)
-                    , change_(ch.change_)
-                    , unsent_fragments_(ch.unsent_fragments_)
-                {
-                }
+    ChangeForReader_t& operator=(
+            const ChangeForReader_t& ch)
+    {
+        status_ = ch.status_;
+        is_relevant_ = ch.is_relevant_;
+        seq_num_ = ch.seq_num_;
+        change_ = ch.change_;
+        unsent_fragments_ = ch.unsent_fragments_;
+        return *this;
+    }
 
-                //TODO(Ricardo) Temporal
-                //ChangeForReader_t(const CacheChange_t* change) : status_(UNSENT),
-                ChangeForReader_t(CacheChange_t* change)
-                    : status_(UNSENT)
-                    , is_relevant_(true)
-                    , seq_num_(change->sequenceNumber)
-                    , change_(change)
-                {
-                    if (change->getFragmentSize() != 0)
-                    {
-                        for (uint32_t i = 1; i != change->getFragmentCount() + 1; i++)
-                        {
-                            unsent_fragments_.insert(i); // Indexed on 1
-                        }
-                    }
-                }
+    /**
+     * Get the cache change
+     * @return Cache change
+     */
+    // TODO(Ricardo) Temporal
+    //const CacheChange_t* getChange() const
+    CacheChange_t* getChange() const
+    {
+        return change_;
+    }
 
-                ChangeForReader_t(const SequenceNumber_t& seq_num)
-                    : status_(UNSENT)
-                    , is_relevant_(true)
-                    , seq_num_(seq_num)
-                    , change_(nullptr)
-                {
-                }
+    void setStatus(
+            const ChangeForReaderStatus_t status)
+    {
+        status_ = status;
+    }
 
-                ~ChangeForReader_t(){}
+    ChangeForReaderStatus_t getStatus() const
+    {
+        return status_;
+    }
 
-                ChangeForReader_t& operator=(const ChangeForReader_t& ch)
-                {
-                    status_ = ch.status_;
-                    is_relevant_ = ch.is_relevant_;
-                    seq_num_ = ch.seq_num_;
-                    change_ = ch.change_;
-                    unsent_fragments_ = ch.unsent_fragments_;
-                    return *this;
-                }
+    void setRelevance(
+            const bool relevance)
+    {
+        is_relevant_ = relevance;
+    }
 
-                /**
-                 * Get the cache change
-                 * @return Cache change
-                 */
-                // TODO(Ricardo) Temporal
-                //const CacheChange_t* getChange() const
-                CacheChange_t* getChange() const
-                {
-                    return change_;
-                }
+    bool isRelevant() const
+    {
+        return is_relevant_;
+    }
 
-                void setStatus(const ChangeForReaderStatus_t status)
-                {
-                    status_ = status;
-                }
+    const SequenceNumber_t getSequenceNumber() const
+    {
+        return seq_num_;
+    }
 
-                ChangeForReaderStatus_t getStatus() const
-                {
-                    return status_;
-                }
+    //! Set change as not valid
+    void notValid()
+    {
+        is_relevant_ = false;
+        change_ = nullptr;
+    }
 
-                void setRelevance(const bool relevance)
-                {
-                    is_relevant_ = relevance;
-                }
+    //! Set change as valid
+    bool isValid() const
+    {
+        return change_ != nullptr;
+    }
 
-                bool isRelevant() const
-                {
-                    return is_relevant_;
-                }
+    FragmentNumberSet_t getUnsentFragments() const
+    {
+        FragmentNumberSet_t rv;
+        auto min = unsent_fragments_.begin();
+        if (min != unsent_fragments_.end())
+        {
+            rv.base(*min);
+            for (FragmentNumber_t fn : unsent_fragments_)
+            {
+                rv.add(fn);
+            }
+        }
 
-                const SequenceNumber_t getSequenceNumber() const
-                {
-                    return seq_num_;
-                }
+        return rv;
+    }
 
-                //! Set change as not valid
-                void notValid()
-                {
-                    is_relevant_ = false;
-                    change_ = nullptr;
-                }
+    void markAllFragmentsAsUnsent()
+    {
+        if (change_ != nullptr && change_->getFragmentSize() != 0)
+        {
+            for (uint32_t i = 1; i != change_->getFragmentCount() + 1; i++)
+            {
+                unsent_fragments_.insert(i);            // Indexed on 1
+            }
+        }
+    }
 
-                //! Set change as valid
-                bool isValid() const
-                {
-                    return change_ != nullptr;
-                }
+    void markFragmentsAsSent(
+            const FragmentNumber_t& sentFragment)
+    {
+        unsent_fragments_.erase(sentFragment);
+    }
 
-                FragmentNumberSet_t getUnsentFragments() const
-                {
-                    FragmentNumberSet_t rv;
-                    auto min = unsent_fragments_.begin();
-                    if (min != unsent_fragments_.end())
-                    {
-                        rv.base(*min);
-                        for (FragmentNumber_t fn : unsent_fragments_)
-                        {
-                            rv.add(fn);
-                        }
-                    }
-
-                    return rv;
-                }
-
-                void markAllFragmentsAsUnsent()
-                {
-                   if (change_ != nullptr && change_->getFragmentSize() != 0)
-                   {
-                       for (uint32_t i = 1; i != change_->getFragmentCount() + 1; i++)
-                       {
-                           unsent_fragments_.insert(i); // Indexed on 1
-                       }
-                   }
-                }
-
-                void markFragmentsAsSent(const FragmentNumber_t& sentFragment)
-                {
-                    unsent_fragments_.erase(sentFragment);
-                }
-
-                void markFragmentsAsUnsent(const FragmentNumberSet_t& unsentFragments)
-                {
-                    unsentFragments.for_each([this](FragmentNumber_t element)
+    void markFragmentsAsUnsent(
+            const FragmentNumberSet_t& unsentFragments)
+    {
+        unsentFragments.for_each([this](FragmentNumber_t element)
                     {
                         unsent_fragments_.insert(element);
                     });
-                }
-
-                private:
-
-                //!Status
-                ChangeForReaderStatus_t status_;
-
-                //!Boolean specifying if this change is relevant
-                bool is_relevant_;
-
-                //!Sequence number
-                SequenceNumber_t seq_num_;
-
-                // TODO(Ricardo) Temporal
-                //const CacheChange_t* change_;
-                CacheChange_t* change_;
-
-                std::set<FragmentNumber_t> unsent_fragments_;
-            };
-
-            struct ChangeForReaderCmp
-            {
-                bool operator()(const ChangeForReader_t& a, const ChangeForReader_t& b) const
-                {
-                    return a.seq_num_ < b.seq_num_;
-                }
-            };
-
-            /**
-             * Struct ChangeFromWriter_t used to indicate the state of a specific change with respect to a specific writer, as well as its relevance.
-             *  @ingroup COMMON_MODULE
-             */
-            class ChangeFromWriter_t
-            {
-                friend struct ChangeFromWriterCmp;
-
-                public:
-
-                ChangeFromWriter_t() : status_(UNKNOWN), is_relevant_(true)
-                {
-
-                }
-
-                ChangeFromWriter_t(const ChangeFromWriter_t& ch) : status_(ch.status_),
-                is_relevant_(ch.is_relevant_), seq_num_(ch.seq_num_)
-                {
-                }
-
-                ChangeFromWriter_t(const SequenceNumber_t& seq_num) : status_(UNKNOWN),
-                is_relevant_(true), seq_num_(seq_num)
-                {
-                }
-
-                ~ChangeFromWriter_t(){};
-
-                ChangeFromWriter_t& operator=(const ChangeFromWriter_t& ch)
-                {
-                    status_ = ch.status_;
-                    is_relevant_ = ch.is_relevant_;
-                    seq_num_ = ch.seq_num_;
-                    return *this;
-                }
-
-                void setStatus(const ChangeFromWriterStatus_t status)
-                {
-                    status_ = status;
-                }
-
-                ChangeFromWriterStatus_t getStatus() const
-                {
-                    return status_;
-                }
-
-                void setRelevance(const bool relevance)
-                {
-                    is_relevant_ = relevance;
-                }
-
-                bool isRelevant() const
-                {
-                    return is_relevant_;
-                }
-
-                const SequenceNumber_t getSequenceNumber() const
-                {
-                    return seq_num_;
-                }
-
-                //! Set change as not valid
-                void notValid()
-                {
-                    is_relevant_ = false;
-                }
-
-                bool operator < (const ChangeFromWriter_t& rhs) const
-                {
-                    return seq_num_ < rhs.seq_num_;
-                }
-
-                private:
-
-                //! Status
-                ChangeFromWriterStatus_t status_;
-
-                //! Boolean specifying if this change is relevant
-                bool is_relevant_;
-
-                //! Sequence number
-                SequenceNumber_t seq_num_;
-            };
-#endif
-        }
     }
+
+private:
+
+    //!Status
+    ChangeForReaderStatus_t status_;
+
+    //!Boolean specifying if this change is relevant
+    bool is_relevant_;
+
+    //!Sequence number
+    SequenceNumber_t seq_num_;
+
+    // TODO(Ricardo) Temporal
+    //const CacheChange_t* change_;
+    CacheChange_t* change_;
+
+    std::set<FragmentNumber_t> unsent_fragments_;
+};
+
+struct ChangeForReaderCmp
+{
+    bool operator()(
+            const ChangeForReader_t& a,
+            const ChangeForReader_t& b) const
+    {
+        return a.seq_num_ < b.seq_num_;
+    }
+};
+
+/**
+ * Struct ChangeFromWriter_t used to indicate the state of a specific change with respect to a specific writer, as well as its relevance.
+ *  @ingroup COMMON_MODULE
+ */
+class ChangeFromWriter_t
+{
+    friend struct ChangeFromWriterCmp;
+
+public:
+
+    ChangeFromWriter_t()
+        : status_(UNKNOWN)
+        , is_relevant_(true)
+    {
+
+    }
+
+    ChangeFromWriter_t(
+            const ChangeFromWriter_t& ch)
+        : status_(ch.status_)
+        , is_relevant_(ch.is_relevant_)
+        , seq_num_(ch.seq_num_)
+    {
+    }
+
+    ChangeFromWriter_t(
+            const SequenceNumber_t& seq_num)
+        : status_(UNKNOWN)
+        , is_relevant_(true)
+        , seq_num_(seq_num)
+    {
+    }
+
+    ~ChangeFromWriter_t(){};
+
+    ChangeFromWriter_t& operator=(
+            const ChangeFromWriter_t& ch)
+    {
+        status_ = ch.status_;
+        is_relevant_ = ch.is_relevant_;
+        seq_num_ = ch.seq_num_;
+        return *this;
+    }
+
+    void setStatus(
+            const ChangeFromWriterStatus_t status)
+    {
+        status_ = status;
+    }
+
+    ChangeFromWriterStatus_t getStatus() const
+    {
+        return status_;
+    }
+
+    void setRelevance(
+            const bool relevance)
+    {
+        is_relevant_ = relevance;
+    }
+
+    bool isRelevant() const
+    {
+        return is_relevant_;
+    }
+
+    const SequenceNumber_t getSequenceNumber() const
+    {
+        return seq_num_;
+    }
+
+    //! Set change as not valid
+    void notValid()
+    {
+        is_relevant_ = false;
+    }
+
+    bool operator < (
+            const ChangeFromWriter_t& rhs) const
+    {
+        return seq_num_ < rhs.seq_num_;
+    }
+
+private:
+
+    //! Status
+    ChangeFromWriterStatus_t status_;
+
+    //! Boolean specifying if this change is relevant
+    bool is_relevant_;
+
+    //! Sequence number
+    SequenceNumber_t seq_num_;
+};
+#endif
+}
+}
 }
 #endif /* _FASTDDS_RTPS_CACHECHANGE_H_ */

--- a/include/fastdds/rtps/common/CacheChange.h
+++ b/include/fastdds/rtps/common/CacheChange.h
@@ -31,21 +31,17 @@
 namespace eprosima {
 namespace fastrtps {
 namespace rtps {
+
 /**
  * @enum ChangeKind_t, different types of CacheChange_t.
  * @ingroup COMMON_MODULE
  */
-#if defined(_WIN32)
 enum RTPS_DllAPI ChangeKind_t
 {
-#else
-enum ChangeKind_t
-{
-#endif
     ALIVE,                            //!< ALIVE
     NOT_ALIVE_DISPOSED,               //!< NOT_ALIVE_DISPOSED
-    NOT_ALIVE_UNREGISTERED,            //!< NOT_ALIVE_UNREGISTERED
-    NOT_ALIVE_DISPOSED_UNREGISTERED             //!<NOT_ALIVE_DISPOSED_UNREGISTERED
+    NOT_ALIVE_UNREGISTERED,           //!< NOT_ALIVE_UNREGISTERED
+    NOT_ALIVE_DISPOSED_UNREGISTERED   //!< NOT_ALIVE_DISPOSED_UNREGISTERED
 };
 
 enum ChangeFragmentStatus_t

--- a/include/fastdds/rtps/common/CacheChange.h
+++ b/include/fastdds/rtps/common/CacheChange.h
@@ -57,7 +57,7 @@ enum ChangeFragmentStatus_t
 struct RTPS_DllAPI CacheChange_t
 {
     //!Kind of change, default value ALIVE.
-    ChangeKind_t kind;
+    ChangeKind_t kind = ALIVE;
     //!GUID_t of the writer that generated this change.
     GUID_t writerGUID;
     //!Handle of the data associated wiht this change.
@@ -67,23 +67,18 @@ struct RTPS_DllAPI CacheChange_t
     //!Serialized Payload associated with the change.
     SerializedPayload_t serializedPayload;
     //!Indicates if the cache has been read (only used in READERS)
-    bool isRead;
+    bool isRead = false;
     //!Source TimeStamp (only used in Readers)
     Time_t sourceTimestamp;
 
     WriteParams write_params;
-    bool is_untyped_;
+    bool is_untyped_ = true;;
 
     /*!
      * @brief Default constructor.
      * Creates an empty CacheChange_t.
      */
     CacheChange_t()
-        : kind(ALIVE)
-        , isRead(false)
-        , is_untyped_(true)
-        , dataFragments_(nullptr)
-        , fragment_size_(0)
     {
     }
 
@@ -101,12 +96,8 @@ struct RTPS_DllAPI CacheChange_t
     CacheChange_t(
             uint32_t payload_size,
             bool is_untyped = false)
-        : kind(ALIVE)
-        , serializedPayload(payload_size)
-        , isRead(false)
+        : serializedPayload(payload_size)
         , is_untyped_(is_untyped)
-        , dataFragments_(nullptr)
-        , fragment_size_(0)
     {
     }
 
@@ -210,13 +201,13 @@ struct RTPS_DllAPI CacheChange_t
 private:
 
     // Data fragments
-    std::vector<uint32_t>* dataFragments_;
+    std::vector<uint32_t>* dataFragments_ = nullptr;
 
     // Fragment size
-    uint16_t fragment_size_;
+    uint16_t fragment_size_ = 0;
 
     // Number of fragments
-    uint32_t fragment_count_;
+    uint32_t fragment_count_ = 0;
 };
 
 #ifndef DOXYGEN_SHOULD_SKIP_THIS_PUBLIC

--- a/include/fastdds/rtps/common/CacheChange.h
+++ b/include/fastdds/rtps/common/CacheChange.h
@@ -66,7 +66,7 @@ struct RTPS_DllAPI CacheChange_t
     Time_t sourceTimestamp;
 
     WriteParams write_params;
-    bool is_untyped_ = true;;
+    bool is_untyped_ = true;
 
     /*!
      * @brief Default constructor.

--- a/include/fastdds/rtps/common/CacheChange.h
+++ b/include/fastdds/rtps/common/CacheChange.h
@@ -317,7 +317,7 @@ private:
         size_t offset = fragment_size_;
         offset *= fragment_index;
         offset = (offset + 3) & ~3;
-        return (uint32_t*)(&serializedPayload.data[offset]);
+        return reinterpret_cast<uint32_t*>(&serializedPayload.data[offset]);
     }
 };
 

--- a/include/fastdds/rtps/common/CacheChange.h
+++ b/include/fastdds/rtps/common/CacheChange.h
@@ -245,9 +245,14 @@ struct RTPS_DllAPI CacheChange_t
             uint32_t initial_fragment,
             uint32_t num_of_fragments)
     {
-        if (fragment_size_ > 0)
+        if ( (fragment_size_ > 0) && (initial_fragment < fragment_count_) )
         {
             uint32_t last_fragment = initial_fragment + num_of_fragments;
+            if (last_fragment > fragment_count_)
+            {
+                last_fragment = fragment_count_;
+            }
+
             if (initial_fragment <= first_missing_fragment_)
             {
                 // Perform first = *first until first >= last_received

--- a/include/fastdds/rtps/reader/RTPSReader.h
+++ b/include/fastdds/rtps/reader/RTPSReader.h
@@ -101,13 +101,15 @@ public:
      *
      * @param change Pointer to the CacheChange_t.
      * @param sampleSize Size of the complete, assembled message.
-     * @param fragmentStartingNum Starting number of this particular fragment.
+     * @param fragmentStartingNum Starting number of this particular message.
+     * @param fragmentsInSubmessage Number of fragments on this particular message.
      * @return true if the reader accepts message.
      */
     RTPS_DllAPI virtual bool processDataFragMsg(
             CacheChange_t* change,
             uint32_t sampleSize,
-            uint32_t fragmentStartingNum) = 0;
+            uint32_t fragmentStartingNum,
+            uint16_t fragmentsInSubmessage) = 0;
 
     /**
      * Processes a new HEARTBEAT message.

--- a/include/fastdds/rtps/reader/StatefulReader.h
+++ b/include/fastdds/rtps/reader/StatefulReader.h
@@ -98,15 +98,18 @@ class StatefulReader : public RTPSReader
 
         /**
          * Processes a new DATA FRAG message.
+         *
          * @param change Pointer to the CacheChange_t.
-         * @param sampleSize Size of the complete assembled message.
-         * @param fragmentStartingNum fragment number of this particular fragment.
-         * @return true if the reader accepts messages.
+         * @param sampleSize Size of the complete, assembled message.
+         * @param fragmentStartingNum Starting number of this particular message.
+         * @param fragmentsInSubmessage Number of fragments on this particular message.
+         * @return true if the reader accepts message.
          */
         bool processDataFragMsg(
                 CacheChange_t* change,
                 uint32_t sampleSize,
-                uint32_t fragmentStartingNum) override;
+                uint32_t fragmentStartingNum,
+                uint16_t fragmentsInSubmessage) override;
 
         /**
          * Processes a new HEARTBEAT message.

--- a/include/fastdds/rtps/reader/StatelessReader.h
+++ b/include/fastdds/rtps/reader/StatelessReader.h
@@ -95,15 +95,18 @@ public:
 
     /**
      * Processes a new DATA FRAG message.
+     *
      * @param change Pointer to the CacheChange_t.
-     * @param sampleSize Size of the complete assembled message.
-     * @param fragmentStartingNum fragment number of this particular fragment.
+     * @param sampleSize Size of the complete, assembled message.
+     * @param fragmentStartingNum Starting number of this particular message.
+     * @param fragmentsInSubmessage Number of fragments on this particular message.
      * @return true if the reader accepts message.
      */
     bool processDataFragMsg(
             CacheChange_t* change,
             uint32_t sampleSize,
-            uint32_t fragmentStartingNum) override;
+            uint32_t fragmentStartingNum,
+            uint16_t fragmentsInSubmessage) override;
 
     /**
      * Processes a new HEARTBEAT message.

--- a/src/cpp/rtps/messages/MessageReceiver.cpp
+++ b/src/cpp/rtps/messages/MessageReceiver.cpp
@@ -750,11 +750,7 @@ bool MessageReceiver::proc_Submsg_DataFrag(CDRMessage_t* msg, SubmessageHeader_t
         {
             ch.serializedPayload.length = payload_size;
 
-            // TODO Mejorar el reubicar el vector de fragmentos.
             ch.setFragmentSize(fragmentSize);
-            ch.getDataFragments()->clear();
-            ch.getDataFragments()->resize(fragmentsInSubmessage, ChangeFragmentStatus_t::PRESENT);
-
             ch.serializedPayload.data = &msg->buffer[msg->pos];
             ch.serializedPayload.length = payload_size;
             msg->pos += payload_size;

--- a/src/cpp/rtps/messages/MessageReceiver.cpp
+++ b/src/cpp/rtps/messages/MessageReceiver.cpp
@@ -800,9 +800,9 @@ bool MessageReceiver::proc_Submsg_DataFrag(CDRMessage_t* msg, SubmessageHeader_t
         << AssociatedReaders.size());
     //Look for the correct reader to add the change
     findAllReaders(readerID, [
-            &ch, sampleSize, fragmentStartingNum
+            &ch, sampleSize, fragmentStartingNum, fragmentsInSubmessage
         ] (RTPSReader* reader) {
-            reader->processDataFragMsg(&ch, sampleSize, fragmentStartingNum);
+            reader->processDataFragMsg(&ch, sampleSize, fragmentStartingNum, fragmentsInSubmessage);
         });
 
     ch.serializedPayload.data = nullptr;

--- a/src/cpp/rtps/messages/MessageReceiver.cpp
+++ b/src/cpp/rtps/messages/MessageReceiver.cpp
@@ -217,13 +217,14 @@ void MessageReceiver::processCDRMsg(const Locator_t& loc, CDRMessage_t*msg)
 
         valid = true;
         count++;
+        uint32_t next_msg_pos = submessage->pos;
+        next_msg_pos += (submsgh.submessageLength + 3) & ~3;
         switch(submsgh.submessageId)
         {
             case DATA:
                 {
                     if(this->destGuidPrefix != participantGuidPrefix)
                     {
-                        submessage->pos += submsgh.submessageLength;
                         logInfo(RTPS_MSG_IN,IDSTRING"Data Submsg ignored, DST is another RTPSParticipant");
                     }
                     else
@@ -236,7 +237,6 @@ void MessageReceiver::processCDRMsg(const Locator_t& loc, CDRMessage_t*msg)
             case DATA_FRAG:
                 if (this->destGuidPrefix != participantGuidPrefix)
                 {
-                    submessage->pos += submsgh.submessageLength;
                     logInfo(RTPS_MSG_IN, IDSTRING"DataFrag Submsg ignored, DST is another RTPSParticipant");
                 }
                 else
@@ -249,7 +249,6 @@ void MessageReceiver::processCDRMsg(const Locator_t& loc, CDRMessage_t*msg)
                 {
                     if(this->destGuidPrefix != participantGuidPrefix)
                     {
-                        submessage->pos += submsgh.submessageLength;
                         logInfo(RTPS_MSG_IN,IDSTRING"Gap Submsg ignored, DST is another RTPSParticipant...");
                     }
                     else
@@ -263,7 +262,6 @@ void MessageReceiver::processCDRMsg(const Locator_t& loc, CDRMessage_t*msg)
                 {
                     if(this->destGuidPrefix != participantGuidPrefix)
                     {
-                        submessage->pos += submsgh.submessageLength;
                         logInfo(RTPS_MSG_IN,IDSTRING"Acknack Submsg ignored, DST is another RTPSParticipant...");
                     }
                     else
@@ -277,7 +275,6 @@ void MessageReceiver::processCDRMsg(const Locator_t& loc, CDRMessage_t*msg)
                 {
                     if (this->destGuidPrefix != participantGuidPrefix)
                     {
-                        submessage->pos += submsgh.submessageLength;
                         logInfo(RTPS_MSG_IN, IDSTRING"NackFrag Submsg ignored, DST is another RTPSParticipant...");
                     }
                     else
@@ -291,7 +288,6 @@ void MessageReceiver::processCDRMsg(const Locator_t& loc, CDRMessage_t*msg)
                 {
                     if(this->destGuidPrefix != participantGuidPrefix)
                     {
-                        submessage->pos += submsgh.submessageLength;
                         logInfo(RTPS_MSG_IN,IDSTRING"HB Submsg ignored, DST is another RTPSParticipant...");
                     }
                     else
@@ -305,7 +301,6 @@ void MessageReceiver::processCDRMsg(const Locator_t& loc, CDRMessage_t*msg)
                 {
                     if (this->destGuidPrefix != participantGuidPrefix)
                     {
-                        submessage->pos += submsgh.submessageLength;
                         logInfo(RTPS_MSG_IN, IDSTRING"HBFrag Submsg ignored, DST is another RTPSParticipant...");
                     }
                     else
@@ -317,7 +312,6 @@ void MessageReceiver::processCDRMsg(const Locator_t& loc, CDRMessage_t*msg)
                 }
             case PAD:
                 logWarning(RTPS_MSG_IN,IDSTRING"PAD messages not yet implemented, ignoring");
-                submessage->pos += submsgh.submessageLength; //IGNORE AND CONTINUE
                 break;
             case INFO_DST:
                 logInfo(RTPS_MSG_IN,IDSTRING"InfoDST message received, processing...");
@@ -338,7 +332,6 @@ void MessageReceiver::processCDRMsg(const Locator_t& loc, CDRMessage_t*msg)
             case INFO_REPLY_IP4:
                 break;
             default:
-                submessage->pos += submsgh.submessageLength; //ID NOT KNOWN. IGNORE AND CONTINUE
                 break;
         }
 
@@ -346,6 +339,8 @@ void MessageReceiver::processCDRMsg(const Locator_t& loc, CDRMessage_t*msg)
         {
             break;
         }
+
+        submessage->pos = next_msg_pos;
     }
 
 

--- a/src/cpp/rtps/messages/submessages/DataMsg.hpp
+++ b/src/cpp/rtps/messages/submessages/DataMsg.hpp
@@ -399,12 +399,12 @@ bool RTPSMessageCreator::addSubmessageDataFrag(
 
     // TODO(Ricardo) This should be on cachechange.
     // Align submessage to rtps alignment (4).
+    submessage_size = uint16_t(msg->pos - position_size_count_size);
     uint32_t align = (4 - msg->pos % 4) & 3;
     for (uint32_t count = 0; count < align; ++count)
         added_no_error &= CDRMessage::addOctet(msg, 0);
 
     //TODO(Ricardo) Improve.
-    submessage_size = uint16_t(msg->pos - position_size_count_size);
     octet* o= reinterpret_cast<octet*>(&submessage_size);
     if(msg->msg_endian == DEFAULT_ENDIAN)
     {

--- a/src/cpp/rtps/reader/FragmentedChangePitStop.cpp
+++ b/src/cpp/rtps/reader/FragmentedChangePitStop.cpp
@@ -61,7 +61,7 @@ CacheChange_t* FragmentedChangePitStop::process(
         original_change->copy_not_memcpy(incoming_change);
         // The length of the serialized payload has to be sample size.
         original_change->serializedPayload.length = sample_size;
-        original_change->setFragmentSize(incoming_change->getFragmentSize());
+        original_change->setFragmentSize(incoming_change->getFragmentSize(), true);
 
         // Insert
         original_change_cit = changes_.insert(ChangeInPit(original_change));

--- a/src/cpp/rtps/reader/FragmentedChangePitStop.cpp
+++ b/src/cpp/rtps/reader/FragmentedChangePitStop.cpp
@@ -69,51 +69,17 @@ CacheChange_t* FragmentedChangePitStop::process(
 
     original_change_cit->getChange()->received_fragments(fragment_starting_num - 1, fragments_in_submessage);
 
-    bool was_updated = false;
-    for (uint32_t count = (fragment_starting_num - 1); count < (fragment_starting_num - 1) + fragments_in_submessage; ++count)
+    size_t original_offset = size_t(fragment_starting_num - 1) * original_change_cit->getChange()->getFragmentSize();
+
+    memcpy(
+        &original_change_cit->getChange()->serializedPayload.data[original_offset],
+        incoming_change->serializedPayload.data,
+        incoming_change->serializedPayload.length);
+
+    if (original_change_cit->getChange()->is_fully_assembled())
     {
-        if(original_change_cit->getChange()->getDataFragments()->at(count) == ChangeFragmentStatus_t::NOT_PRESENT)
-        {
-            size_t original_offset = size_t(count) * original_change_cit->getChange()->getFragmentSize();
-            size_t incoming_offset = size_t(count - (fragment_starting_num - 1)) * incoming_change->getFragmentSize();
-
-            // All cases minus last fragment.
-            if (count + 1 != original_change_cit->getChange()->getFragmentCount())
-            {
-                memcpy(original_change_cit->getChange()->serializedPayload.data + original_offset,
-                        incoming_change->serializedPayload.data + incoming_offset,
-                        incoming_change->getFragmentSize());
-            }
-            // Last fragment is a special case when copying.
-            else
-            {
-                memcpy(original_change_cit->getChange()->serializedPayload.data + original_offset,
-                        incoming_change->serializedPayload.data + incoming_offset,
-                        original_change_cit->getChange()->serializedPayload.length - original_offset);
-            }
-
-            original_change_cit->getChange()->getDataFragments()->at(count) = ChangeFragmentStatus_t::PRESENT;
-
-            was_updated = true;
-        }
-    }
-
-    // If was updated, check if it is completed.
-    if(was_updated)
-    {
-        auto fit = original_change_cit->getChange()->getDataFragments()->begin();
-        for(; fit != original_change_cit->getChange()->getDataFragments()->end(); ++fit)
-        {
-            if(*fit == ChangeFragmentStatus_t::NOT_PRESENT)
-                break;
-        }
-
-        // If it is completed, return CacheChange_t and remove information.
-        if(fit == original_change_cit->getChange()->getDataFragments()->end())
-        {
-            returnedValue = original_change_cit->getChange();
-            changes_.erase(original_change_cit);
-        }
+        returnedValue = original_change_cit->getChange();
+        changes_.erase(original_change_cit);
     }
 
     return returnedValue;

--- a/src/cpp/rtps/reader/FragmentedChangePitStop.cpp
+++ b/src/cpp/rtps/reader/FragmentedChangePitStop.cpp
@@ -67,6 +67,8 @@ CacheChange_t* FragmentedChangePitStop::process(
         original_change_cit = changes_.insert(ChangeInPit(original_change));
     }
 
+    original_change_cit->getChange()->received_fragments(fragment_starting_num - 1, fragments_in_submessage);
+
     bool was_updated = false;
     for (uint32_t count = (fragment_starting_num - 1); count < (fragment_starting_num - 1) + fragments_in_submessage; ++count)
     {

--- a/src/cpp/rtps/reader/FragmentedChangePitStop.h
+++ b/src/cpp/rtps/reader/FragmentedChangePitStop.h
@@ -110,12 +110,17 @@ FragmentedChangePitStop(RTPSReader *parent) : parent_(parent) {}
 /*!
  * @brief Process incomming fragments.
  * @param incoming_change. CacheChange_t that stores the incomming fragments.
- * @param sampleSize Total size of the sample. It was received in the DATA_FRAG submessage.
- * @param fragmentStartingNum. First fragment number in the DATA_FRAG submessage.
+ * @param sample_size Total size of the sample. It was received in the DATA_FRAG submessage.
+ * @param fragment_starting_num. First fragment number in the DATA_FRAG submessage.
+ * @param fragments_in_submessage. Number of fragments present in the DATA_FRAG submessage.
  * @return If a CacheChange_t is completed with new incomming fragments, this will be returned.
  * In other case nullptr is returned.
  */
-CacheChange_t* process(CacheChange_t* incoming_change, uint32_t sampleSize, uint32_t fragmentStartingNum);
+CacheChange_t* process(
+        CacheChange_t* incoming_change,
+        uint32_t sample_size,
+        FragmentNumber_t fragment_starting_num,
+        uint16_t fragments_in_submessage);
 
 /*!
  * @brief Search if there is a CacheChange_t, giving SequenceNumber_t and writer GUID_t,

--- a/src/cpp/rtps/reader/StatefulReader.cpp
+++ b/src/cpp/rtps/reader/StatefulReader.cpp
@@ -430,7 +430,8 @@ bool StatefulReader::processDataFragMsg(
 
             // Fragments manager has to process incomming fragments.
             // If CacheChange_t is completed, it will be returned;
-            CacheChange_t* change_completed = fragmentedChangePitStop_->process(change_to_add, sampleSize, fragmentStartingNum);
+            CacheChange_t* change_completed = fragmentedChangePitStop_->process(
+                change_to_add, sampleSize, fragmentStartingNum, change_to_add->getFragmentCount());
 
 #if HAVE_SECURITY
             if(getAttributes().security_attributes().is_payload_protected)

--- a/src/cpp/rtps/reader/StatefulReader.cpp
+++ b/src/cpp/rtps/reader/StatefulReader.cpp
@@ -369,7 +369,8 @@ bool StatefulReader::processDataMsg(CacheChange_t *change)
 bool StatefulReader::processDataFragMsg(
         CacheChange_t* incomingChange,
         uint32_t sampleSize,
-        uint32_t fragmentStartingNum)
+        uint32_t fragmentStartingNum,
+        uint16_t fragmentsInSubmessage)
 {
     WriterProxy *pWP = nullptr;
 
@@ -431,7 +432,7 @@ bool StatefulReader::processDataFragMsg(
             // Fragments manager has to process incomming fragments.
             // If CacheChange_t is completed, it will be returned;
             CacheChange_t* change_completed = fragmentedChangePitStop_->process(
-                change_to_add, sampleSize, fragmentStartingNum, change_to_add->getFragmentCount());
+                change_to_add, sampleSize, fragmentStartingNum, fragmentsInSubmessage);
 
 #if HAVE_SECURITY
             if(getAttributes().security_attributes().is_payload_protected)

--- a/src/cpp/rtps/reader/StatefulReader.cpp
+++ b/src/cpp/rtps/reader/StatefulReader.cpp
@@ -939,33 +939,7 @@ void StatefulReader::send_acknack(
             for (auto cit : uncompleted_changes)
             {
                 FragmentNumberSet_t frag_sns;
-
-                //  Search first fragment not present.
-                uint32_t frag_num = 0;
-                auto fit = cit->getDataFragments()->begin();
-                for (; fit != cit->getDataFragments()->end(); ++fit)
-                {
-                    ++frag_num;
-                    if (*fit == ChangeFragmentStatus_t::NOT_PRESENT)
-                        break;
-                }
-
-                // Never should happend.
-                assert(frag_num != 0);
-                assert(fit != cit->getDataFragments()->end());
-
-                // Store FragmentNumberSet_t base.
-                frag_sns.base(frag_num);
-
-                // Fill the FragmentNumberSet_t bitmap.
-                for (; fit != cit->getDataFragments()->end(); ++fit)
-                {
-                    if (*fit == ChangeFragmentStatus_t::NOT_PRESENT)
-                        frag_sns.add(frag_num);
-
-                    ++frag_num;
-                }
-
+                cit->get_missing_fragments(frag_sns);
                 ++nackfrag_count_;
                 logInfo(RTPS_READER, "Sending NACKFRAG for sample" << cit->sequenceNumber << ": " << frag_sns;);
 

--- a/src/cpp/rtps/reader/StatelessReader.cpp
+++ b/src/cpp/rtps/reader/StatelessReader.cpp
@@ -331,7 +331,8 @@ bool StatelessReader::processDataMsg(CacheChange_t *change)
 bool StatelessReader::processDataFragMsg(
         CacheChange_t* incomingChange,
         uint32_t sampleSize,
-        uint32_t fragmentStartingNum)
+        uint32_t fragmentStartingNum,
+        uint16_t fragmentsInSubmessage)
 {
     assert(incomingChange);
 
@@ -389,7 +390,7 @@ bool StatelessReader::processDataFragMsg(
             // Fragments manager has to process incomming fragments.
             // If CacheChange_t is completed, it will be returned;
             CacheChange_t* change_completed = fragmentedChangePitStop_->process(
-                change_to_add, sampleSize, fragmentStartingNum, change_to_add->getFragmentCount());
+                change_to_add, sampleSize, fragmentStartingNum, fragmentsInSubmessage);
 
 #if HAVE_SECURITY
             if(getAttributes().security_attributes().is_payload_protected)

--- a/src/cpp/rtps/reader/StatelessReader.cpp
+++ b/src/cpp/rtps/reader/StatelessReader.cpp
@@ -388,7 +388,8 @@ bool StatelessReader::processDataFragMsg(
 
             // Fragments manager has to process incomming fragments.
             // If CacheChange_t is completed, it will be returned;
-            CacheChange_t* change_completed = fragmentedChangePitStop_->process(change_to_add, sampleSize, fragmentStartingNum);
+            CacheChange_t* change_completed = fragmentedChangePitStop_->process(
+                change_to_add, sampleSize, fragmentStartingNum, change_to_add->getFragmentCount());
 
 #if HAVE_SECURITY
             if(getAttributes().security_attributes().is_payload_protected)

--- a/src/cpp/rtps/writer/RTPSWriterCollector.h
+++ b/src/cpp/rtps/writer/RTPSWriterCollector.h
@@ -80,7 +80,7 @@ class RTPSWriterCollector
             {
                 optionalFragmentsNotSent.for_each([this, change, remoteReader](FragmentNumber_t sn)
                 {
-                    assert(sn <= change->getDataFragments()->size());
+                    assert(sn <= change->getFragmentCount());
                     auto it = mItems_.emplace(change->sequenceNumber, sn, change);
                     it.first->remoteReaders.push_back(remoteReader);
                 });

--- a/test/unittest/rtps/common/CMakeLists.txt
+++ b/test/unittest/rtps/common/CMakeLists.txt
@@ -17,10 +17,19 @@ if(NOT ((MSVC OR MSVC_IDE) AND EPROSIMA_INSTALLER))
     check_gtest()
 
     if(GTEST_FOUND)
+        set(CACHECHANGETESTS_SOURCE CacheChangeTests.cpp
+            ${PROJECT_SOURCE_DIR}/src/cpp/rtps/common/Time_t.cpp)
         set(SEQUENCENUMBERTESTS_SOURCE SequenceNumberTests.cpp)
         set(PORTPARAMETERSTESTS_SOURCE PortParametersTests.cpp
             ${PROJECT_SOURCE_DIR}/src/cpp/dds/log/Log.cpp
             ${PROJECT_SOURCE_DIR}/src/cpp/dds/log/StdoutConsumer.cpp)
+
+        add_executable(CacheChangeTests ${CACHECHANGETESTS_SOURCE})
+        target_compile_definitions(CacheChangeTests PRIVATE FASTRTPS_NO_LIB)
+        target_include_directories(CacheChangeTests PRIVATE ${GTEST_INCLUDE_DIRS}
+            ${PROJECT_SOURCE_DIR}/include ${PROJECT_BINARY_DIR}/include)
+        target_link_libraries(CacheChangeTests ${GTEST_LIBRARIES})
+        add_gtest(CacheChangeTests SOURCES ${CACHECHANGETESTS_SOURCE})
 
         add_executable(SequenceNumberTests ${SEQUENCENUMBERTESTS_SOURCE})
         target_compile_definitions(SequenceNumberTests PRIVATE FASTRTPS_NO_LIB)

--- a/test/unittest/rtps/common/CacheChangeTests.cpp
+++ b/test/unittest/rtps/common/CacheChangeTests.cpp
@@ -118,10 +118,10 @@ TEST(CacheChange, FragmentManagement)
         }
     };
 
-    CacheChange_t uut(100);
-    uut.serializedPayload.length = 100;
+    CacheChange_t uut(90);
+    uut.serializedPayload.length = 90;
     
-    uut.setFragmentSize(10, true);
+    uut.setFragmentSize(9, true);
     for (const FragmentTestStep& step : test_steps)
     {
         step.do_test(uut);

--- a/test/unittest/rtps/common/CacheChangeTests.cpp
+++ b/test/unittest/rtps/common/CacheChangeTests.cpp
@@ -1,0 +1,135 @@
+// Copyright 2016 Proyectos y Sistemas de Mantenimiento SL (eProsima).
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <fastrtps/rtps/common/CacheChange.h>
+
+#include <climits>
+#include <vector>
+#include <gtest/gtest.h>
+
+using namespace eprosima::fastrtps::rtps;
+
+struct FragmentTestStep
+{
+    std::string fail_description;
+
+    struct __Input
+    {
+        uint32_t initial_fragment;
+        uint16_t num_fragments;
+    } input;
+
+    struct __Check
+    {
+        bool missing_fragments[10];
+    } check;
+
+    void do_test(CacheChange_t& uut) const
+    {
+        if (input.num_fragments > 0)
+        {
+            uut.received_fragments(input.initial_fragment, input.num_fragments);
+        }
+
+        FragmentNumberSet_t fns;
+        uut.get_missing_fragments(fns);
+
+        for (FragmentNumber_t i = 1; i <= 10; i++)
+        {
+            EXPECT_EQ(fns.is_set(i), check.missing_fragments[i - 1]) 
+                << "  on: " << fail_description << std::endl << "  index: " << i-1;
+        }
+    }
+};
+
+/*!
+ * @fn TEST(CacheChange, FragmentManagement)
+ * @brief This test checks the fragment management behavior of CacheChange_t.
+ */
+TEST(CacheChange, FragmentManagement)
+{
+    const FragmentTestStep test_steps[] =
+    {
+        {
+            "initial state",
+            {0, 0},
+            {true, true, true, true, true, true, true, true, true, true}
+        },
+        {
+            "received out-of-bounds (10)",
+            {10, 1},
+            {true, true, true, true, true, true, true, true, true, true}
+        },
+        {
+            "received (1)",
+            {1, 1},
+            {true, false, true, true, true, true, true, true, true, true}
+        },
+        {
+            "received (1) again",
+            {1, 1},
+            {true, false, true, true, true, true, true, true, true, true}
+        },
+        {
+            "received (1, 2)",
+            {1, 2},
+            {true, false, false, true, true, true, true, true, true, true}
+        },
+        {
+            "received (0)",
+            {0, 1},
+            {false, false, false, true, true, true, true, true, true, true}
+        },
+        {
+            "received (0) again",
+            {0, 1},
+            {false, false, false, true, true, true, true, true, true, true}
+        },
+        {
+            "received (8)",
+            {8, 1},
+            {false, false, false, true, true, true, true, true, false, true}
+        },
+        {
+            "received (7, 8, 9)",
+            {7, 3},
+            {false, false, false, true, true, true, true, false, false, false}
+        },
+        {
+            "received (6)",
+            {6, 1},
+            {false, false, false, true, true, true, false, false, false, false}
+        },
+        {
+            "received (3, 4, 5)",
+            {3, 3},
+            {false, false, false, false, false, false, false, false, false, false}
+        }
+    };
+
+    CacheChange_t uut(100);
+    uut.serializedPayload.length = 100;
+    
+    uut.setFragmentSize(10, true);
+    for (const FragmentTestStep& step : test_steps)
+    {
+        step.do_test(uut);
+    }
+}
+
+int main(int argc, char **argv)
+{
+    testing::InitGoogleTest(&argc, argv);
+    return RUN_ALL_TESTS();
+}

--- a/test/unittest/rtps/common/CacheChangeTests.cpp
+++ b/test/unittest/rtps/common/CacheChangeTests.cpp
@@ -102,8 +102,8 @@ TEST(CacheChange, FragmentManagement)
             {false, false, false, true, true, true, true, true, false, true}
         },
         {
-            "received (7, 8, 9)",
-            {7, 3},
+            "received (7, 8, 9, 10)",
+            {7, 4},
             {false, false, false, true, true, true, true, false, false, false}
         },
         {


### PR DESCRIPTION
This is part of the Fragmentation API refactor.

The `dataFragments_` vector is removed by having the list of missing fragments implemented inside the data payload. The first 4 bytes of each fragment will have the index of the next missing fragment.