### PR TITLE
Feature/pim typesupport [6639]

### DIFF
--- a/examples/C++/DDS/DynamicHelloWorldExample/HelloWorldSubscriber.cpp
+++ b/examples/C++/DDS/DynamicHelloWorldExample/HelloWorldSubscriber.cpp
@@ -115,7 +115,7 @@ void HelloWorldSubscriber::SubListener::on_type_discovery(
     TypeSupport m_type(new eprosima::fastrtps::types::DynamicPubSubType(dyn_type));
     subscriber_->mp_participant->register_type(m_type);
 
-    std::cout << "Discovered type: " << m_type->getName() << " from topic " << topic << std::endl;
+    std::cout << "Discovered type: " << m_type.get_type_name() << " from topic " << topic << std::endl;
 
     if (subscriber_->mp_subscriber == nullptr)
     {
@@ -132,7 +132,7 @@ void HelloWorldSubscriber::SubListener::on_type_discovery(
             return;
         }
     }
-    subscriber_->topic_.topicDataType = m_type->getName();
+    subscriber_->topic_.topicDataType = m_type.get_type_name();
     DataReader* reader = subscriber_->mp_subscriber->create_datareader(
         subscriber_->topic_,
         subscriber_->qos_,

--- a/examples/C++/DDS/HelloWorldExample/HelloWorldPublisher.cpp
+++ b/examples/C++/DDS/HelloWorldExample/HelloWorldPublisher.cpp
@@ -51,7 +51,7 @@ bool HelloWorldPublisher::init()
     }
 
     //REGISTER THE TYPE
-    type_.register_type(participant_, type_->getName());
+    type_.register_type(participant_, type_.get_type_name());
 
     //CREATE THE PUBLISHER
     eprosima::fastrtps::PublisherAttributes pub_att;

--- a/examples/C++/DDS/HelloWorldExample/HelloWorldSubscriber.cpp
+++ b/examples/C++/DDS/HelloWorldExample/HelloWorldSubscriber.cpp
@@ -46,7 +46,7 @@ bool HelloWorldSubscriber::init()
     }
 
     //REGISTER THE TYPE
-    type_.register_type(participant_, type_->getName());
+    type_.register_type(participant_, type_.get_type_name());
 
     //CREATE THE SUBSCRIBER
     eprosima::fastrtps::SubscriberAttributes sub_att;

--- a/include/fastdds/dds/builtin/typelookup/common/TypeLookupTypes.hpp
+++ b/include/fastdds/dds/builtin/typelookup/common/TypeLookupTypes.hpp
@@ -381,7 +381,7 @@ class TypeLookup_RequestTypeSupport : public TypeSupport
 public:
     RTPS_DllAPI bool serialize(
             void* data,
-            fastrtps::rtps::SerializedPayload_t* payload) override;
+            fastrtps::rtps::SerializedPayload_t* payload) const override;
 
     RTPS_DllAPI bool deserialize(
             fastrtps::rtps::SerializedPayload_t* payload,
@@ -401,7 +401,7 @@ class TypeLookup_ReplyTypeSupport : public TypeSupport
 public:
     RTPS_DllAPI bool serialize(
             void* data,
-            fastrtps::rtps::SerializedPayload_t* payload) override;
+            fastrtps::rtps::SerializedPayload_t* payload) const override;
 
     RTPS_DllAPI bool deserialize(
             fastrtps::rtps::SerializedPayload_t* payload,

--- a/include/fastdds/dds/domain/DomainParticipant.hpp
+++ b/include/fastdds/dds/domain/DomainParticipant.hpp
@@ -130,7 +130,7 @@ public:
      * @param type_name The name that will be used to identify the Type.
      * @return True if registered.
      */
-    bool register_type(
+    ReturnCode_t register_type(
             TypeSupport type,
             const std::string& type_name);
 
@@ -139,7 +139,7 @@ public:
      * @param type TypeSupport.
      * @return True if registered.
      */
-    bool register_type(
+    ReturnCode_t register_type(
             TypeSupport type);
 
     /**
@@ -147,7 +147,7 @@ public:
      * @param typeName Name of the type
      * @return True if unregistered.
      */
-    bool unregister_type(
+    ReturnCode_t unregister_type(
             const char* typeName);
 
     // TODO create/delete topic
@@ -413,7 +413,7 @@ public:
      * @return true if type is already available (callback will not be called). false if type isn't available yet
      * (the callback will be called if negotiation is success, and ignored in other case).
      */
-    bool register_remote_type(
+    ReturnCode_t register_remote_type(
             const fastrtps::types::TypeInformation& type_information,
             const std::string& type_name,
             std::function<void(const std::string& name, const fastrtps::types::DynamicType_ptr type)>& callback);

--- a/include/fastdds/dds/topic/TypeSupport.hpp
+++ b/include/fastdds/dds/topic/TypeSupport.hpp
@@ -21,6 +21,7 @@
 
 #include <fastdds/dds/topic/TopicDataType.hpp>
 #include <fastrtps/types/DynamicPubSubType.h>
+#include <fastrtps/types/TypesBase.h>
 #include <string>
 #include <functional>
 #include <memory>
@@ -89,7 +90,7 @@ public:
                   std::make_shared<fastrtps::types::DynamicPubSubType>(std::move(ptr))))
     {}
 
-    RTPS_DllAPI virtual bool register_type(
+    RTPS_DllAPI virtual eprosima::fastrtps::types::ReturnCode_t register_type(
             DomainParticipant* participant,
             std::string type_name) const;
 

--- a/include/fastdds/dds/topic/TypeSupport.hpp
+++ b/include/fastdds/dds/topic/TypeSupport.hpp
@@ -48,7 +48,7 @@ private:
     const fastrtps::types::TypeIdentifier* type_id_;
 
     // TopicDataType for retro-compatibility
-    fastdds::dds::TopicDataType* topic_data_type_;
+    std::shared_ptr<fastdds::dds::TopicDataType> topic_data_type_;
 
 public:
     RTPS_DllAPI TypeSupport()
@@ -73,7 +73,7 @@ public:
             fastdds::dds::TopicDataType* ptr)
         : data_type_name_(ptr != nullptr ? ptr->m_topicDataTypeName : "")
         , type_id_(ptr != nullptr ? ptr->type_id_ : nullptr)
-        , topic_data_type_(ptr)
+        , topic_data_type_(std::shared_ptr<fastdds::dds::TopicDataType>(ptr))
     {}
 
     /*!
@@ -85,8 +85,8 @@ public:
             fastrtps::types::DynamicPubSubType ptr)
         : data_type_name_(ptr.m_topicDataTypeName)
         , type_id_(ptr.type_id_)
-        , topic_data_type_( std::shared_ptr<fastdds::dds::TopicDataType>(
-                  std::make_shared<fastrtps::types::DynamicPubSubType>(std::move(ptr))).get())
+        , topic_data_type_(std::shared_ptr<fastdds::dds::TopicDataType>(
+                  std::make_shared<fastrtps::types::DynamicPubSubType>(std::move(ptr))))
     {}
 
     RTPS_DllAPI virtual bool register_type(
@@ -190,7 +190,7 @@ public:
 
     RTPS_DllAPI TopicDataType* get() const
     {
-        return topic_data_type_;
+        return topic_data_type_.get();
     }
 };
 

--- a/include/fastdds/dds/topic/TypeSupport.hpp
+++ b/include/fastdds/dds/topic/TypeSupport.hpp
@@ -32,29 +32,35 @@ namespace dds {
 class DomainParticipant;
 
 /**
- * NOTE: This class inherits from std::shared_ptr<TopicDataType>.
  * Class TypeSupport used to provide the DomainRTPSParticipant with the methods to serialize,
  * deserialize and get the key of a specific data type.
  * The user should created a class that inherits from this one,
  * where Serialize and deserialize methods MUST be implemented.
  * @ingroup FASTDDS_MODULE
  */
-class TypeSupport : public std::shared_ptr<fastdds::dds::TopicDataType>
+class TypeSupport
 {
-public:
-    using Base = std::shared_ptr<fastdds::dds::TopicDataType>;
-    using Base::operator->;
-    using Base::operator*;
-    using Base::operator bool;
-    using Base::operator=;
+private:
+    //! Data Type Name
+    std::string data_type_name_;
 
+    //! Type Identifier
+    const fastrtps::types::TypeIdentifier* type_id_;
+
+    // TopicDataType for retro-compatibility
+    fastdds::dds::TopicDataType* topic_data_type_;
+
+public:
     RTPS_DllAPI TypeSupport()
-        : std::shared_ptr<fastdds::dds::TopicDataType>(nullptr)
+        : type_id_(nullptr)
+        , topic_data_type_(nullptr)
     {}
 
     RTPS_DllAPI TypeSupport(
             const TypeSupport& type)
-        : std::shared_ptr<fastdds::dds::TopicDataType>(type)
+        : data_type_name_(type.data_type_name_)
+        , type_id_(type.type_id_)
+        , topic_data_type_(type.topic_data_type_)
     {}
 
     /*!
@@ -65,7 +71,9 @@ public:
      */
     RTPS_DllAPI explicit TypeSupport(
             fastdds::dds::TopicDataType* ptr)
-        : std::shared_ptr<fastdds::dds::TopicDataType>(ptr)
+        : data_type_name_(ptr != nullptr ? ptr->m_topicDataTypeName : "")
+        , type_id_(ptr != nullptr ? ptr->type_id_ : nullptr)
+        , topic_data_type_(ptr)
     {}
 
     /*!
@@ -75,7 +83,10 @@ public:
      */
     RTPS_DllAPI TypeSupport(
             fastrtps::types::DynamicPubSubType ptr)
-        : std::shared_ptr<fastdds::dds::TopicDataType>(std::make_shared<fastrtps::types::DynamicPubSubType>(std::move(ptr)))
+        : data_type_name_(ptr.m_topicDataTypeName)
+        , type_id_(ptr.type_id_)
+        , topic_data_type_( std::shared_ptr<fastdds::dds::TopicDataType>(
+                  std::make_shared<fastrtps::types::DynamicPubSubType>(std::move(ptr))).get())
     {}
 
     RTPS_DllAPI virtual bool register_type(
@@ -84,38 +95,57 @@ public:
 
     RTPS_DllAPI virtual const std::string& get_type_name() const
     {
-        return get()->m_topicDataTypeName;
+        return data_type_name_;
     }
 
     RTPS_DllAPI virtual bool serialize(
             void* data,
-            fastrtps::rtps::SerializedPayload_t* payload)
+            fastrtps::rtps::SerializedPayload_t* payload) const
     {
-        return get()->serialize(data, payload);
+        if (topic_data_type_ != nullptr)
+        {
+            return topic_data_type_->serialize(data, payload);
+        }
+        return false;
     }
 
     RTPS_DllAPI virtual bool deserialize(
             fastrtps::rtps::SerializedPayload_t* payload,
             void* data)
     {
-        return get()->deserialize(payload, data);
+        if (topic_data_type_ != nullptr)
+        {
+            return topic_data_type_->deserialize(payload, data);
+        }
+        return false;
     }
 
     RTPS_DllAPI virtual std::function<uint32_t()> get_serialized_size_provider(
             void* data)
     {
-        return get()->getSerializedSizeProvider(data);
+        if (topic_data_type_ != nullptr)
+        {
+            topic_data_type_->getSerializedSizeProvider(data);
+        }
+        return [](){ return 0; };
     }
 
     RTPS_DllAPI virtual void* create_data()
     {
-        return get()->createData();
+        if (topic_data_type_ != nullptr)
+        {
+            return topic_data_type_->createData();
+        }
+        return nullptr;
     }
 
     RTPS_DllAPI virtual void delete_data(
-            void * data)
+            void* data)
     {
-        return get()->deleteData(data);
+        if (topic_data_type_ != nullptr)
+        {
+            topic_data_type_->deleteData(data);
+        }
     }
 
     RTPS_DllAPI virtual bool get_key(
@@ -123,20 +153,44 @@ public:
             fastrtps::rtps::InstanceHandle_t* i_handle,
             bool force_md5 = false)
     {
-        return get()->getKey(data, i_handle, force_md5);
+        if (topic_data_type_ != nullptr)
+        {
+            return topic_data_type_->getKey(data, i_handle, force_md5);
+        }
+        return false;
     }
 
     RTPS_DllAPI virtual bool operator==(
             const TypeSupport& type_support)
     {
-        return get()->m_typeSize == type_support->m_typeSize
-               && get()->m_isGetKeyDefined == type_support->m_isGetKeyDefined
-               && get()->m_topicDataTypeName == type_support->m_topicDataTypeName;
+        if (topic_data_type_ != nullptr && type_support.topic_data_type_ != nullptr)
+        {
+            if (topic_data_type_ == type_support.topic_data_type_)
+            {
+                return true;
+            }
+            else
+            {
+                return topic_data_type_->m_typeSize == type_support.topic_data_type_->m_typeSize
+                       && topic_data_type_->m_isGetKeyDefined == type_support.topic_data_type_->m_isGetKeyDefined
+                       && topic_data_type_->m_topicDataTypeName == type_support.topic_data_type_->m_topicDataTypeName;
+            }
+        }
+        return data_type_name_ == type_support.data_type_name_;
     }
 
     RTPS_DllAPI bool empty() const
     {
-        return get() == nullptr;
+        if (topic_data_type_ != nullptr)
+        {
+            return topic_data_type_ == nullptr;
+        }
+        return data_type_name_.empty();
+    }
+
+    RTPS_DllAPI TopicDataType* get() const
+    {
+        return topic_data_type_;
     }
 };
 

--- a/src/cpp/fastdds/builtin/typelookup/common/TypeLookupTypes.cpp
+++ b/src/cpp/fastdds/builtin/typelookup/common/TypeLookupTypes.cpp
@@ -1196,7 +1196,7 @@ void TypeLookup_Reply::deserialize(eprosima::fastcdr::Cdr &dcdr)
 // TypeSupports
 bool TypeLookup_RequestTypeSupport::serialize(
         void* data,
-        fastrtps::rtps::SerializedPayload_t* payload)
+        fastrtps::rtps::SerializedPayload_t* payload) const
 {
     TypeLookup_Request* type = static_cast<TypeLookup_Request*>(data);
     //eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(payload->data), payload->max_size);
@@ -1295,7 +1295,7 @@ TypeLookup_ReplyTypeSupport::TypeLookup_ReplyTypeSupport()
 */
 bool TypeLookup_ReplyTypeSupport::serialize(
         void* data,
-        fastrtps::rtps::SerializedPayload_t* payload)
+        fastrtps::rtps::SerializedPayload_t* payload) const
 {
     TypeLookup_Reply* type = static_cast<TypeLookup_Reply*>(data);
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(payload->data), payload->max_size);

--- a/src/cpp/fastdds/domain/DomainParticipant.cpp
+++ b/src/cpp/fastdds/domain/DomainParticipant.cpp
@@ -72,20 +72,20 @@ ReturnCode_t DomainParticipant::delete_subscriber(
     return impl_->delete_subscriber(subscriber);
 }
 
-bool DomainParticipant::register_type(
+ReturnCode_t DomainParticipant::register_type(
         TypeSupport type,
         const std::string& type_name)
 {
     return impl_->register_type(type, type_name);
 }
 
-bool DomainParticipant::register_type(
+ReturnCode_t DomainParticipant::register_type(
         TypeSupport type)
 {
     return impl_->register_type(type, type.get_type_name());
 }
 
-bool DomainParticipant::unregister_type(
+ReturnCode_t DomainParticipant::unregister_type(
         const char* typeName)
 {
     return impl_->unregister_type(typeName);
@@ -275,7 +275,7 @@ fastrtps::rtps::SampleIdentity DomainParticipant::get_types(
     return impl_->get_types(in);
 }
 
-bool DomainParticipant::register_remote_type(
+ReturnCode_t DomainParticipant::register_remote_type(
         const fastrtps::types::TypeInformation& type_information,
         const std::string& type_name,
         std::function<void(const std::string& name, const fastrtps::types::DynamicType_ptr type)>& callback)

--- a/src/cpp/fastdds/domain/DomainParticipantImpl.cpp
+++ b/src/cpp/fastdds/domain/DomainParticipantImpl.cpp
@@ -579,7 +579,7 @@ const TypeSupport DomainParticipantImpl::find_type(
     return TypeSupport(nullptr);
 }
 
-bool DomainParticipantImpl::register_type(
+ReturnCode_t DomainParticipantImpl::register_type(
         const TypeSupport type,
         const std::string& type_name)
 {
@@ -589,26 +589,26 @@ bool DomainParticipantImpl::register_type(
     {
         if (t == type)
         {
-            return true;
+            return ReturnCode_t::RETCODE_OK;
         }
 
         logError(PARTICIPANT, "Another type with the same name '" << type_name << "' is already registered.");
+        return ReturnCode_t::RETCODE_PRECONDITION_NOT_MET;
     }
 
     if (type_name.size() <= 0)
     {
         logError(PARTICIPANT, "Registered Type must have a name");
-        return false;
+        return ReturnCode_t::RETCODE_PRECONDITION_NOT_MET;
     }
 
     logInfo(PARTICIPANT, "Type " << type_name << " registered.");
     std::lock_guard<std::mutex> lock(mtx_types_);
-    types_.insert(std::make_pair(type_name, type));
-
-    return true;
+    auto it = types_.insert(std::make_pair(type_name, type));
+    return (it.second) ? ReturnCode_t::RETCODE_OK : ReturnCode_t::RETCODE_OUT_OF_RESOURCES;
 }
 
-bool DomainParticipantImpl::register_dynamic_type_to_factories(
+ReturnCode_t DomainParticipantImpl::register_dynamic_type_to_factories(
     const std::string& type_name) const
 {
     using namespace  eprosima::fastrtps::types;
@@ -646,22 +646,22 @@ bool DomainParticipantImpl::register_dynamic_type_to_factories(
                 const TypeIdentifier *type_id_complete = objectFactory->get_type_identifier(dpst->getName(), true);
                 const TypeObject *type_obj_complete = objectFactory->get_type_object(dpst->getName(), true);
                 objectFactory->add_type_object(dpst->getName(), type_id_complete, type_obj_complete); // Add complete
-                return true;
+                return ReturnCode_t::RETCODE_OK;
             }
         }
     }
 
-    return false; // Isn't a registered dynamic type.
+    return ReturnCode_t::RETCODE_ERROR; // Isn't a registered dynamic type.
 }
 
-bool DomainParticipantImpl::unregister_type(
+ReturnCode_t DomainParticipantImpl::unregister_type(
         const char* type_name)
 {
     TypeSupport t = find_type(type_name);
 
     if (t.empty())
     {
-        return true; // Not registered, so unregistering complete.
+        return ReturnCode_t::RETCODE_OK; // Not registered, so unregistering complete.
     }
 
     {
@@ -672,7 +672,7 @@ bool DomainParticipantImpl::unregister_type(
         {
             if (sit.second->type_in_use(type_name))
             {
-                return false; // Is in use
+                return ReturnCode_t::RETCODE_PRECONDITION_NOT_MET; // Is in use
             }
         }
     }
@@ -685,7 +685,7 @@ bool DomainParticipantImpl::unregister_type(
         {
             if (pit.second->type_in_use(type_name))
             {
-                return false; // Is in use
+                return ReturnCode_t::RETCODE_PRECONDITION_NOT_MET; // Is in use
             }
         }
     }
@@ -693,7 +693,7 @@ bool DomainParticipantImpl::unregister_type(
     std::lock_guard<std::mutex> lock(mtx_types_);
     types_.erase(type_name);
 
-    return true;
+    return ReturnCode_t::RETCODE_OK;
 }
 
 void DomainParticipantImpl::MyRTPSParticipantListener::onParticipantDiscovery(
@@ -847,7 +847,7 @@ fastrtps::rtps::SampleIdentity DomainParticipantImpl::get_types(
     return rtps_participant_->typelookup_manager()->get_types(in);
 }
 
-bool DomainParticipantImpl::register_remote_type(
+ReturnCode_t DomainParticipantImpl::register_remote_type(
         const fastrtps::types::TypeInformation& type_information,
         const std::string& type_name,
         std::function<void(const std::string& name, const fastrtps::types::DynamicType_ptr type)>& callback)
@@ -863,12 +863,16 @@ bool DomainParticipantImpl::register_remote_type(
 
         if (nullptr != dyn)
         {
-            if (register_dynamic_type(dyn))
+            // For plain types, don't call the callback
+            return register_dynamic_type(dyn);
+            /*
+            if (!!register_dynamic_type(dyn))
             {
                 //callback(type_name, dyn); // For plain types, don't call the callback
                 return true;
             }
             return false;
+            */
         }
         // If cannot create the dynamic type, probably is because it depend on unknown types.
         // We must continue.
@@ -889,12 +893,16 @@ bool DomainParticipantImpl::register_remote_type(
 
         if (nullptr != dyn)
         {
-            if (register_dynamic_type(dyn))
+            // If the type is already registered, don't call the callback.
+            return register_dynamic_type(dyn);
+            /*
+            if (!!register_dynamic_type(dyn))
             {
                 //callback(type_name, dyn); // If the type is already registered, don't call the callback.
                 return true;
             }
             return false;
+            */
         }
     }
     else if (rtps_participant_->typelookup_manager() != nullptr)
@@ -947,9 +955,9 @@ bool DomainParticipantImpl::register_remote_type(
         // Move the filled vector to the map
         parent_requests_.emplace(std::make_pair(requestId, std::move(vector)));
 
-        return false;
+        return ReturnCode_t::RETCODE_NO_DATA;
     }
-    return false;
+    return ReturnCode_t::RETCODE_PRECONDITION_NOT_MET;
 }
 
 bool DomainParticipantImpl::check_get_type_request(
@@ -974,7 +982,7 @@ bool DomainParticipantImpl::check_get_type_request(
             if (nullptr != dyn_type)
             {
                 dyn_type->set_name(name);
-                if (register_dynamic_type(dyn_type))
+                if (!!register_dynamic_type(dyn_type))
                 {
                     callback(name, dyn_type);
                     remove_parent_request(requestId);
@@ -994,7 +1002,7 @@ bool DomainParticipantImpl::check_get_type_request(
 
                 if (nullptr != dynamic)
                 {
-                    if (register_dynamic_type(dynamic))
+                    if (!!register_dynamic_type(dynamic))
                     {
                         callback(name, dynamic);
                         remove_parent_request(requestId);
@@ -1167,7 +1175,7 @@ bool DomainParticipantImpl::check_get_dependencies_request(
     return false;
 }
 
-bool DomainParticipantImpl::register_dynamic_type(
+ReturnCode_t DomainParticipantImpl::register_dynamic_type(
         fastrtps::types::DynamicType_ptr dyn_type)
 {
     TypeSupport type(new fastrtps::types::DynamicPubSubType(dyn_type));

--- a/src/cpp/fastdds/domain/DomainParticipantImpl.cpp
+++ b/src/cpp/fastdds/domain/DomainParticipantImpl.cpp
@@ -585,7 +585,7 @@ bool DomainParticipantImpl::register_type(
 {
     TypeSupport t = find_type(type_name);
 
-    if (t != nullptr)
+    if (t.get() != nullptr)
     {
         if (t == type)
         {

--- a/src/cpp/fastdds/domain/DomainParticipantImpl.hpp
+++ b/src/cpp/fastdds/domain/DomainParticipantImpl.hpp
@@ -129,7 +129,7 @@ public:
      * @param type_name The name that will be used to identify the Type.
      * @return True if registered.
      */
-    bool register_type(
+    ReturnCode_t register_type(
             TypeSupport type,
             const std::string& type_name);
 
@@ -139,7 +139,7 @@ public:
      * @param type_name
      * @return True if registered.
      */
-    bool register_dynamic_type_to_factories(
+    ReturnCode_t register_dynamic_type_to_factories(
         const std::string& type_name) const;
 
     /**
@@ -147,7 +147,7 @@ public:
      * @param typeName Name of the type
      * @return True if unregistered.
      */
-    bool unregister_type(
+    ReturnCode_t unregister_type(
             const char* typeName);
 
     // TODO create/delete topic
@@ -278,7 +278,7 @@ public:
     fastrtps::rtps::SampleIdentity get_types(
             const fastrtps::types::TypeIdentifierSeq& in) const;
 
-    bool register_remote_type(
+    ReturnCode_t register_remote_type(
             const fastrtps::types::TypeInformation& type_information,
             const std::string& type_name,
             std::function<void(const std::string& name, const fastrtps::types::DynamicType_ptr type)>& callback);
@@ -397,7 +397,7 @@ private:
     bool exists_entity_id(
             const fastrtps::rtps::EntityId_t& entity_id) const;
 
-    bool register_dynamic_type(
+    ReturnCode_t register_dynamic_type(
             fastrtps::types::DynamicType_ptr dyn_type);
 
     bool check_get_type_request(

--- a/src/cpp/fastdds/publisher/PublisherImpl.cpp
+++ b/src/cpp/fastdds/publisher/PublisherImpl.cpp
@@ -166,7 +166,7 @@ DataWriter* PublisherImpl::create_datawriter(
     }
 
     // Check the type supports keys.
-    if (topic_att.topicKind == WITH_KEY && !type_support->m_isGetKeyDefined)
+    if (topic_att.topicKind == WITH_KEY && !type_support.get()->m_isGetKeyDefined)
     {
         logError(PUBLISHER, "Keyed Topic " << topic_att.getTopicName() << " needs getKey function");
         return nullptr;

--- a/src/cpp/fastdds/subscriber/SubscriberImpl.cpp
+++ b/src/cpp/fastdds/subscriber/SubscriberImpl.cpp
@@ -132,7 +132,7 @@ DataReader* SubscriberImpl::create_datareader(
         logError(SUBSCRIBER, "Type : " << topic_att.getTopicDataType() << " Not Registered");
         return nullptr;
     }
-    if (topic_att.topicKind == WITH_KEY && !type_support->m_isGetKeyDefined)
+    if (topic_att.topicKind == WITH_KEY && !type_support.get()->m_isGetKeyDefined)
     {
         logError(SUBSCRIBER, "Keyed Topic needs getKey function");
         return nullptr;

--- a/src/cpp/fastdds/topic/DataReaderImpl.cpp
+++ b/src/cpp/fastdds/topic/DataReaderImpl.cpp
@@ -61,7 +61,7 @@ DataReaderImpl::DataReaderImpl(
     , history_(topic_att_,
                type_.get(),
                qos_,
-               type_->m_typeSize + 3, /* Possible alignment */
+               type_.get()->m_typeSize + 3, /* Possible alignment */
                memory_policy)
     , listener_(listener)
     , reader_listener_(this)

--- a/src/cpp/fastdds/topic/DataWriterImpl.cpp
+++ b/src/cpp/fastdds/topic/DataWriterImpl.cpp
@@ -61,7 +61,7 @@ DataWriterImpl::DataWriterImpl(
     , topic_att_(topic_att)
     , w_att_(att)
     , qos_(&qos == &DATAWRITER_QOS_DEFAULT ? publisher_->get_default_datawriter_qos() : qos)
-    , history_(topic_att_, type_->m_typeSize
+    , history_(topic_att_, type_.get()->m_typeSize
 #if HAVE_SECURITY
         // In future v2 changepool is in writer, and writer set this value to cachechagepool.
         + 20 /*SecureDataHeader*/ + 4 + ((2* 16) /*EVP_MAX_IV_LENGTH max block size*/ - 1 ) /* SecureDataBodey*/
@@ -133,7 +133,7 @@ DataWriterImpl::~DataWriterImpl()
 
     if (writer_ != nullptr)
     {
-        logInfo(PUBLISHER, guid().entityId << " in topic: " << type_->getName());
+        logInfo(PUBLISHER, guid().entityId << " in topic: " << type_.get_type_name());
     }
 
     RTPSDomain::removeRTPSWriter(writer_);
@@ -223,7 +223,7 @@ bool DataWriterImpl::check_new_change_preconditions(
         || change_kind == NOT_ALIVE_DISPOSED
         || change_kind == NOT_ALIVE_DISPOSED_UNREGISTERED)
     {
-        if (!type_->m_isGetKeyDefined)
+        if (!type_.get()->m_isGetKeyDefined)
         {
             logError(PUBLISHER,"Topic is NO_KEY, operation not permitted");
             return false;
@@ -246,13 +246,13 @@ bool DataWriterImpl::perform_create_new_change(
     std::unique_lock<RecursiveTimedMutex> lock(writer_->getMutex(), std::defer_lock);
     if (lock.try_lock_until(max_blocking_time))
     {
-        CacheChange_t* ch = writer_->new_change(type_->getSerializedSizeProvider(data), change_kind, handle);
+        CacheChange_t* ch = writer_->new_change(type_.get()->getSerializedSizeProvider(data), change_kind, handle);
         if (ch != nullptr)
         {
             if (change_kind == ALIVE)
             {
                 //If these two checks are correct, we asume the cachechange is valid and thwn we can write to it.
-                if (!type_->serialize(data, &ch->serializedPayload))
+                if (!type_.serialize(data, &ch->serializedPayload))
                 {
                     logWarning(RTPS_WRITER,"RTPSWriter:Serialization returns false";);
                     history_.release_Cache(ch);
@@ -357,13 +357,13 @@ bool DataWriterImpl::create_new_change_with_params(
     }
 
     InstanceHandle_t handle;
-    if (type_->m_isGetKeyDefined)
+    if (type_.get()->m_isGetKeyDefined)
     {
         bool is_key_protected = false;
 #if HAVE_SECURITY
         is_key_protected = writer_->getAttributes().security_attributes().is_key_protected;
 #endif
-        type_->getKey(data,&handle,is_key_protected);
+        type_.get()->getKey(data,&handle,is_key_protected);
     }
 
     return perform_create_new_change(changeKind, data, wparams, handle);

--- a/src/cpp/fastdds/topic/TypeSupport.cpp
+++ b/src/cpp/fastdds/topic/TypeSupport.cpp
@@ -21,8 +21,9 @@
 #include <fastdds/dds/domain/DomainParticipant.hpp>
 
 using namespace eprosima::fastdds::dds;
+using namespace eprosima::fastrtps::types;
 
-bool TypeSupport::register_type(
+ReturnCode_t TypeSupport::register_type(
         DomainParticipant* participant,
         std::string type_name) const
 {

--- a/test/dds/communication/Publisher.cpp
+++ b/test/dds/communication/Publisher.cpp
@@ -260,7 +260,7 @@ int main(
     PublisherAttributes publisher_attributes;
     //Domain::getDefaultPublisherAttributes(publisher_attributes);
     publisher_attributes.topic.topicKind = NO_KEY;
-    publisher_attributes.topic.topicDataType = type->getName();
+    publisher_attributes.topic.topicDataType = type.get_type_name();
     publisher_attributes.topic.topicName = topic.str();
     publisher_attributes.qos.m_liveliness.lease_duration = 3;
     publisher_attributes.qos.m_liveliness.announcement_period = 1;

--- a/test/xtypes/TestPublisher.cpp
+++ b/test/xtypes/TestPublisher.cpp
@@ -88,7 +88,7 @@ bool TestPublisher::init(
     Wparam.topic.auto_fill_type_object = false;
     Wparam.topic.auto_fill_type_information = false;
     Wparam.topic.topicKind = topic_kind;
-    Wparam.topic.topicDataType = m_Type.get() != nullptr ? m_Type.get_type_name() : nullptr;
+    Wparam.topic.topicDataType = m_Type.get() != nullptr ? m_Type.get_type_name() : "";
 
     //REGISTER THE TYPE
     if (m_Type.get() != nullptr)

--- a/test/xtypes/TestPublisher.cpp
+++ b/test/xtypes/TestPublisher.cpp
@@ -65,7 +65,7 @@ bool TestPublisher::init(
         bool use_typelookup)
 {
     m_Name = name;
-    m_Type.swap(type);
+    m_Type = type;
     using_typelookup_ = use_typelookup;
 
     ParticipantAttributes PParam;
@@ -88,10 +88,10 @@ bool TestPublisher::init(
     Wparam.topic.auto_fill_type_object = false;
     Wparam.topic.auto_fill_type_information = false;
     Wparam.topic.topicKind = topic_kind;
-    Wparam.topic.topicDataType = m_Type != nullptr ? m_Type->getName() : nullptr;
+    Wparam.topic.topicDataType = m_Type.get() != nullptr ? m_Type.get_type_name() : nullptr;
 
     //REGISTER THE TYPE
-    if (m_Type != nullptr)
+    if (m_Type.get() != nullptr)
     {
         mp_participant->register_type(m_Type);
     }
@@ -120,7 +120,7 @@ bool TestPublisher::init(
     // Wparam.topic.dataRepresentationQos = XML_DATA_REPRESENTATION
     // Wparam.topic.dataRepresentationQos = XCDR2_DATA_REPRESENTATION
 
-    if (m_Type != nullptr)
+    if (m_Type.get() != nullptr)
     {
         mp_publisher = mp_participant->create_publisher(PUBLISHER_QOS_DEFAULT, Wparam, nullptr);
         if (mp_publisher == nullptr)
@@ -130,7 +130,7 @@ bool TestPublisher::init(
 
         writer_ = mp_publisher->create_datawriter(Wparam.topic, Wparam.qos, &m_pubListener);
 
-        m_Data = m_Type->createData();
+        m_Data = m_Type.create_data();
     }
 
     m_bInitialized = true;
@@ -140,9 +140,9 @@ bool TestPublisher::init(
 
 TestPublisher::~TestPublisher()
 {
-    if (m_Type)
+    if (m_Type.get())
     {
-        m_Type->deleteData(m_Data);
+        m_Type.delete_data(m_Data);
     }
     DomainParticipantFactory::get_instance()->delete_participant(mp_participant);
 }

--- a/test/xtypes/TestSubscriber.cpp
+++ b/test/xtypes/TestSubscriber.cpp
@@ -66,7 +66,7 @@ bool TestSubscriber::init(
         bool use_typelookup)
 {
     m_Name = name;
-    m_Type.swap(type);
+    m_Type = type;
     using_typelookup_ = use_typelookup;
     ParticipantAttributes PParam;
     PParam.rtps.builtin.domainId = domain;
@@ -85,12 +85,12 @@ bool TestSubscriber::init(
     //CREATE THE SUBSCRIBER
     SubscriberAttributes Rparam;
     Rparam.topic.topicKind = topic_kind;
-    Rparam.topic.topicDataType = m_Type != nullptr ? m_Type->getName() : nullptr;
+    Rparam.topic.topicDataType = m_Type.get() != nullptr ? m_Type.get_type_name() : nullptr;
     Rparam.topic.auto_fill_type_object = false;
     Rparam.topic.auto_fill_type_information = false;
 
     //REGISTER THE TYPE
-    if (m_Type != nullptr)
+    if (m_Type.get() != nullptr)
     {
         mp_participant->register_type(m_Type);
     }
@@ -121,7 +121,7 @@ bool TestSubscriber::init(
     }
 
     // Create sub and reader if topic was provided
-    if (m_Type != nullptr)
+    if (m_Type.get() != nullptr)
     {
         mp_subscriber = mp_participant->create_subscriber(SUBSCRIBER_QOS_DEFAULT, Rparam, nullptr);
 
@@ -131,7 +131,7 @@ bool TestSubscriber::init(
         }
 
         reader_ = mp_subscriber->create_datareader(Rparam.topic, Rparam.qos, &m_subListener);
-        m_Data = m_Type->createData();
+        m_Data = m_Type.create_data();
     }
 
     m_bInitialized = true;
@@ -143,9 +143,9 @@ bool TestSubscriber::init(
 
 TestSubscriber::~TestSubscriber()
 {
-    if (m_Type != nullptr)
+    if (m_Type.get() != nullptr)
     {
-        m_Type->deleteData(m_Data);
+        m_Type.delete_data(m_Data);
     }
     DomainParticipantFactory::get_instance()->delete_participant(mp_participant);
 }

--- a/test/xtypes/TestSubscriber.cpp
+++ b/test/xtypes/TestSubscriber.cpp
@@ -301,7 +301,7 @@ bool TestSubscriber::register_discovered_type()
     TypeSupport type(disc_type_);
     topic_att.auto_fill_type_object = true;
     topic_att.auto_fill_type_information = true;
-    return mp_participant->register_type(type, disc_type_->get_name());
+    return mp_participant->register_type(type, disc_type_->get_name()) == ReturnCode_t::RETCODE_OK;
 }
 
 void TestSubscriber::run()

--- a/test/xtypes/TestSubscriber.cpp
+++ b/test/xtypes/TestSubscriber.cpp
@@ -85,7 +85,7 @@ bool TestSubscriber::init(
     //CREATE THE SUBSCRIBER
     SubscriberAttributes Rparam;
     Rparam.topic.topicKind = topic_kind;
-    Rparam.topic.topicDataType = m_Type.get() != nullptr ? m_Type.get_type_name() : nullptr;
+    Rparam.topic.topicDataType = m_Type.get() != nullptr ? m_Type.get_type_name() : "";
     Rparam.topic.auto_fill_type_object = false;
     Rparam.topic.auto_fill_type_information = false;
 


### PR DESCRIPTION
This PR makes TypeSupport a base class, still compatible with TopicDataType but by storing it as `shared_ptr`.