### PR TITLE
[1.9.x] Fix reception of ParameterList [6685]

### DIFF
--- a/src/cpp/qos/ParameterList.cpp
+++ b/src/cpp/qos/ParameterList.cpp
@@ -27,7 +27,19 @@ namespace fastrtps {
 
 using namespace rtps;
 
-#define IF_VALID_CALL {if(valid){qos_size += plength;if(!processor(&p)) return false;}else{return false;}break;}
+#define IF_VALID_CALL() {                              \
+                            if(valid)                  \
+                            {                          \
+                                qos_size += plength;   \
+                                if(!processor(&p))     \
+                                    return false;      \
+                            }                          \
+                            else                       \
+                            {                          \
+                                return false;          \
+                            }                          \
+                            break;                     \
+                        }
 
 bool ParameterList::writeEncapsulationToCDRMsg(rtps::CDRMessage_t* msg)
 {
@@ -150,7 +162,7 @@ bool ParameterList::readParameterListfromCDRMsg(CDRMessage_t& msg, std::function
                     ParameterLocator_t p(pid, plength);
                     valid &= CDRMessage::readLocator(&msg, &p.locator);
                     valid &= (plength == PARAMETER_LOCATOR_LENGTH);
-                    IF_VALID_CALL
+                    IF_VALID_CALL()
                 }
                 case PID_DEFAULT_UNICAST_PORT:
                 case PID_METATRAFFIC_UNICAST_PORT:
@@ -159,7 +171,7 @@ bool ParameterList::readParameterListfromCDRMsg(CDRMessage_t& msg, std::function
                     ParameterPort_t p(pid, plength);
                     valid &= CDRMessage::readUInt32(&msg, &p.port);
                     valid &= (plength == PARAMETER_LOCATOR_LENGTH);
-                    IF_VALID_CALL
+                    IF_VALID_CALL()
                 }
                 case PID_PROTOCOL_VERSION:
                 {
@@ -168,7 +180,7 @@ bool ParameterList::readParameterListfromCDRMsg(CDRMessage_t& msg, std::function
                     valid &= CDRMessage::readOctet(&msg, &p.protocolVersion.m_minor);
                     valid &= (plength == PARAMETER_PROTOCOL_LENGTH);
                     msg.pos += 2;
-                    IF_VALID_CALL
+                    IF_VALID_CALL()
                 }
                 case PID_EXPECTS_INLINE_QOS:
                 {
@@ -179,7 +191,7 @@ bool ParameterList::readParameterListfromCDRMsg(CDRMessage_t& msg, std::function
                     ParameterBool_t p(PID_EXPECTS_INLINE_QOS, plength);
                     valid &= CDRMessage::readOctet(&msg, (octet*)&p.value);
                     msg.pos += 3;
-                    IF_VALID_CALL
+                    IF_VALID_CALL()
                 }
                 case PID_VENDORID:
                 {
@@ -188,7 +200,7 @@ bool ParameterList::readParameterListfromCDRMsg(CDRMessage_t& msg, std::function
                     valid &= CDRMessage::readOctet(&msg, &p.vendorId[1]);
                     valid &= (plength == PARAMETER_VENDOR_LENGTH);
                     msg.pos += 2;
-                    IF_VALID_CALL
+                    IF_VALID_CALL()
                 }
                 case PID_MULTICAST_IPADDRESS:
                 case PID_DEFAULT_UNICAST_IPADDRESS:
@@ -224,7 +236,7 @@ bool ParameterList::readParameterListfromCDRMsg(CDRMessage_t& msg, std::function
                     ParameterGuid_t p(pid, plength);
                     valid &= CDRMessage::readData(&msg, p.guid.guidPrefix.value, 12);
                     valid &= CDRMessage::readData(&msg, p.guid.entityId.value, 4);
-                    IF_VALID_CALL
+                    IF_VALID_CALL()
                 }
                 case PID_TOPIC_NAME:
                 case PID_TYPE_NAME:
@@ -240,7 +252,7 @@ bool ParameterList::readParameterListfromCDRMsg(CDRMessage_t& msg, std::function
                     p.setName(aux.c_str());
                     //                cout << "READ: "<< p.m_string<<endl;
                     //                cout << msg.pos << endl;
-                    IF_VALID_CALL
+                    IF_VALID_CALL()
                 }
                 case PID_PROPERTY_LIST:
                 {
@@ -305,7 +317,7 @@ bool ParameterList::readParameterListfromCDRMsg(CDRMessage_t& msg, std::function
                     }
                     ParameterKey_t p(PID_KEY_HASH, 16);
                     valid &= CDRMessage::readData(&msg, p.key.value, 16);
-                    IF_VALID_CALL
+                    IF_VALID_CALL()
                 }
                 case PID_SENTINEL:
                 {
@@ -321,7 +333,7 @@ bool ParameterList::readParameterListfromCDRMsg(CDRMessage_t& msg, std::function
                     DurabilityQosPolicy p;
                     valid &= CDRMessage::readOctet(&msg, (octet*)&p.kind);
                     msg.pos += 3;
-                    IF_VALID_CALL
+                    IF_VALID_CALL()
                 }
                 case PID_DEADLINE:
                 {
@@ -334,7 +346,7 @@ bool ParameterList::readParameterListfromCDRMsg(CDRMessage_t& msg, std::function
                     uint32_t frac(0);
                     valid &= CDRMessage::readUInt32(&msg, &frac);
                     p.period.fraction(frac);
-                    IF_VALID_CALL
+                    IF_VALID_CALL()
                 }
                 case PID_LATENCY_BUDGET:
                 {
@@ -347,7 +359,7 @@ bool ParameterList::readParameterListfromCDRMsg(CDRMessage_t& msg, std::function
                     uint32_t frac(0);
                     valid &= CDRMessage::readUInt32(&msg, &frac);
                     p.duration.fraction(frac);
-                    IF_VALID_CALL
+                    IF_VALID_CALL()
                 }
                 case PID_LIVELINESS:
                 {
@@ -362,7 +374,7 @@ bool ParameterList::readParameterListfromCDRMsg(CDRMessage_t& msg, std::function
                     uint32_t frac(0);
                     valid &= CDRMessage::readUInt32(&msg, &frac);
                     p.lease_duration.fraction(frac);
-                    IF_VALID_CALL
+                    IF_VALID_CALL()
                 }
                 case PID_OWNERSHIP:
                 {
@@ -373,7 +385,7 @@ bool ParameterList::readParameterListfromCDRMsg(CDRMessage_t& msg, std::function
                     OwnershipQosPolicy p;
                     valid &= CDRMessage::readOctet(&msg, (octet*)&p.kind);
                     msg.pos += 3;
-                    IF_VALID_CALL
+                    IF_VALID_CALL()
                 }
                 case PID_RELIABILITY:
                 {
@@ -388,7 +400,7 @@ bool ParameterList::readParameterListfromCDRMsg(CDRMessage_t& msg, std::function
                     uint32_t frac(0);
                     valid &= CDRMessage::readUInt32(&msg, &frac);
                     p.max_blocking_time.fraction(frac);
-                    IF_VALID_CALL
+                    IF_VALID_CALL()
                 }
                 case PID_DESTINATION_ORDER:
                 {
@@ -399,7 +411,7 @@ bool ParameterList::readParameterListfromCDRMsg(CDRMessage_t& msg, std::function
                     DestinationOrderQosPolicy p;
                     valid &= CDRMessage::readOctet(&msg, (octet*)&p.kind);
                     msg.pos += 3;
-                    IF_VALID_CALL
+                    IF_VALID_CALL()
                 }
                 case PID_USER_DATA:
                 {
@@ -445,7 +457,7 @@ bool ParameterList::readParameterListfromCDRMsg(CDRMessage_t& msg, std::function
                     uint32_t frac(0);
                     valid &= CDRMessage::readUInt32(&msg, &frac);
                     p.minimum_separation.fraction(frac);
-                    IF_VALID_CALL
+                    IF_VALID_CALL()
                 }
                 case PID_PRESENTATION:
                 {
@@ -459,7 +471,7 @@ bool ParameterList::readParameterListfromCDRMsg(CDRMessage_t& msg, std::function
                     valid &= CDRMessage::readOctet(&msg, (octet*)&p.coherent_access);
                     valid &= CDRMessage::readOctet(&msg, (octet*)&p.ordered_access);
                     msg.pos += 2;
-                    IF_VALID_CALL
+                    IF_VALID_CALL()
                 }
                 case PID_PARTITION:
                 {
@@ -481,7 +493,7 @@ bool ParameterList::readParameterListfromCDRMsg(CDRMessage_t& msg, std::function
                         p.names.push_back(auxstr);
                     }
 
-                    IF_VALID_CALL
+                    IF_VALID_CALL()
                 }
                 case PID_TOPIC_DATA:
                 {
@@ -496,7 +508,7 @@ bool ParameterList::readParameterListfromCDRMsg(CDRMessage_t& msg, std::function
                     {
                         return false;
                     }
-                    IF_VALID_CALL
+                    IF_VALID_CALL()
                 }
                 case PID_GROUP_DATA:
                 {
@@ -511,7 +523,7 @@ bool ParameterList::readParameterListfromCDRMsg(CDRMessage_t& msg, std::function
                     {
                         return false;
                     }
-                    IF_VALID_CALL
+                    IF_VALID_CALL()
                 }
                 case PID_HISTORY:
                 {
@@ -522,7 +534,7 @@ bool ParameterList::readParameterListfromCDRMsg(CDRMessage_t& msg, std::function
                     HistoryQosPolicy p;
                     valid &= CDRMessage::readOctet(&msg, (octet*)&p.kind); msg.pos += 3;
                     valid &= CDRMessage::readInt32(&msg, &p.depth);
-                    IF_VALID_CALL
+                    IF_VALID_CALL()
                 }
                 case PID_DURABILITY_SERVICE:
                 {
@@ -540,7 +552,7 @@ bool ParameterList::readParameterListfromCDRMsg(CDRMessage_t& msg, std::function
                     valid &= CDRMessage::readInt32(&msg, &p.max_samples);
                     valid &= CDRMessage::readInt32(&msg, &p.max_instances);
                     valid &= CDRMessage::readInt32(&msg, &p.max_samples_per_instance);
-                    IF_VALID_CALL
+                    IF_VALID_CALL()
                 }
                 case PID_LIFESPAN:
                 {
@@ -553,7 +565,7 @@ bool ParameterList::readParameterListfromCDRMsg(CDRMessage_t& msg, std::function
                     uint32_t frac(0);
                     valid &= CDRMessage::readUInt32(&msg, &frac);
                     p.duration.fraction(frac);
-                    IF_VALID_CALL
+                    IF_VALID_CALL()
                 }
                 case PID_OWNERSHIP_STRENGTH:
                 {
@@ -563,7 +575,7 @@ bool ParameterList::readParameterListfromCDRMsg(CDRMessage_t& msg, std::function
                     }
                     OwnershipStrengthQosPolicy p;
                     valid &= CDRMessage::readUInt32(&msg, &p.value);
-                    IF_VALID_CALL
+                    IF_VALID_CALL()
                 }
                 case PID_RESOURCE_LIMITS:
                 {
@@ -575,7 +587,7 @@ bool ParameterList::readParameterListfromCDRMsg(CDRMessage_t& msg, std::function
                     valid &= CDRMessage::readInt32(&msg, &p.max_samples);
                     valid &= CDRMessage::readInt32(&msg, &p.max_instances);
                     valid &= CDRMessage::readInt32(&msg, &p.max_samples_per_instance);
-                    IF_VALID_CALL
+                    IF_VALID_CALL()
                 }
                 case PID_TRANSPORT_PRIORITY:
                 {
@@ -585,7 +597,7 @@ bool ParameterList::readParameterListfromCDRMsg(CDRMessage_t& msg, std::function
                     }
                     TransportPriorityQosPolicy p;
                     valid &= CDRMessage::readUInt32(&msg, &p.value);
-                    IF_VALID_CALL
+                    IF_VALID_CALL()
                 }
                 case PID_PARTICIPANT_MANUAL_LIVELINESS_COUNT:
                 {
@@ -595,7 +607,7 @@ bool ParameterList::readParameterListfromCDRMsg(CDRMessage_t& msg, std::function
                     }
                     ParameterCount_t p(PID_PARTICIPANT_MANUAL_LIVELINESS_COUNT, plength);
                     valid &= CDRMessage::readUInt32(&msg, &p.count);
-                    IF_VALID_CALL
+                    IF_VALID_CALL()
                 }
                 case PID_PARTICIPANT_BUILTIN_ENDPOINTS:
                 case PID_BUILTIN_ENDPOINT_SET:
@@ -606,7 +618,7 @@ bool ParameterList::readParameterListfromCDRMsg(CDRMessage_t& msg, std::function
                     }
                     ParameterBuiltinEndpointSet_t p(pid, plength);
                     valid &= CDRMessage::readUInt32(&msg, &p.endpointSet);
-                    IF_VALID_CALL
+                    IF_VALID_CALL()
                 }
                 case PID_PARTICIPANT_LEASE_DURATION:
                 {
@@ -621,7 +633,7 @@ bool ParameterList::readParameterListfromCDRMsg(CDRMessage_t& msg, std::function
                     uint32_t frac(0);
                     valid &= CDRMessage::readUInt32(&msg, &frac);
                     p.time.fraction(frac);
-                    IF_VALID_CALL
+                    IF_VALID_CALL()
                 }
                 case PID_CONTENT_FILTER_PROPERTY:
                 {
@@ -642,7 +654,7 @@ bool ParameterList::readParameterListfromCDRMsg(CDRMessage_t& msg, std::function
                     }
                     ParameterEntityId_t p(pid, plength);
                     valid &= CDRMessage::readEntityId(&msg, &p.entityId);
-                    IF_VALID_CALL
+                    IF_VALID_CALL()
                 }
                 case PID_TYPE_MAX_SIZE_SERIALIZED:
                 {
@@ -652,7 +664,7 @@ bool ParameterList::readParameterListfromCDRMsg(CDRMessage_t& msg, std::function
                     }
                     ParameterCount_t p(pid, plength);
                     valid &= CDRMessage::readUInt32(&msg, &p.count);
-                    IF_VALID_CALL
+                    IF_VALID_CALL()
                 }
                 case PID_RELATED_SAMPLE_IDENTITY:
                 {
@@ -663,7 +675,7 @@ bool ParameterList::readParameterListfromCDRMsg(CDRMessage_t& msg, std::function
                         valid &= CDRMessage::readData(&msg, p.sample_id.writer_guid().entityId.value, EntityId_t::size);
                         valid &= CDRMessage::readInt32(&msg, &p.sample_id.sequence_number().high);
                         valid &= CDRMessage::readUInt32(&msg, &p.sample_id.sequence_number().low);
-                        IF_VALID_CALL
+                        IF_VALID_CALL()
                     }
                     else if (plength > msg.length - msg.pos || plength > 24)
                     {
@@ -689,7 +701,7 @@ bool ParameterList::readParameterListfromCDRMsg(CDRMessage_t& msg, std::function
                         p.m_value.push_back(static_cast<DataRepresentationId_t>(temp));
 
                     }
-                    IF_VALID_CALL
+                    IF_VALID_CALL()
                 }
                 case PID_TYPE_CONSISTENCY_ENFORCEMENT:
                 {
@@ -727,7 +739,7 @@ bool ParameterList::readParameterListfromCDRMsg(CDRMessage_t& msg, std::function
                             valid &= CDRMessage::readOctet(&msg, &temp);
                         }
 
-                        IF_VALID_CALL
+                        IF_VALID_CALL()
                     }
 
                     return false;
@@ -736,13 +748,13 @@ bool ParameterList::readParameterListfromCDRMsg(CDRMessage_t& msg, std::function
                 {
                     TypeIdV1 p;
                     valid &= p.readFromCDRMessage(&msg, plength);
-                    IF_VALID_CALL
+                    IF_VALID_CALL()
                 }
                 case PID_TYPE_OBJECTV1:
                 {
                     TypeObjectV1 p;
                     valid &= p.readFromCDRMessage(&msg, plength);
-                    IF_VALID_CALL
+                    IF_VALID_CALL()
                 }
 
 #if HAVE_SECURITY
@@ -752,7 +764,7 @@ bool ParameterList::readParameterListfromCDRMsg(CDRMessage_t& msg, std::function
                     ParameterToken_t p(pid, plength);
                     valid &= CDRMessage::readDataHolder(&msg, p.token);
                     msg.pos += (4 - msg.pos % 4) & 3; //align
-                    IF_VALID_CALL
+                    IF_VALID_CALL()
                 }
 
                 case PID_PARTICIPANT_SECURITY_INFO:
@@ -764,7 +776,7 @@ bool ParameterList::readParameterListfromCDRMsg(CDRMessage_t& msg, std::function
                     ParameterParticipantSecurityInfo_t p(pid, plength);
                     valid &= CDRMessage::readUInt32(&msg, &p.security_attributes);
                     valid &= CDRMessage::readUInt32(&msg, &p.plugin_security_attributes);
-                    IF_VALID_CALL
+                    IF_VALID_CALL()
                 }
 
                 case PID_ENDPOINT_SECURITY_INFO:
@@ -776,7 +788,7 @@ bool ParameterList::readParameterListfromCDRMsg(CDRMessage_t& msg, std::function
                     ParameterEndpointSecurityInfo_t p(pid, plength);
                     valid &= CDRMessage::readUInt32(&msg, &p.security_attributes);
                     valid &= CDRMessage::readUInt32(&msg, &p.plugin_security_attributes);
-                    IF_VALID_CALL
+                    IF_VALID_CALL()
                 }
 #endif
                 case PID_DISABLE_POSITIVE_ACKS:
@@ -794,7 +806,7 @@ bool ParameterList::readParameterListfromCDRMsg(CDRMessage_t& msg, std::function
 
                     DisablePositiveACKsQosPolicy p;
                     p.enabled = (value == 0) ? false : true;
-                    IF_VALID_CALL
+                    IF_VALID_CALL()
                 }
 
                 case PID_PAD:

--- a/src/cpp/qos/ParameterList.cpp
+++ b/src/cpp/qos/ParameterList.cpp
@@ -689,44 +689,54 @@ bool ParameterList::readParameterListfromCDRMsg(CDRMessage_t& msg, std::function
                 }
                 case PID_TYPE_CONSISTENCY_ENFORCEMENT:
                 {
-                    if (7 < plength)
+                    if (plength < 2)
                     {
-                        uint16_t uKind(0);
-                        octet temp(0);
-                        TypeConsistencyEnforcementQosPolicy p;
-                        p.m_ignore_sequence_bounds = false;
-                        p.m_ignore_string_bounds = false;
-                        p.m_ignore_member_names = false;
-                        p.m_prevent_type_widening = false;
-                        p.m_force_type_validation = false;
-
-                        valid &= CDRMessage::readUInt16(&msg, &uKind);
-                        p.m_kind = static_cast<TypeConsistencyKind>(uKind);
-
-                        valid &= CDRMessage::readOctet(&msg, &temp);
-                        p.m_ignore_sequence_bounds = temp == 0 ? false : true;
-
-                        valid &= CDRMessage::readOctet(&msg, &temp);
-                        p.m_ignore_string_bounds = temp == 0 ? false : true;
-
-                        valid &= CDRMessage::readOctet(&msg, &temp);
-                        p.m_ignore_member_names = temp == 0 ? false : true;
-
-                        valid &= CDRMessage::readOctet(&msg, &temp);
-                        p.m_prevent_type_widening = temp == 0 ? false : true;
-
-                        valid &= CDRMessage::readOctet(&msg, &temp);
-                        p.m_force_type_validation = temp == 0 ? false : true;
-
-                        for (int i = 7; valid && i < plength; ++i) // Consume the alignment
-                        {
-                            valid &= CDRMessage::readOctet(&msg, &temp);
-                        }
-
-                        IF_VALID_CALL()
+                        return false;
                     }
 
-                    return false;
+                    uint16_t uKind(0);
+                    octet temp(0);
+                    TypeConsistencyEnforcementQosPolicy p;
+                    p.m_ignore_sequence_bounds = false;
+                    p.m_ignore_string_bounds = false;
+                    p.m_ignore_member_names = false;
+                    p.m_prevent_type_widening = false;
+                    p.m_force_type_validation = false;
+
+                    valid &= CDRMessage::readUInt16(&msg, &uKind);
+                    p.m_kind = static_cast<TypeConsistencyKind>(uKind);
+
+                    if (plength >= 3)
+                    {
+                        valid &= CDRMessage::readOctet(&msg, &temp);
+                        p.m_ignore_sequence_bounds = temp == 0 ? false : true;
+                    }
+
+                    if (valid && plength >= 4)
+                    {
+                        valid &= CDRMessage::readOctet(&msg, &temp);
+                        p.m_ignore_string_bounds = temp == 0 ? false : true;
+                    }
+
+                    if (valid && plength >= 5)
+                    {
+                        valid &= CDRMessage::readOctet(&msg, &temp);
+                        p.m_ignore_member_names = temp == 0 ? false : true;
+                    }
+
+                    if (valid && plength >= 6)
+                    {
+                        valid &= CDRMessage::readOctet(&msg, &temp);
+                        p.m_prevent_type_widening = temp == 0 ? false : true;
+                    }
+
+                    if (valid && plength >= 7)
+                    {
+                        valid &= CDRMessage::readOctet(&msg, &temp);
+                        p.m_force_type_validation = temp == 0 ? false : true;
+                    }
+
+                    IF_VALID_CALL()
                 }
                 case PID_TYPE_IDV1:
                 {


### PR DESCRIPTION
This PR:
* Brings back compatibility with XTypes 1.1 on PID_TYPE_CONSISTENCY
* Ensures correct alignment when reading a parameter list