### PR TITLE
Refs #6611: Bugfix/throughput wait and sync [6678]

### DIFF
--- a/test/performance/ThroughputPublisher.cpp
+++ b/test/performance/ThroughputPublisher.cpp
@@ -509,17 +509,6 @@ bool ThroughputPublisher::test(
 
     mp_datapub = Domain::createPublisher(mp_par, pubAttr, &m_DataPubListener);
 
-    t_end_ = std::chrono::steady_clock::now();
-
-    std::chrono::duration<double, std::micro> timewait_us(0);
-    std::chrono::duration<double, std::micro> test_time_us = std::chrono::seconds(test_time);
-    uint32_t samples = 0;
-    size_t aux;
-    ThroughputCommandType command;
-    SampleInfo_t info;
-    command.m_command = TEST_STARTS;
-    mp_commandpub->write((void*)&command);
-
     std::unique_lock<std::mutex> data_disc_lock(dataMutex_);
     data_disc_cond_.wait(data_disc_lock, [&]()
     {
@@ -527,9 +516,35 @@ bool ThroughputPublisher::test(
     });
     data_disc_lock.unlock();
 
+    // Declate test time variables
+    std::chrono::duration<double, std::micro> timewait_us(0);
+    std::chrono::duration<double, std::micro> test_time_us = std::chrono::seconds(test_time);
+    std::chrono::steady_clock::time_point batch_start;
+
+    // Send a TEST_STARTS and sleep for a while to give the subscriber time to set up
+    uint32_t samples = 0;
+    size_t aux;
+    ThroughputCommandType command;
+    SampleInfo_t info;
+    command.m_command = TEST_STARTS;
+    mp_commandpub->write((void*)&command);
+
+    // If the subscriber does not acknowledge the TEST_STARTS in time, we consider something went wrong.
+    std::chrono::steady_clock::time_point data_disc_start = std::chrono::steady_clock::now();
+    if (!mp_commandpub->wait_for_all_acked(eprosima::fastrtps::Time_t(20, 0)))
+    {
+        std::cout << "Something went wrong: The subscriber has not acknowledged the TEST_STARTS command." << std::endl;
+        return false;
+    }
+    timewait_us += std::chrono::duration<double, std::micro>(std::chrono::steady_clock::now() - data_disc_start);
+
+    // Send batches until test_time_us is reached
     t_start_ = std::chrono::steady_clock::now();
     while (std::chrono::duration<double, std::micro>(t_end_ - t_start_) < test_time_us)
     {
+        // Get start time
+        batch_start = std::chrono::steady_clock::now();
+        // Send a batch of size demand
         for (uint32_t sample = 0; sample < demand; sample++)
         {
             if (dynamic_data)
@@ -543,10 +558,19 @@ bool ThroughputPublisher::test(
                 mp_datapub->write((void*)throughput);
             }
         }
+        // Get end time
         t_end_ = std::chrono::steady_clock::now();
+        // Add the number of sent samples
         samples += demand;
-        std::this_thread::sleep_for(std::chrono::milliseconds(recovery_time_ms));
-        timewait_us += t_overhead_;
+
+        // If the batch took less than the recovery time, sleep for the difference recovery_time - batch_duration.
+        // Else, go ahead with next batch without time to recover.
+        if ((t_end_ - batch_start) <= std::chrono::milliseconds(recovery_time_ms))
+        {
+            std::this_thread::sleep_for(std::chrono::milliseconds(recovery_time_ms) - (t_end_ - batch_start));
+        }
+
+        timewait_us += t_overhead_ * 2; // We access the clock twice per batch.
     }
     command.m_command = TEST_ENDS;
 

--- a/test/performance/ThroughputSubscriber.cpp
+++ b/test/performance/ThroughputSubscriber.cpp
@@ -171,126 +171,6 @@ void ThroughputSubscriber::CommandSubListener::onNewDataMessage(Subscriber*)
 }
 
 // *******************************************************************************************
-// ********************************** THROUGHPUT SUBSCRIBER **********************************
-// *******************************************************************************************
-void ThroughputSubscriber::processMessage()
-{
-    if (mp_commandsub->takeNextData((void*)&m_CommandSubListener.m_commandin, &m_CommandSubListener.info))
-    {
-        switch (m_CommandSubListener.m_commandin.m_command)
-        {
-            case (DEFAULT):
-            {
-                break;
-            }
-            case (BEGIN):
-            {
-                break;
-            }
-            case (READY_TO_START):
-            {
-                std::cout << "-----------------------------------------------------------------------" << std::endl;
-                std::cout << "Command: READY_TO_START" << std::endl;
-                m_datasize = m_CommandSubListener.m_commandin.m_size;
-                m_demand = m_CommandSubListener.m_commandin.m_demand;
-
-                if (dynamic_data)
-                {
-                    // Create basic builders
-                    DynamicTypeBuilder_ptr struct_type_builder(
-                        DynamicTypeBuilderFactory::get_instance()->create_struct_builder());
-
-                    // Add members to the struct.
-                    struct_type_builder->add_member(
-                        0,
-                        "seqnum",
-                        DynamicTypeBuilderFactory::get_instance()->create_uint32_type());
-                    struct_type_builder->add_member(
-                        1,
-                        "data",
-                        DynamicTypeBuilderFactory::get_instance()->create_sequence_builder(
-                            DynamicTypeBuilderFactory::get_instance()->create_byte_type(),
-                            m_datasize));
-
-                    struct_type_builder->set_name("ThroughputType");
-                    m_pDynType = struct_type_builder->build();
-                    m_DynType.CleanDynamicType();
-                    m_DynType.SetDynamicType(m_pDynType);
-
-                    Domain::registerType(mp_par, &m_DynType);
-
-                    m_DynData = DynamicDataFactory::get_instance()->create_data(m_pDynType);
-                }
-                else
-                {
-                    delete(throughput_t);
-                    delete(throughputin);
-
-                    throughput_t = new ThroughputDataType(m_datasize);
-                    Domain::registerType(mp_par, throughput_t);
-                    throughputin = new ThroughputType((uint16_t)m_datasize);
-                }
-
-                mp_datasub = Domain::createSubscriber(mp_par, subAttr, &m_DataSubListener);
-
-                ThroughputCommandType command(BEGIN);
-                std::this_thread::sleep_for(std::chrono::milliseconds(50));
-                m_DataSubListener.reset();
-                mp_commandpubli->write(&command);
-
-                std::cout << "Waiting for data discovery" << std::endl;
-                std::unique_lock<std::mutex> data_disc_lock(dataMutex_);
-                data_disc_cond_.wait(data_disc_lock, [&]()
-                {
-                    return data_disc_count_ > 0;
-                });
-                data_disc_lock.unlock();
-                std::cout << "Discovery data complete" << std::endl;
-                break;
-            }
-            case (TEST_STARTS):
-            {
-                std::cout << "Command: TEST_STARTS" << std::endl;
-                t_start_ = std::chrono::steady_clock::now();
-                break;
-            }
-            case (TEST_ENDS):
-            {
-                t_end_ = std::chrono::steady_clock::now();
-                std::cout << "Command: TEST_ENDS" << std::endl;
-                m_DataSubListener.saveNumbers();
-                std::unique_lock<std::mutex> lock(mutex_);
-                stop_count_ = 1;
-                lock.unlock();
-                if (dynamic_data)
-                {
-                    DynamicTypeBuilderFactory::delete_instance();
-                    DynamicDataFactory::get_instance()->delete_data(m_DynData);
-                }
-                else
-                {
-                    delete(throughputin);
-                    throughputin = nullptr;
-                }
-                subAttr = mp_datasub->getAttributes();
-                break;
-            }
-            case (ALL_STOPS):
-            {
-                std::unique_lock<std::mutex> lock(mutex_);
-                stop_count_ = 2;
-                lock.unlock();
-                std::cout << "Command: ALL_STOPS" << std::endl;
-            }
-            default:
-            {
-                break;
-            }
-        }
-    }
-}
-
-// *******************************************************************************************
 // *********************************** COMMAND PUB LISTENER **********************************
 // *******************************************************************************************
 ThroughputSubscriber::CommandPubListener::CommandPubListener(ThroughputSubscriber& up)
@@ -322,6 +202,10 @@ void ThroughputSubscriber::CommandPubListener::onPublicationMatched(
     lock.unlock();
     m_up.disc_cond_.notify_one();
 }
+
+// *******************************************************************************************
+// ********************************** THROUGHPUT SUBSCRIBER **********************************
+// *******************************************************************************************
 
 ThroughputSubscriber::~ThroughputSubscriber()
 {
@@ -514,6 +398,126 @@ ThroughputSubscriber::ThroughputSubscriber(
     }
 
     std::this_thread::sleep_for(std::chrono::milliseconds(1000));
+}
+
+void ThroughputSubscriber::processMessage()
+{
+    if(mp_commandsub->wait_for_unread_samples({100, 0}))
+    {
+        if (mp_commandsub->takeNextData((void*)&m_CommandSubListener.m_commandin, &m_CommandSubListener.info))
+        {
+            switch (m_CommandSubListener.m_commandin.m_command)
+            {
+                case (DEFAULT):
+                {
+                    break;
+                }
+                case (BEGIN):
+                {
+                    break;
+                }
+                case (READY_TO_START):
+                {
+                    std::cout << "-----------------------------------------------------------------------" << std::endl;
+                    std::cout << "Command: READY_TO_START" << std::endl;
+                    m_datasize = m_CommandSubListener.m_commandin.m_size;
+                    m_demand = m_CommandSubListener.m_commandin.m_demand;
+
+                    if (dynamic_data)
+                    {
+                        // Create basic builders
+                        DynamicTypeBuilder_ptr struct_type_builder(
+                            DynamicTypeBuilderFactory::get_instance()->create_struct_builder());
+
+                        // Add members to the struct.
+                        struct_type_builder->add_member(
+                            0,
+                            "seqnum",
+                            DynamicTypeBuilderFactory::get_instance()->create_uint32_type());
+                        struct_type_builder->add_member(
+                            1,
+                            "data",
+                            DynamicTypeBuilderFactory::get_instance()->create_sequence_builder(
+                                DynamicTypeBuilderFactory::get_instance()->create_byte_type(),
+                                m_datasize));
+
+                        struct_type_builder->set_name("ThroughputType");
+                        m_pDynType = struct_type_builder->build();
+                        m_DynType.CleanDynamicType();
+                        m_DynType.SetDynamicType(m_pDynType);
+
+                        Domain::registerType(mp_par, &m_DynType);
+
+                        m_DynData = DynamicDataFactory::get_instance()->create_data(m_pDynType);
+                    }
+                    else
+                    {
+                        delete(throughput_t);
+                        delete(throughputin);
+
+                        throughput_t = new ThroughputDataType(m_datasize);
+                        Domain::registerType(mp_par, throughput_t);
+                        throughputin = new ThroughputType((uint16_t)m_datasize);
+                    }
+
+                    mp_datasub = Domain::createSubscriber(mp_par, subAttr, &m_DataSubListener);
+
+                    ThroughputCommandType command(BEGIN);
+                    std::this_thread::sleep_for(std::chrono::milliseconds(50));
+                    m_DataSubListener.reset();
+                    mp_commandpubli->write(&command);
+
+                    std::cout << "Waiting for data discovery" << std::endl;
+                    std::unique_lock<std::mutex> data_disc_lock(dataMutex_);
+                    data_disc_cond_.wait(data_disc_lock, [&]()
+                    {
+                        return data_disc_count_ > 0;
+                    });
+                    data_disc_lock.unlock();
+                    std::cout << "Discovery data complete" << std::endl;
+                    break;
+                }
+                case (TEST_STARTS):
+                {
+                    std::cout << "Command: TEST_STARTS" << std::endl;
+                    t_start_ = std::chrono::steady_clock::now();
+                    break;
+                }
+                case (TEST_ENDS):
+                {
+                    t_end_ = std::chrono::steady_clock::now();
+                    std::cout << "Command: TEST_ENDS" << std::endl;
+                    m_DataSubListener.saveNumbers();
+                    std::unique_lock<std::mutex> lock(mutex_);
+                    stop_count_ = 1;
+                    lock.unlock();
+                    if (dynamic_data)
+                    {
+                        DynamicTypeBuilderFactory::delete_instance();
+                        DynamicDataFactory::get_instance()->delete_data(m_DynData);
+                    }
+                    else
+                    {
+                        delete(throughputin);
+                        throughputin = nullptr;
+                    }
+                    subAttr = mp_datasub->getAttributes();
+                    break;
+                }
+                case (ALL_STOPS):
+                {
+                    std::unique_lock<std::mutex> lock(mutex_);
+                    stop_count_ = 2;
+                    lock.unlock();
+                    std::cout << "Command: ALL_STOPS" << std::endl;
+                }
+                default:
+                {
+                    break;
+                }
+            }
+        }
+    }
 }
 
 void ThroughputSubscriber::run()

--- a/test/performance/ThroughputSubscriber.h
+++ b/test/performance/ThroughputSubscriber.h
@@ -52,17 +52,23 @@ class ThroughputSubscriber
 {
 public:
 
-    ThroughputSubscriber(bool reliable, uint32_t pid, bool hostname,
+    ThroughputSubscriber(
+        bool reliable,
+        uint32_t pid,
+        bool hostname,
         const eprosima::fastrtps::rtps::PropertyPolicy& part_property_policy,
         const eprosima::fastrtps::rtps::PropertyPolicy& property_policy,
-        const std::string& sXMLConfigFile, bool dynamic_types, int forced_domain);
+        const std::string& sXMLConfigFile,
+        bool dynamic_types,
+        int forced_domain);
     virtual ~ThroughputSubscriber();
     void processMessage();
     eprosima::fastrtps::Participant* mp_par;
     eprosima::fastrtps::Subscriber* mp_datasub;
     eprosima::fastrtps::Publisher* mp_commandpubli;
     eprosima::fastrtps::Subscriber* mp_commandsub;
-    std::chrono::steady_clock::time_point t_start_, t_end_;
+    std::chrono::steady_clock::time_point t_start_;
+    std::chrono::steady_clock::time_point t_end_;
     std::chrono::duration<double, std::micro> t_overhead_;
     std::mutex mutex_;
     uint32_t disc_count_;


### PR DESCRIPTION
Publisher
    * Discover data subscriber before sending TEST_STARTS command
    * Wait for ack when sending TEST_STARTS
    * Only wait whatever is left of `recovery_time`
Subscriber
    * wait_for_unread_samples instead of attempting to `take` all the time