### PR TITLE
Remove pitstop usage from StatelessReader [6642]

### DIFF
--- a/include/fastdds/rtps/reader/StatelessReader.h
+++ b/include/fastdds/rtps/reader/StatelessReader.h
@@ -29,18 +29,19 @@
 #include <map>
 
 namespace eprosima {
-namespace fastrtps{
+namespace fastrtps {
 namespace rtps {
 
 /**
  * Class StatelessReader, specialization of the RTPSReader for Best Effort Readers.
  * @ingroup READER_MODULE
  */
-class StatelessReader: public RTPSReader
+class StatelessReader : public RTPSReader
 {
     friend class RTPSParticipantImpl;
 
 public:
+
     virtual ~StatelessReader();
 
 protected:
@@ -59,21 +60,24 @@ public:
      * @param wdata Pointer to the WPD object to add.
      * @return True if correctly added.
      */
-    bool matched_writer_add(const WriterProxyData& wdata) override;
+    bool matched_writer_add(
+            const WriterProxyData& wdata) override;
 
     /**
      * Remove a WriterProxyData from the matached writers.
      * @param writer_guid GUID of the writer to remove.
      * @return True if correct.
      */
-    bool matched_writer_remove(const GUID_t& writer_guid) override;
+    bool matched_writer_remove(
+            const GUID_t& writer_guid) override;
 
     /**
      * Tells us if a specific Writer is matched against this reader.
      * @param writer_guid GUID of the writer to check.
      * @return True if it is matched.
      */
-    bool matched_writer_is_matched(const GUID_t& writer_guid) override;
+    bool matched_writer_is_matched(
+            const GUID_t& writer_guid) override;
 
     /**
      * Method to indicate the reader that some change has been removed due to HistoryQos requirements.
@@ -91,7 +95,8 @@ public:
      * @param change Pointer to the CacheChange_t.
      * @return true if the reader accepts messages from the.
      */
-    bool processDataMsg(CacheChange_t *change) override;
+    bool processDataMsg(
+            CacheChange_t* change) override;
 
     /**
      * Processes a new DATA FRAG message.
@@ -114,7 +119,7 @@ public:
      * @return true if the reader accepts messages from the.
      */
     bool processHeartbeatMsg(
-            const GUID_t &writerGUID,
+            const GUID_t& writerGUID,
             uint32_t hbCount,
             const SequenceNumber_t& firstSN,
             const SequenceNumber_t& lastSN,
@@ -132,7 +137,8 @@ public:
      * @param a_change Pointer of the change to add.
      * @return True if added.
      */
-    bool change_received(CacheChange_t* a_change);
+    bool change_received(
+            CacheChange_t* a_change);
 
     /**
      * Read the next unread CacheChange_t from the history
@@ -187,7 +193,8 @@ private:
         bool has_manual_topic_liveliness;
     };
 
-    bool acceptMsgFrom(const GUID_t& entityId);
+    bool acceptMsgFrom(
+            const GUID_t& entityId);
 
     bool thereIsUpperRecordOf(
             const GUID_t& guid,
@@ -198,7 +205,8 @@ private:
      * @param guid The guid of the remote writer
      * @return True if writer has manual_by_topic livelinesss
      */
-    bool writer_has_manual_liveliness(const GUID_t& guid);
+    bool writer_has_manual_liveliness(
+            const GUID_t& guid);
 
     //!List of GUID_t os matched writers.
     //!Is only used in the Discovery, to correctly notify the user using SubscriptionListener::onSubscriptionMatched();

--- a/include/fastdds/rtps/reader/StatelessReader.h
+++ b/include/fastdds/rtps/reader/StatelessReader.h
@@ -190,7 +190,8 @@ private:
     {
         GUID_t guid;
         GUID_t persistence_guid;
-        bool has_manual_topic_liveliness;
+        bool has_manual_topic_liveliness = false;
+        CacheChange_t* fragmented_change = nullptr;
     };
 
     bool acceptMsgFrom(

--- a/include/fastdds/rtps/reader/StatelessReader.h
+++ b/include/fastdds/rtps/reader/StatelessReader.h
@@ -201,6 +201,13 @@ private:
             const SequenceNumber_t& seq);
 
     /**
+     * @brief Assert liveliness of remote writer
+     * @param guid The guid of the remote writer
+     */
+    void assert_writer_liveliness(
+            const GUID_t& guid);
+
+    /**
      * @brief A method to check if a matched writer has manual_by_topic liveliness
      * @param guid The guid of the remote writer
      * @return True if writer has manual_by_topic livelinesss

--- a/src/cpp/rtps/reader/FragmentedChangePitStop.h
+++ b/src/cpp/rtps/reader/FragmentedChangePitStop.h
@@ -48,7 +48,8 @@ class FragmentedChangePitStop
          * This constructor has to be used if the ChangeInPit will be used to be stored in a container.
          * @param change Related CacheChange_t.
          */
-        ChangeInPit(CacheChange_t* change)
+        ChangeInPit(
+                CacheChange_t* change)
             : sequence_number_(change->sequenceNumber)
             , change_(change)
         {
@@ -59,13 +60,15 @@ class FragmentedChangePitStop
          * @param sequence_number SequenceNumber_t used as key.
          * @remarks Not use this constructor if the object will be stored in a container.
          */
-        ChangeInPit(const SequenceNumber_t &sequence_number)
+        ChangeInPit(
+                const SequenceNumber_t& sequence_number)
             : sequence_number_(sequence_number)
             , change_(nullptr)
         {
         }
 
-        ChangeInPit(const ChangeInPit& cip)
+        ChangeInPit(
+                const ChangeInPit& cip)
             : sequence_number_(cip.sequence_number_)
             , change_(cip.change_)
         {
@@ -73,95 +76,110 @@ class FragmentedChangePitStop
 
         CacheChange_t* getChange() const { return change_; }
 
-        bool operator==(const ChangeInPit& cip) const
+        bool operator==(
+                const ChangeInPit& cip) const
         {
             return sequence_number_ == cip.sequence_number_;
         }
 
     private:
 
-        ChangeInPit& operator=(const ChangeInPit& cip) = delete;
+        ChangeInPit& operator=(
+                const ChangeInPit& cip) = delete;
 
         const SequenceNumber_t sequence_number_;
         CacheChange_t* change_;
 
     public:
+
         /*!
          * @brief Defined the STD hash function for ChangeInPit.
          */
         struct ChangeInPitHash
         {
-            std::size_t operator()(const ChangeInPit& cip) const
+            std::size_t operator()(
+                    const ChangeInPit& cip) const
             {
-                return SequenceNumberHash{}(cip.sequence_number_);
+                return SequenceNumberHash{} (cip.sequence_number_);
             }
         };
     };
 
-    public:
+public:
 
-/*!
- * @brief Default constructor.
- * @param parent RTPSReader managing this object.
- * It is necessary the access to reserve a new CacheChange_t.
- */
-FragmentedChangePitStop(RTPSReader *parent) : parent_(parent) {}
+    /*!
+     * @brief Default constructor.
+     * @param parent RTPSReader managing this object.
+     * It is necessary the access to reserve a new CacheChange_t.
+     */
+    FragmentedChangePitStop(
+            RTPSReader* parent)
+        : parent_(parent) {}
 
-/*!
- * @brief Process incomming fragments.
- * @param incoming_change. CacheChange_t that stores the incomming fragments.
- * @param sample_size Total size of the sample. It was received in the DATA_FRAG submessage.
- * @param fragment_starting_num. First fragment number in the DATA_FRAG submessage.
- * @param fragments_in_submessage. Number of fragments present in the DATA_FRAG submessage.
- * @return If a CacheChange_t is completed with new incomming fragments, this will be returned.
- * In other case nullptr is returned.
- */
-CacheChange_t* process(
-        CacheChange_t* incoming_change,
-        uint32_t sample_size,
-        FragmentNumber_t fragment_starting_num,
-        uint16_t fragments_in_submessage);
+    /*!
+     * @brief Process incomming fragments.
+     * @param incoming_change. CacheChange_t that stores the incomming fragments.
+     * @param sample_size Total size of the sample. It was received in the DATA_FRAG submessage.
+     * @param fragment_starting_num. First fragment number in the DATA_FRAG submessage.
+     * @param fragments_in_submessage. Number of fragments present in the DATA_FRAG submessage.
+     * @return If a CacheChange_t is completed with new incomming fragments, this will be returned.
+     * In other case nullptr is returned.
+     */
+    CacheChange_t* process(
+            CacheChange_t* incoming_change,
+            uint32_t sample_size,
+            FragmentNumber_t fragment_starting_num,
+            uint16_t fragments_in_submessage);
 
-/*!
- * @brief Search if there is a CacheChange_t, giving SequenceNumber_t and writer GUID_t,
- * waiting to be completed because it is fragmented.
- * @param sequence_number SequenceNumber_t of the searched CacheChange_t.
- * @param writer_guid writer GUID_t of the searched CacheChange_t.
- * @return If a CacheChange_t was found, it will be returned. In other case nullptr is returned.
- */
-CacheChange_t* find(const SequenceNumber_t& sequence_number, const GUID_t& writer_guid);
+    /*!
+     * @brief Search if there is a CacheChange_t, giving SequenceNumber_t and writer GUID_t,
+     * waiting to be completed because it is fragmented.
+     * @param sequence_number SequenceNumber_t of the searched CacheChange_t.
+     * @param writer_guid writer GUID_t of the searched CacheChange_t.
+     * @return If a CacheChange_t was found, it will be returned. In other case nullptr is returned.
+     */
+    CacheChange_t* find(
+            const SequenceNumber_t& sequence_number,
+            const GUID_t& writer_guid);
 
-/*!
- * @brief Checks if there is a CacheChange_t, giving SequenceNumber_t and writer GUID_t.
- * In case there is, it will be removed.
- * @param sequence_number SequenceNumber_t of the searched CacheChange_t.
- * @param writer_guid writer GUID_t of the searched CacheChange_t.
- * @return If a CacheChange_t was found and removed, true value will be returned. In other case
- * false value is returned.
- */
-bool try_to_remove(const SequenceNumber_t& sequence_number, const GUID_t& writer_guid);
+    /*!
+     * @brief Checks if there is a CacheChange_t, giving SequenceNumber_t and writer GUID_t.
+     * In case there is, it will be removed.
+     * @param sequence_number SequenceNumber_t of the searched CacheChange_t.
+     * @param writer_guid writer GUID_t of the searched CacheChange_t.
+     * @return If a CacheChange_t was found and removed, true value will be returned. In other case
+     * false value is returned.
+     */
+    bool try_to_remove(
+            const SequenceNumber_t& sequence_number,
+            const GUID_t& writer_guid);
 
-/*!
- * @brief Checks if there are CacheChange_t, with writer GUID_t and a SequenceNumber_t lower than given SequenceNumber_t.
- * In case there are, they will be removed.
- * @param sequence_number SequenceNumber_t used as maximum.
- * @param writer_guid writer GUID_t of the searched CacheChange_t.
- * @return If some CacheChange_t were found and removed, true value will be returned. In other case
- * false value is returned.
- */
-bool try_to_remove_until(const SequenceNumber_t& sequence_number, const GUID_t& writer_guid);
+    /*!
+     * @brief Checks if there are CacheChange_t, with writer GUID_t and a SequenceNumber_t lower than given SequenceNumber_t.
+     * In case there are, they will be removed.
+     * @param sequence_number SequenceNumber_t used as maximum.
+     * @param writer_guid writer GUID_t of the searched CacheChange_t.
+     * @return If some CacheChange_t were found and removed, true value will be returned. In other case
+     * false value is returned.
+     */
+    bool try_to_remove_until(
+            const SequenceNumber_t& sequence_number,
+            const GUID_t& writer_guid);
 
 private:
 
-std::unordered_multiset<ChangeInPit, ChangeInPit::ChangeInPitHash> changes_;
+    std::unordered_multiset<ChangeInPit, ChangeInPit::ChangeInPitHash> changes_;
 
-RTPSReader* parent_;
+    RTPSReader* parent_;
 
-FragmentedChangePitStop(const FragmentedChangePitStop&) = delete;
+    FragmentedChangePitStop(
+            const FragmentedChangePitStop&) = delete;
 
-FragmentedChangePitStop& operator=(const FragmentedChangePitStop&) = delete;
+    FragmentedChangePitStop& operator=(
+            const FragmentedChangePitStop&) = delete;
 };
-}
+
+} // namespace rtps
 } // namespace fastrtps
 } // namespace eprosima
 

--- a/src/cpp/rtps/reader/FragmentedChangePitStop.h
+++ b/src/cpp/rtps/reader/FragmentedChangePitStop.h
@@ -108,6 +108,22 @@ class FragmentedChangePitStop
 public:
 
     /*!
+     * @brief Add received fragments to change
+     *
+     * @param change Pointer to the change being reassembled
+     * @param incoming_data Serialized payload received on the DATA_FRAG message
+     * @param fragment_starting_num First fragment number (1-based) as received on the DATA_FRAG message
+     * @param fragments_in_submessage Number of fragments as received on the DATA_FRAG message
+     *
+     * @return true if the change is fully reassembled after adding received fragments.
+     */
+    static bool add_fragments_to_change(
+            CacheChange_t* change,
+            const SerializedPayload_t& incoming_data,
+            uint32_t fragment_starting_num,
+            uint32_t fragments_in_submessage);
+
+    /*!
      * @brief Default constructor.
      * @param parent RTPSReader managing this object.
      * It is necessary the access to reserve a new CacheChange_t.

--- a/src/cpp/rtps/reader/StatelessReader.cpp
+++ b/src/cpp/rtps/reader/StatelessReader.cpp
@@ -409,16 +409,9 @@ bool StatelessReader::processDataFragMsg(
                 CacheChange_t* change_completed = nullptr;
                 if (work_change != nullptr)
                 {
-                    work_change->received_fragments(fragmentStartingNum - 1, fragmentsInSubmessage);
-
-                    size_t offset = size_t(fragmentStartingNum - 1) * work_change->getFragmentSize();
-
-                    memcpy(
-                        &work_change->serializedPayload.data[offset],
-                        change_to_add->serializedPayload.data,
-                        change_to_add->serializedPayload.length);
-
-                    if (work_change->is_fully_assembled())
+                    if(FragmentedChangePitStop::add_fragments_to_change(
+                        work_change, change_to_add->serializedPayload,
+                        fragmentStartingNum, fragmentsInSubmessage))
                     {
                         change_completed = work_change;
                         work_change = nullptr;

--- a/src/cpp/rtps/reader/StatelessReader.cpp
+++ b/src/cpp/rtps/reader/StatelessReader.cpp
@@ -37,7 +37,6 @@
 
 using namespace eprosima::fastrtps::rtps;
 
-
 StatelessReader::~StatelessReader()
 {
     logInfo(RTPS_READER, "Removing reader " << this->getGuid());
@@ -77,7 +76,7 @@ bool StatelessReader::matched_writer_add(
         add_persistence_guid(info.guid, info.persistence_guid);
 
         m_acceptMessagesFromUnkownWriters = false;
-        logInfo(RTPS_READER, "Writer " << info.guid << " added to " << m_guid.entityId);
+        logInfo(RTPS_READER, "Writer " << info.guid << " added to reader " << m_guid);
 
         if (liveliness_lease_duration_ < c_TimeInfinite)
         {
@@ -85,9 +84,9 @@ bool StatelessReader::matched_writer_add(
             if ( wlp != nullptr)
             {
                 wlp->sub_liveliness_manager_->add_writer(
-                            wdata.guid(),
-                            liveliness_kind_,
-                            liveliness_lease_duration_);
+                    wdata.guid(),
+                    liveliness_kind_,
+                    liveliness_lease_duration_);
             }
             else
             {
@@ -98,11 +97,12 @@ bool StatelessReader::matched_writer_add(
         return true;
     }
 
-    logWarning(RTPS_READER, "No space to add writer " << wdata.guid() << " to reader " << m_guid.entityId);
+    logWarning(RTPS_READER, "No space to add writer " << wdata.guid() << " to reader " << m_guid);
     return false;
 }
 
-bool StatelessReader::matched_writer_remove(const GUID_t& writer_guid)
+bool StatelessReader::matched_writer_remove(
+        const GUID_t& writer_guid)
 {
     std::lock_guard<RecursiveTimedMutex> guard(mp_mutex);
 
@@ -111,7 +111,7 @@ bool StatelessReader::matched_writer_remove(const GUID_t& writer_guid)
     {
         if (it->guid == writer_guid)
         {
-            logInfo(RTPS_READER, "Writer " << writer_guid << " removed from " << m_guid.entityId);
+            logInfo(RTPS_READER, "Writer " << writer_guid << " removed from " << m_guid);
 
             if (liveliness_lease_duration_ < c_TimeInfinite)
             {
@@ -119,14 +119,14 @@ bool StatelessReader::matched_writer_remove(const GUID_t& writer_guid)
                 if ( wlp != nullptr)
                 {
                     wlp->sub_liveliness_manager_->remove_writer(
-                                writer_guid,
-                                liveliness_kind_,
-                                liveliness_lease_duration_);
+                        writer_guid,
+                        liveliness_kind_,
+                        liveliness_lease_duration_);
                 }
                 else
                 {
                     logError(RTPS_LIVELINESS,
-                             "Finite liveliness lease duration but WLP not enabled, cannot remove writer");
+                        "Finite liveliness lease duration but WLP not enabled, cannot remove writer");
                 }
             }
 
@@ -140,34 +140,36 @@ bool StatelessReader::matched_writer_remove(const GUID_t& writer_guid)
     return false;
 }
 
-bool StatelessReader::matched_writer_is_matched(const GUID_t& writer_guid)
+bool StatelessReader::matched_writer_is_matched(
+        const GUID_t& writer_guid)
 {
     std::lock_guard<RecursiveTimedMutex> guard(mp_mutex);
     return std::any_of(matched_writers_.begin(), matched_writers_.end(),
-        [writer_guid](const RemoteWriterInfo_t& item)
+        [writer_guid](
+                const RemoteWriterInfo_t& item)
         {
             return item.guid == writer_guid;
         });
 }
 
-bool StatelessReader::change_received(CacheChange_t* change)
+bool StatelessReader::change_received(
+        CacheChange_t* change)
 {
     // Only make visible the change if there is not other with bigger sequence number.
     // TODO Revisar si no hay que incluirlo.
-    if(!thereIsUpperRecordOf(change->writerGUID, change->sequenceNumber))
+    if (!thereIsUpperRecordOf(change->writerGUID, change->sequenceNumber))
     {
-        if(mp_history->received_change(change, 0))
+        if (mp_history->received_change(change, 0))
         {
             update_last_notified(change->writerGUID, change->sequenceNumber);
             ++total_unread_;
 
-            if(getListener() != nullptr)
+            if (getListener() != nullptr)
             {
                 getListener()->onNewCacheChangeAdded(this, change);
             }
 
             new_notification_cv_.notify_all();
-
             return true;
         }
     }
@@ -182,9 +184,9 @@ bool StatelessReader::nextUntakenCache(
     std::lock_guard<RecursiveTimedMutex> guard(mp_mutex);
     bool ret = mp_history->get_min_change(change);
 
-    if(ret)
+    if (ret)
     {
-        if(!(*change)->isRead)
+        if (!(*change)->isRead)
         {
             if (0 < total_unread_)
             {
@@ -207,17 +209,17 @@ bool StatelessReader::nextUnreadCache(
     bool found = false;
     std::vector<CacheChange_t*>::iterator it;
 
-    for(it = mp_history->changesBegin();
-            it!=mp_history->changesEnd();++it)
+    for (it = mp_history->changesBegin();
+            it!=mp_history->changesEnd(); ++it)
     {
-        if(!(*it)->isRead)
+        if (!(*it)->isRead)
         {
             found = true;
             break;
         }
     }
 
-    if(found)
+    if (found)
     {
         *change = *it;
         if (0 < total_unread_)
@@ -238,7 +240,7 @@ bool StatelessReader::change_removed_by_history(
         CacheChange_t* ch,
         WriterProxy* /*prox*/)
 {
-    if(!ch->isRead)
+    if (!ch->isRead)
     {
         if (0 < total_unread_)
         {
@@ -249,29 +251,29 @@ bool StatelessReader::change_removed_by_history(
     return true;
 }
 
-bool StatelessReader::processDataMsg(CacheChange_t *change)
+bool StatelessReader::processDataMsg(
+        CacheChange_t* change)
 {
     assert(change);
 
     std::unique_lock<RecursiveTimedMutex> lock(mp_mutex);
 
-    if(acceptMsgFrom(change->writerGUID))
+    if (acceptMsgFrom(change->writerGUID))
     {
-        logInfo(RTPS_MSG_IN, IDSTRING "Trying to add change " << change->sequenceNumber << " TO reader: "
-            << getGuid().entityId);
+        logInfo(RTPS_MSG_IN, IDSTRING "Trying to add change " << change->sequenceNumber << " TO reader: " << m_guid);
 
         if (liveliness_lease_duration_ < c_TimeInfinite)
         {
             if (liveliness_kind_ == MANUAL_BY_TOPIC_LIVELINESS_QOS ||
-                writer_has_manual_liveliness(change->writerGUID))
+                    writer_has_manual_liveliness(change->writerGUID))
             {
                 auto wlp = this->mp_RTPSParticipant->wlp();
                 if ( wlp != nullptr)
                 {
                     wlp->sub_liveliness_manager_->assert_liveliness(
-                                change->writerGUID,
-                                liveliness_kind_,
-                                liveliness_lease_duration_);
+                        change->writerGUID,
+                        liveliness_kind_,
+                        liveliness_lease_duration_);
                 }
                 else
                 {
@@ -283,13 +285,14 @@ bool StatelessReader::processDataMsg(CacheChange_t *change)
         CacheChange_t* change_to_add;
 
         //Reserve a new cache from the corresponding cache pool
-        if(reserveCache(&change_to_add, change->serializedPayload.length))
+        if (reserveCache(&change_to_add, change->serializedPayload.length))
         {
 #if HAVE_SECURITY
-            if(getAttributes().security_attributes().is_payload_protected)
+            if (getAttributes().security_attributes().is_payload_protected)
             {
                 change_to_add->copy_not_memcpy(change);
-                if(!getRTPSParticipant()->security_manager().decode_serialized_payload(change->serializedPayload,
+                if (!getRTPSParticipant()->security_manager().decode_serialized_payload(
+                        change->serializedPayload,
                         change_to_add->serializedPayload, m_guid, change->writerGUID))
                 {
                     releaseCache(change_to_add);
@@ -300,25 +303,25 @@ bool StatelessReader::processDataMsg(CacheChange_t *change)
             else
             {
 #endif
-                if (!change_to_add->copy(change))
-                {
-                    logWarning(RTPS_MSG_IN, IDSTRING "Problem copying CacheChange, received data is: "
+            if (!change_to_add->copy(change))
+            {
+                logWarning(RTPS_MSG_IN, IDSTRING "Problem copying CacheChange, received data is: "
                         << change->serializedPayload.length << " bytes and max size in reader "
-                        << getGuid().entityId << " is " << change_to_add->serializedPayload.max_size);
-                    releaseCache(change_to_add);
-                    return false;
-                }
-#if HAVE_SECURITY
+                        << m_guid << " is " << change_to_add->serializedPayload.max_size);
+                releaseCache(change_to_add);
+                return false;
             }
+#if HAVE_SECURITY
+        }
 #endif
         }
         else
         {
-            logError(RTPS_MSG_IN, IDSTRING "Problem reserving CacheChange in reader: " << getGuid().entityId);
+            logError(RTPS_MSG_IN, IDSTRING "Problem reserving CacheChange in reader: " << m_guid);
             return false;
         }
 
-        if(!change_received(change_to_add))
+        if (!change_received(change_to_add))
         {
             logInfo(RTPS_MSG_IN, IDSTRING "MessageReceiver not add change " << change_to_add->sequenceNumber);
             releaseCache(change_to_add);
@@ -343,15 +346,15 @@ bool StatelessReader::processDataFragMsg(
         if (liveliness_lease_duration_ < c_TimeInfinite)
         {
             if (liveliness_kind_ == MANUAL_BY_TOPIC_LIVELINESS_QOS ||
-                writer_has_manual_liveliness(incomingChange->writerGUID))
+                    writer_has_manual_liveliness(incomingChange->writerGUID))
             {
                 auto wlp = this->mp_RTPSParticipant->wlp();
                 if ( wlp != nullptr)
                 {
                     wlp->sub_liveliness_manager_->assert_liveliness(
-                                incomingChange->writerGUID,
-                                liveliness_kind_,
-                                liveliness_lease_duration_);
+                        incomingChange->writerGUID,
+                        liveliness_kind_,
+                        liveliness_lease_duration_);
                 }
                 else
                 {
@@ -361,20 +364,23 @@ bool StatelessReader::processDataFragMsg(
         }
 
         // Check if CacheChange was received.
-        if(!thereIsUpperRecordOf(incomingChange->writerGUID, incomingChange->sequenceNumber))
+        if (!thereIsUpperRecordOf(incomingChange->writerGUID, incomingChange->sequenceNumber))
         {
-            logInfo(RTPS_MSG_IN, IDSTRING"Trying to add fragment " << incomingChange->sequenceNumber.to64long() << " TO reader: " << getGuid().entityId);
+            logInfo(RTPS_MSG_IN, IDSTRING "Trying to add fragment " << incomingChange->sequenceNumber.to64long() <<
+                " TO reader: " << m_guid);
 
             CacheChange_t* change_to_add = incomingChange;
 
 #if HAVE_SECURITY
-            if(getAttributes().security_attributes().is_payload_protected)
+            if (getAttributes().security_attributes().is_payload_protected)
             {
-                if(reserveCache(&change_to_add, incomingChange->serializedPayload.length)) //Reserve a new cache from the corresponding cache pool
+                // Reserve a new cache from the corresponding cache pool
+                if (reserveCache(&change_to_add, incomingChange->serializedPayload.length)) 
                 {
                     change_to_add->copy_not_memcpy(incomingChange);
-                    if(!getRTPSParticipant()->security_manager().decode_serialized_payload(incomingChange->serializedPayload,
-                                change_to_add->serializedPayload, m_guid, incomingChange->writerGUID))
+                    if (!getRTPSParticipant()->security_manager().decode_serialized_payload(
+                            incomingChange->serializedPayload,
+                            change_to_add->serializedPayload, m_guid, incomingChange->writerGUID))
                     {
                         releaseCache(change_to_add);
                         logWarning(RTPS_MSG_IN, "Cannont decode serialized payload");
@@ -393,16 +399,19 @@ bool StatelessReader::processDataFragMsg(
                 change_to_add, sampleSize, fragmentStartingNum, fragmentsInSubmessage);
 
 #if HAVE_SECURITY
-            if(getAttributes().security_attributes().is_payload_protected)
+            if (getAttributes().security_attributes().is_payload_protected)
+            {
                 releaseCache(change_to_add);
+            }
 #endif
 
             // If the change was completed, process it.
-            if(change_completed != nullptr)
+            if (change_completed != nullptr)
             {
                 if (!change_received(change_completed))
                 {
-                    logInfo(RTPS_MSG_IN, IDSTRING"MessageReceiver not add change " << change_completed->sequenceNumber.to64long());
+                    logInfo(RTPS_MSG_IN,
+                        IDSTRING "MessageReceiver not add change " << change_completed->sequenceNumber.to64long());
 
                     // Release CacheChange_t.
                     releaseCache(change_completed);
@@ -433,9 +442,10 @@ bool StatelessReader::processGapMsg(
     return true;
 }
 
-bool StatelessReader::acceptMsgFrom(const GUID_t& writerId)
+bool StatelessReader::acceptMsgFrom(
+        const GUID_t& writerId)
 {
-    if(this->m_acceptMessagesFromUnkownWriters)
+    if (this->m_acceptMessagesFromUnkownWriters)
     {
         return true;
     }
@@ -445,10 +455,10 @@ bool StatelessReader::acceptMsgFrom(const GUID_t& writerId)
     }
 
     return std::any_of(matched_writers_.begin(), matched_writers_.end(),
-        [& writerId](const RemoteWriterInfo_t& writer)
-        {
-            return writer.guid == writerId;
-        });
+                   [&writerId](const RemoteWriterInfo_t& writer)
+    {
+        return writer.guid == writerId;
+    });
 }
 
 bool StatelessReader::thereIsUpperRecordOf(
@@ -458,7 +468,8 @@ bool StatelessReader::thereIsUpperRecordOf(
     return get_last_notified(guid) >= seq;
 }
 
-bool StatelessReader::writer_has_manual_liveliness(const GUID_t& guid)
+bool StatelessReader::writer_has_manual_liveliness(
+        const GUID_t& guid)
 {
     for (const RemoteWriterInfo_t& writer : matched_writers_)
     {

--- a/src/cpp/rtps/reader/StatelessReader.cpp
+++ b/src/cpp/rtps/reader/StatelessReader.cpp
@@ -39,7 +39,7 @@ using namespace eprosima::fastrtps::rtps;
 
 StatelessReader::~StatelessReader()
 {
-    logInfo(RTPS_READER, "Removing reader " << this->getGuid());
+    logInfo(RTPS_READER, "Removing reader " << m_guid);
 }
 
 StatelessReader::StatelessReader(
@@ -80,7 +80,7 @@ bool StatelessReader::matched_writer_add(
 
         if (liveliness_lease_duration_ < c_TimeInfinite)
         {
-            auto wlp = this->mp_RTPSParticipant->wlp();
+            auto wlp = mp_RTPSParticipant->wlp();
             if ( wlp != nullptr)
             {
                 wlp->sub_liveliness_manager_->add_writer(
@@ -115,7 +115,7 @@ bool StatelessReader::matched_writer_remove(
 
             if (liveliness_lease_duration_ < c_TimeInfinite)
             {
-                auto wlp = this->mp_RTPSParticipant->wlp();
+                auto wlp = mp_RTPSParticipant->wlp();
                 if ( wlp != nullptr)
                 {
                     wlp->sub_liveliness_manager_->remove_writer(
@@ -262,25 +262,7 @@ bool StatelessReader::processDataMsg(
     {
         logInfo(RTPS_MSG_IN, IDSTRING "Trying to add change " << change->sequenceNumber << " TO reader: " << m_guid);
 
-        if (liveliness_lease_duration_ < c_TimeInfinite)
-        {
-            if (liveliness_kind_ == MANUAL_BY_TOPIC_LIVELINESS_QOS ||
-                    writer_has_manual_liveliness(change->writerGUID))
-            {
-                auto wlp = this->mp_RTPSParticipant->wlp();
-                if ( wlp != nullptr)
-                {
-                    wlp->sub_liveliness_manager_->assert_liveliness(
-                        change->writerGUID,
-                        liveliness_kind_,
-                        liveliness_lease_duration_);
-                }
-                else
-                {
-                    logError(RTPS_LIVELINESS, "Finite liveliness lease duration but WLP not enabled");
-                }
-            }
-        }
+        assert_writer_liveliness(change->writerGUID);
 
         CacheChange_t* change_to_add;
 
@@ -343,25 +325,7 @@ bool StatelessReader::processDataFragMsg(
 
     if (acceptMsgFrom(incomingChange->writerGUID))
     {
-        if (liveliness_lease_duration_ < c_TimeInfinite)
-        {
-            if (liveliness_kind_ == MANUAL_BY_TOPIC_LIVELINESS_QOS ||
-                    writer_has_manual_liveliness(incomingChange->writerGUID))
-            {
-                auto wlp = this->mp_RTPSParticipant->wlp();
-                if ( wlp != nullptr)
-                {
-                    wlp->sub_liveliness_manager_->assert_liveliness(
-                        incomingChange->writerGUID,
-                        liveliness_kind_,
-                        liveliness_lease_duration_);
-                }
-                else
-                {
-                    logError(RTPS_LIVELINESS, "Finite liveliness lease duration but WLP not enabled");
-                }
-            }
-        }
+        assert_writer_liveliness(incomingChange->writerGUID);
 
         // Check if CacheChange was received.
         if (!thereIsUpperRecordOf(incomingChange->writerGUID, incomingChange->sequenceNumber))
@@ -445,11 +409,11 @@ bool StatelessReader::processGapMsg(
 bool StatelessReader::acceptMsgFrom(
         const GUID_t& writerId)
 {
-    if (this->m_acceptMessagesFromUnkownWriters)
+    if (m_acceptMessagesFromUnkownWriters)
     {
         return true;
     }
-    else if (writerId.entityId == this->m_trustedWriterEntityId)
+    else if (writerId.entityId == m_trustedWriterEntityId)
     {
         return true;
     }
@@ -466,6 +430,30 @@ bool StatelessReader::thereIsUpperRecordOf(
         const SequenceNumber_t& seq)
 {
     return get_last_notified(guid) >= seq;
+}
+
+void StatelessReader::assert_writer_liveliness(
+        const GUID_t& guid)
+{
+    if (liveliness_lease_duration_ < c_TimeInfinite)
+    {
+        if (liveliness_kind_ == MANUAL_BY_TOPIC_LIVELINESS_QOS ||
+            writer_has_manual_liveliness(guid))
+        {
+            auto wlp = mp_RTPSParticipant->wlp();
+            if (wlp != nullptr)
+            {
+                wlp->sub_liveliness_manager_->assert_liveliness(
+                    guid,
+                    liveliness_kind_,
+                    liveliness_lease_duration_);
+            }
+            else
+            {
+                logError(RTPS_LIVELINESS, "Finite liveliness lease duration but WLP not enabled");
+            }
+        }
+    }
 }
 
 bool StatelessReader::writer_has_manual_liveliness(


### PR DESCRIPTION
This is a follow-up of #789 

In order to avoid dynamic allocations and improve performance, this PR changes StatelessReader to avoid the usage of FragmentedChangePitStop, by having a single change pending reconstruction per matched writer.

The only drawback is that it removes the reception of fragments from unknown writers, but that should only happen with DATA(p) messages which are usually small enough to be sent on a single DATA message.