### PR TITLE
Backport/optional log fill attr from profiles [6740]

### DIFF
--- a/include/fastrtps/xmlparser/XMLProfileManager.h
+++ b/include/fastrtps/xmlparser/XMLProfileManager.h
@@ -95,12 +95,12 @@ public:
      * @param profile_name Name for the profile to be used to fill the structure.
      * @param atts Structure to be filled.
      * @param log_error Flag to log an error if the profile_name is not found.
-     * @return XMLP_ret::XML_OK on success, XMLP_ret::XML_ERROR in other case.
+     * @return XMLP_ret::XML_OK on success, XMLP_ret::XML_ERROR in other case. Defaults true.
      */
     RTPS_DllAPI static XMLP_ret fillParticipantAttributes(
             const std::string& profile_name,
             ParticipantAttributes& atts,
-            bool log_error = false);
+            bool log_error = true);
 
     //!Fills participant_attributes with the default values.
     RTPS_DllAPI static void getDefaultParticipantAttributes(
@@ -111,12 +111,12 @@ public:
      * @param profile_name Name for the profile to be used to fill the structure.
      * @param atts Structure to be filled.
      * @param log_error Flag to log an error if the profile_name is not found.
-     * @return XMLP_ret::XML_OK on success, XMLP_ret::XML_ERROR in other case.
+     * @return XMLP_ret::XML_OK on success, XMLP_ret::XML_ERROR in other case. Defaults true.
      */
     RTPS_DllAPI static XMLP_ret fillPublisherAttributes(
             const std::string& profile_name,
             PublisherAttributes& atts,
-            bool log_error = false);
+            bool log_error = true);
 
     //!Fills publisher_attributes with the default values.
     RTPS_DllAPI static void getDefaultPublisherAttributes(
@@ -127,12 +127,12 @@ public:
      * @param profile_name Name for the profile to be used to fill the structure.
      * @param atts Structure to be filled.
      * @param log_error Flag to log an error if the profile_name is not found.
-     * @return XMLP_ret::XML_OK on success, XMLP_ret::XML_ERROR in other case.
+     * @return XMLP_ret::XML_OK on success, XMLP_ret::XML_ERROR in other case. Defaults true.
      */
     RTPS_DllAPI static XMLP_ret fillSubscriberAttributes(
             const std::string& profile_name,
             SubscriberAttributes& atts,
-            bool log_error = false);
+            bool log_error = true);
 
     //!Fills subscriber_attributes with the default values.
     RTPS_DllAPI static void getDefaultSubscriberAttributes(

--- a/include/fastrtps/xmlparser/XMLProfileManager.h
+++ b/include/fastrtps/xmlparser/XMLProfileManager.h
@@ -94,8 +94,8 @@ public:
      * Search for the profile specified and fill the structure.
      * @param profile_name Name for the profile to be used to fill the structure.
      * @param atts Structure to be filled.
-     * @param log_error Flag to log an error if the profile_name is not found.
-     * @return XMLP_ret::XML_OK on success, XMLP_ret::XML_ERROR in other case. Defaults true.
+     * @param log_error Flag to log an error if the profile_name is not found. Defaults true.
+     * @return XMLP_ret::XML_OK on success, XMLP_ret::XML_ERROR in other case.
      */
     RTPS_DllAPI static XMLP_ret fillParticipantAttributes(
             const std::string& profile_name,
@@ -110,8 +110,8 @@ public:
      * Search for the profile specified and fill the structure.
      * @param profile_name Name for the profile to be used to fill the structure.
      * @param atts Structure to be filled.
-     * @param log_error Flag to log an error if the profile_name is not found.
-     * @return XMLP_ret::XML_OK on success, XMLP_ret::XML_ERROR in other case. Defaults true.
+     * @param log_error Flag to log an error if the profile_name is not found. Defaults true.
+     * @return XMLP_ret::XML_OK on success, XMLP_ret::XML_ERROR in other case.
      */
     RTPS_DllAPI static XMLP_ret fillPublisherAttributes(
             const std::string& profile_name,
@@ -126,8 +126,8 @@ public:
      * Search for the profile specified and fill the structure.
      * @param profile_name Name for the profile to be used to fill the structure.
      * @param atts Structure to be filled.
-     * @param log_error Flag to log an error if the profile_name is not found.
-     * @return XMLP_ret::XML_OK on success, XMLP_ret::XML_ERROR in other case. Defaults true.
+     * @param log_error Flag to log an error if the profile_name is not found. Defaults true.
+     * @return XMLP_ret::XML_OK on success, XMLP_ret::XML_ERROR in other case.
      */
     RTPS_DllAPI static XMLP_ret fillSubscriberAttributes(
             const std::string& profile_name,

--- a/include/fastrtps/xmlparser/XMLProfileManager.h
+++ b/include/fastrtps/xmlparser/XMLProfileManager.h
@@ -91,11 +91,13 @@ class XMLProfileManager
         * Search for the profile specified and fill the structure.
         * @param profile_name Name for the profile to be used to fill the structure.
         * @param atts Structure to be filled.
+        * @param log_error Flag to log an error if the profile_name is not found.
         * @return XMLP_ret::XML_OK on success, XMLP_ret::XML_ERROR in other case.
         */
         RTPS_DllAPI static XMLP_ret fillParticipantAttributes(
                 const std::string& profile_name,
-                ParticipantAttributes& atts);
+                ParticipantAttributes& atts,
+                bool log_error = false);
 
         //!Fills participant_attributes with the default values.
         RTPS_DllAPI static void getDefaultParticipantAttributes(ParticipantAttributes& participant_attributes);
@@ -104,11 +106,13 @@ class XMLProfileManager
         * Search for the profile specified and fill the structure.
         * @param profile_name Name for the profile to be used to fill the structure.
         * @param atts Structure to be filled.
+        * @param log_error Flag to log an error if the profile_name is not found.
         * @return XMLP_ret::XML_OK on success, XMLP_ret::XML_ERROR in other case.
         */
         RTPS_DllAPI static XMLP_ret fillPublisherAttributes(
                 const std::string& profile_name,
-                PublisherAttributes& atts);
+                PublisherAttributes& atts,
+                bool log_error = false);
 
         //!Fills publisher_attributes with the default values.
         RTPS_DllAPI static void getDefaultPublisherAttributes(PublisherAttributes& publisher_attributes);
@@ -117,11 +121,13 @@ class XMLProfileManager
         * Search for the profile specified and fill the structure.
         * @param profile_name Name for the profile to be used to fill the structure.
         * @param atts Structure to be filled.
+        * @param log_error Flag to log an error if the profile_name is not found.
         * @return XMLP_ret::XML_OK on success, XMLP_ret::XML_ERROR in other case.
         */
         RTPS_DllAPI static XMLP_ret fillSubscriberAttributes(
                 const std::string &profile_name,
-                SubscriberAttributes &atts);
+                SubscriberAttributes &atts,
+                bool log_error = false);
 
         //!Fills subscriber_attributes with the default values.
         RTPS_DllAPI static void getDefaultSubscriberAttributes(SubscriberAttributes& subscriber_attributes);

--- a/include/fastrtps/xmlparser/XMLProfileManager.h
+++ b/include/fastrtps/xmlparser/XMLProfileManager.h
@@ -140,12 +140,12 @@ public:
 
     //!Add a new transport instance along with its id.
     RTPS_DllAPI static bool insertTransportById(
-            const std::string& sId,
+            const std::string& transport_id,
             sp_transport_t transport);
 
     //!Retrieves a transport instance by its id.
     RTPS_DllAPI static sp_transport_t getTransportById(
-            const std::string& sId);
+            const std::string& transport_id);
 
     /**
      * Search for the profile specified and fill the structure.
@@ -163,12 +163,12 @@ public:
 
     //!Add a new dynamic type instance along with its name.
     RTPS_DllAPI static bool insertDynamicTypeByName(
-            const std::string& sName,
+            const std::string& type_name,
             p_dynamictypebuilder_t type);
 
     //!Retrieves a transport instance by its name.
     RTPS_DllAPI static p_dynamictypebuilder_t getDynamicTypeByName(
-            const std::string& sName);
+            const std::string& type_name);
 
     /**
      * Deletes the XMLProsileManager instance.
@@ -177,17 +177,17 @@ public:
      */
     RTPS_DllAPI static void DeleteInstance()
     {
-        m_participant_profiles.clear();
-        m_publisher_profiles.clear();
-        m_subscriber_profiles.clear();
-        m_xml_files.clear();
-        m_transport_profiles.clear();
+        participant_profiles_.clear();
+        publisher_profiles_.clear();
+        subscriber_profiles_.clear();
+        xml_files_.clear();
+        transport_profiles_.clear();
 
-        for (auto pair : m_dynamictypes)
+        for (auto pair : dynamic_types_)
         {
-        types::DynamicTypeBuilderFactory::get_instance()->delete_builder(pair.second);
+            types::DynamicTypeBuilderFactory::get_instance()->delete_builder(pair.second);
         }
-        m_dynamictypes.clear();
+        dynamic_types_.clear();
     }
 
     /**
@@ -196,11 +196,11 @@ public:
      * XMLProfileManager::DeleteDynamicPubSubType method.
      */
     RTPS_DllAPI static types::DynamicPubSubType* CreateDynamicPubSubType(
-            const std::string& typeName)
+            const std::string& type_name)
     {
-        if (m_dynamictypes.find(typeName) != m_dynamictypes.end())
+        if (dynamic_types_.find(type_name) != dynamic_types_.end())
         {
-            return new types::DynamicPubSubType(m_dynamictypes[typeName]->build());
+            return new types::DynamicPubSubType(dynamic_types_[type_name]->build());
         }
         return nullptr;
     }
@@ -243,19 +243,19 @@ private:
 
     static BaseNode* root;
 
-    static participant_map_t m_participant_profiles;
+    static participant_map_t participant_profiles_;
 
-    static publisher_map_t m_publisher_profiles;
+    static publisher_map_t publisher_profiles_;
 
-    static subscriber_map_t m_subscriber_profiles;
+    static subscriber_map_t subscriber_profiles_;
 
-    static topic_map_t m_topic_profiles;
+    static topic_map_t topic_profiles_;
 
-    static xmlfiles_map_t m_xml_files;
+    static xmlfiles_map_t xml_files_;
 
-    static sp_transport_map_t m_transport_profiles;
+    static sp_transport_map_t transport_profiles_;
 
-    static p_dynamictype_map_t m_dynamictypes;
+    static p_dynamictype_map_t dynamic_types_;
 };
 
 } /* xmlparser */

--- a/include/fastrtps/xmlparser/XMLProfileManager.h
+++ b/include/fastrtps/xmlparser/XMLProfileManager.h
@@ -28,22 +28,20 @@
 #include <string>
 #include <map>
 
+namespace eprosima {
+namespace fastrtps {
+namespace xmlparser {
 
-
-namespace eprosima{
-namespace fastrtps{
-namespace xmlparser{
-
-typedef std::map<std::string, up_participant_t> participant_map_t;
-typedef participant_map_t::iterator             part_map_iterator_t;
-typedef std::map<std::string, up_publisher_t>   publisher_map_t;
-typedef publisher_map_t::iterator               publ_map_iterator_t;
-typedef std::map<std::string, up_subscriber_t>  subscriber_map_t;
-typedef subscriber_map_t::iterator              subs_map_iterator_t;
-typedef std::map<std::string, up_topic_t>       topic_map_t;
-typedef topic_map_t::iterator                   topic_map_iterator_t;
-typedef std::map<std::string, XMLP_ret>         xmlfiles_map_t;
-typedef xmlfiles_map_t::iterator                xmlfile_map_iterator_t;
+using participant_map_t = std::map<std::string, up_participant_t>;
+using part_map_iterator_t = participant_map_t::iterator;
+using publisher_map_t = std::map<std::string, up_publisher_t>;
+using publ_map_iterator_t = publisher_map_t::iterator;
+using subscriber_map_t = std::map<std::string, up_subscriber_t>;
+using subs_map_iterator_t = subscriber_map_t::iterator;
+using topic_map_t = std::map<std::string, up_topic_t>;
+using topic_map_iterator_t = topic_map_t::iterator;
+using xmlfiles_map_t = std::map<std::string, XMLP_ret>;
+using xmlfile_map_iterator_t = xmlfiles_map_t::iterator;
 
 
 /**
@@ -52,199 +50,212 @@ typedef xmlfiles_map_t::iterator                xmlfile_map_iterator_t;
  */
 class XMLProfileManager
 {
-    public:
-        /**
-        * Load the default profiles XML file.
-        * @return XMLP_ret::XML_OK on success, XMLP_ret::XML_ERROR in other case.
-        */
-        RTPS_DllAPI static void loadDefaultXMLFile();
+public:
 
-        /**
-        * Load a profiles XML file.
-        * @param filename Name for the file to be loaded.
-        * @return XMLP_ret::XML_OK on success, XMLP_ret::XML_ERROR in other case.
-        */
-        RTPS_DllAPI static XMLP_ret loadXMLFile(const std::string& filename);
+    /**
+     * Load the default profiles XML file.
+     * @return XMLP_ret::XML_OK on success, XMLP_ret::XML_ERROR in other case.
+     */
+    RTPS_DllAPI static void loadDefaultXMLFile();
 
-        /**
-        * Load a profiles XML node.
-        * @param doc Node to be loaded.
-        * @return XMLP_ret::XML_OK on success, XMLP_ret::XML_ERROR in other case.
-        */
-        RTPS_DllAPI static XMLP_ret loadXMLNode(tinyxml2::XMLDocument& doc);
+    /**
+     * Load a profiles XML file.
+     * @param filename Name for the file to be loaded.
+     * @return XMLP_ret::XML_OK on success, XMLP_ret::XML_ERROR in other case.
+     */
+    RTPS_DllAPI static XMLP_ret loadXMLFile(
+            const std::string& filename);
 
-        /**
-        * Load a profiles XML node.
-        * @param profiles Node to be loaded.
-        * @return XMLP_ret::XML_OK on success, XMLP_ret::XML_ERROR in other case.
-        */
-        RTPS_DllAPI static XMLP_ret loadXMLProfiles(tinyxml2::XMLElement& profiles);
+    /**
+     * Load a profiles XML node.
+     * @param doc Node to be loaded.
+     * @return XMLP_ret::XML_OK on success, XMLP_ret::XML_ERROR in other case.
+     */
+    RTPS_DllAPI static XMLP_ret loadXMLNode(
+            tinyxml2::XMLDocument& doc);
 
-        /**
-        * Load a dynamic types XML node.
-        * @param types Node to be loaded.
-        * @return XMLP_ret::XML_OK on success, XMLP_ret::XML_ERROR in other case.
-        */
-        RTPS_DllAPI static XMLP_ret loadXMLDynamicTypes(tinyxml2::XMLElement& types);
+    /**
+     * Load a profiles XML node.
+     * @param profiles Node to be loaded.
+     * @return XMLP_ret::XML_OK on success, XMLP_ret::XML_ERROR in other case.
+     */
+    RTPS_DllAPI static XMLP_ret loadXMLProfiles(
+            tinyxml2::XMLElement& profiles);
 
-        /**
-        * Search for the profile specified and fill the structure.
-        * @param profile_name Name for the profile to be used to fill the structure.
-        * @param atts Structure to be filled.
-        * @param log_error Flag to log an error if the profile_name is not found.
-        * @return XMLP_ret::XML_OK on success, XMLP_ret::XML_ERROR in other case.
-        */
-        RTPS_DllAPI static XMLP_ret fillParticipantAttributes(
-                const std::string& profile_name,
-                ParticipantAttributes& atts,
-                bool log_error = false);
+    /**
+     * Load a dynamic types XML node.
+     * @param types Node to be loaded.
+     * @return XMLP_ret::XML_OK on success, XMLP_ret::XML_ERROR in other case.
+     */
+    RTPS_DllAPI static XMLP_ret loadXMLDynamicTypes(
+            tinyxml2::XMLElement& types);
 
-        //!Fills participant_attributes with the default values.
-        RTPS_DllAPI static void getDefaultParticipantAttributes(ParticipantAttributes& participant_attributes);
+    /**
+     * Search for the profile specified and fill the structure.
+     * @param profile_name Name for the profile to be used to fill the structure.
+     * @param atts Structure to be filled.
+     * @param log_error Flag to log an error if the profile_name is not found.
+     * @return XMLP_ret::XML_OK on success, XMLP_ret::XML_ERROR in other case.
+     */
+    RTPS_DllAPI static XMLP_ret fillParticipantAttributes(
+            const std::string& profile_name,
+            ParticipantAttributes& atts,
+            bool log_error = false);
 
-        /**
-        * Search for the profile specified and fill the structure.
-        * @param profile_name Name for the profile to be used to fill the structure.
-        * @param atts Structure to be filled.
-        * @param log_error Flag to log an error if the profile_name is not found.
-        * @return XMLP_ret::XML_OK on success, XMLP_ret::XML_ERROR in other case.
-        */
-        RTPS_DllAPI static XMLP_ret fillPublisherAttributes(
-                const std::string& profile_name,
-                PublisherAttributes& atts,
-                bool log_error = false);
+    //!Fills participant_attributes with the default values.
+    RTPS_DllAPI static void getDefaultParticipantAttributes(
+            ParticipantAttributes& participant_attributes);
 
-        //!Fills publisher_attributes with the default values.
-        RTPS_DllAPI static void getDefaultPublisherAttributes(PublisherAttributes& publisher_attributes);
+    /**
+     * Search for the profile specified and fill the structure.
+     * @param profile_name Name for the profile to be used to fill the structure.
+     * @param atts Structure to be filled.
+     * @param log_error Flag to log an error if the profile_name is not found.
+     * @return XMLP_ret::XML_OK on success, XMLP_ret::XML_ERROR in other case.
+     */
+    RTPS_DllAPI static XMLP_ret fillPublisherAttributes(
+            const std::string& profile_name,
+            PublisherAttributes& atts,
+            bool log_error = false);
 
-        /**
-        * Search for the profile specified and fill the structure.
-        * @param profile_name Name for the profile to be used to fill the structure.
-        * @param atts Structure to be filled.
-        * @param log_error Flag to log an error if the profile_name is not found.
-        * @return XMLP_ret::XML_OK on success, XMLP_ret::XML_ERROR in other case.
-        */
-        RTPS_DllAPI static XMLP_ret fillSubscriberAttributes(
-                const std::string &profile_name,
-                SubscriberAttributes &atts,
-                bool log_error = false);
+    //!Fills publisher_attributes with the default values.
+    RTPS_DllAPI static void getDefaultPublisherAttributes(
+            PublisherAttributes& publisher_attributes);
 
-        //!Fills subscriber_attributes with the default values.
-        RTPS_DllAPI static void getDefaultSubscriberAttributes(SubscriberAttributes& subscriber_attributes);
+    /**
+     * Search for the profile specified and fill the structure.
+     * @param profile_name Name for the profile to be used to fill the structure.
+     * @param atts Structure to be filled.
+     * @param log_error Flag to log an error if the profile_name is not found.
+     * @return XMLP_ret::XML_OK on success, XMLP_ret::XML_ERROR in other case.
+     */
+    RTPS_DllAPI static XMLP_ret fillSubscriberAttributes(
+            const std::string& profile_name,
+            SubscriberAttributes& atts,
+            bool log_error = false);
 
-        //!Add a new transport instance along with its id.
-        RTPS_DllAPI static bool insertTransportById(
-                const std::string& sId,
-                sp_transport_t transport);
+    //!Fills subscriber_attributes with the default values.
+    RTPS_DllAPI static void getDefaultSubscriberAttributes(
+            SubscriberAttributes& subscriber_attributes);
 
-        //!Retrieves a transport instance by its id.
-        RTPS_DllAPI static sp_transport_t getTransportById(const std::string& sId);
+    //!Add a new transport instance along with its id.
+    RTPS_DllAPI static bool insertTransportById(
+            const std::string& sId,
+            sp_transport_t transport);
 
-        /**
-        * Search for the profile specified and fill the structure.
-        * @param profile_name Name for the profile to be used to fill the structure.
-        * @param atts Structure to be filled.
-        * @return XMLP_ret::XML_OK on success, XMLP_ret::XML_ERROR in other case.
-        */
-        RTPS_DllAPI static XMLP_ret fillTopicAttributes(
-                const std::string& profile_name,
-                TopicAttributes& atts);
+    //!Retrieves a transport instance by its id.
+    RTPS_DllAPI static sp_transport_t getTransportById(
+            const std::string& sId);
 
-        //!Fills topic_attributes with the default values.
-        RTPS_DllAPI static void getDefaultTopicAttributes(TopicAttributes& topic_attributes);
+    /**
+     * Search for the profile specified and fill the structure.
+     * @param profile_name Name for the profile to be used to fill the structure.
+     * @param atts Structure to be filled.
+     * @return XMLP_ret::XML_OK on success, XMLP_ret::XML_ERROR in other case.
+     */
+    RTPS_DllAPI static XMLP_ret fillTopicAttributes(
+            const std::string& profile_name,
+            TopicAttributes& atts);
 
-        //!Add a new dynamic type instance along with its name.
-        RTPS_DllAPI static bool insertDynamicTypeByName(
-                const std::string& sName,
-                p_dynamictypebuilder_t type);
+    //!Fills topic_attributes with the default values.
+    RTPS_DllAPI static void getDefaultTopicAttributes(
+            TopicAttributes& topic_attributes);
 
-        //!Retrieves a transport instance by its name.
-        RTPS_DllAPI static p_dynamictypebuilder_t getDynamicTypeByName(const std::string& sName);
+    //!Add a new dynamic type instance along with its name.
+    RTPS_DllAPI static bool insertDynamicTypeByName(
+            const std::string& sName,
+            p_dynamictypebuilder_t type);
 
-        /**
-         * Deletes the XMLProsileManager instance.
-         * FastRTPS's Domain calls this method automatically on its destructor, but
-         * if using XMLProfileManager outside of FastRTPS, it should be called manually.
-         */
-        RTPS_DllAPI static void DeleteInstance()
+    //!Retrieves a transport instance by its name.
+    RTPS_DllAPI static p_dynamictypebuilder_t getDynamicTypeByName(
+            const std::string& sName);
+
+    /**
+     * Deletes the XMLProsileManager instance.
+     * FastRTPS's Domain calls this method automatically on its destructor, but
+     * if using XMLProfileManager outside of FastRTPS, it should be called manually.
+     */
+    RTPS_DllAPI static void DeleteInstance()
+    {
+        m_participant_profiles.clear();
+        m_publisher_profiles.clear();
+        m_subscriber_profiles.clear();
+        m_xml_files.clear();
+        m_transport_profiles.clear();
+
+        for (auto pair : m_dynamictypes)
         {
-            m_participant_profiles.clear();
-            m_publisher_profiles.clear();
-            m_subscriber_profiles.clear();
-            m_xml_files.clear();
-            m_transport_profiles.clear();
-
-            for (auto pair : m_dynamictypes)
-            {
-                types::DynamicTypeBuilderFactory::get_instance()->delete_builder(pair.second);
-            }
-            m_dynamictypes.clear();
+        types::DynamicTypeBuilderFactory::get_instance()->delete_builder(pair.second);
         }
+        m_dynamictypes.clear();
+    }
 
-        /**
-         * Retrieves a DynamicPubSubType for the given dynamic type name.
-         * Any instance retrieve by calling this method must be deleted calling the
-         * XMLProfileManager::DeleteDynamicPubSubType method.
-         */
-        RTPS_DllAPI static types::DynamicPubSubType* CreateDynamicPubSubType(const std::string& typeName)
+    /**
+     * Retrieves a DynamicPubSubType for the given dynamic type name.
+     * Any instance retrieve by calling this method must be deleted calling the
+     * XMLProfileManager::DeleteDynamicPubSubType method.
+     */
+    RTPS_DllAPI static types::DynamicPubSubType* CreateDynamicPubSubType(
+            const std::string& typeName)
+    {
+        if (m_dynamictypes.find(typeName) != m_dynamictypes.end())
         {
-            if (m_dynamictypes.find(typeName) != m_dynamictypes.end())
-            {
-                return new types::DynamicPubSubType(m_dynamictypes[typeName]->build());
-            }
-            return nullptr;
+            return new types::DynamicPubSubType(m_dynamictypes[typeName]->build());
         }
+        return nullptr;
+    }
 
-        /**
-         * Deletes the given DynamicPubSubType previously created by calling
-         * XMLProfileManager::CreateDynamicPubSubType method.
-         */
-        RTPS_DllAPI static void DeleteDynamicPubSubType(types::DynamicPubSubType *type)
-        {
-            delete type;
-        }
+    /**
+     * Deletes the given DynamicPubSubType previously created by calling
+     * XMLProfileManager::CreateDynamicPubSubType method.
+     */
+    RTPS_DllAPI static void DeleteDynamicPubSubType(
+            types::DynamicPubSubType* type)
+    {
+        delete type;
+    }
 
-    private:
-        RTPS_DllAPI static XMLP_ret extractDynamicTypes(
-                up_base_node_t properties,
-                const std::string& filename);
+private:
 
-        RTPS_DllAPI static XMLP_ret extractProfiles(
-                up_base_node_t properties,
-                const std::string& filename);
+    RTPS_DllAPI static XMLP_ret extractDynamicTypes(
+            up_base_node_t properties,
+            const std::string& filename);
 
-        RTPS_DllAPI static XMLP_ret extractParticipantProfile(
+    RTPS_DllAPI static XMLP_ret extractProfiles(
+            up_base_node_t properties,
+            const std::string& filename);
+
+    RTPS_DllAPI static XMLP_ret extractParticipantProfile(
             up_base_node_t& profile,
             const std::string& filename);
 
-        RTPS_DllAPI static XMLP_ret extractPublisherProfile(
+    RTPS_DllAPI static XMLP_ret extractPublisherProfile(
             up_base_node_t& profile,
             const std::string& filename);
 
-        RTPS_DllAPI static XMLP_ret extractSubscriberProfile(
+    RTPS_DllAPI static XMLP_ret extractSubscriberProfile(
             up_base_node_t& profile,
             const std::string& filename);
 
-        RTPS_DllAPI static XMLP_ret extractTopicProfile(
+    RTPS_DllAPI static XMLP_ret extractTopicProfile(
             up_base_node_t& profile,
             const std::string& filename);
 
+    static BaseNode* root;
 
-        static BaseNode* root;
+    static participant_map_t m_participant_profiles;
 
-        static participant_map_t m_participant_profiles;
+    static publisher_map_t m_publisher_profiles;
 
-        static publisher_map_t   m_publisher_profiles;
+    static subscriber_map_t m_subscriber_profiles;
 
-        static subscriber_map_t  m_subscriber_profiles;
+    static topic_map_t m_topic_profiles;
 
-        static topic_map_t       m_topic_profiles;
+    static xmlfiles_map_t m_xml_files;
 
-        static xmlfiles_map_t    m_xml_files;
+    static sp_transport_map_t m_transport_profiles;
 
-        static sp_transport_map_t m_transport_profiles;
-
-        static p_dynamictype_map_t m_dynamictypes;
+    static p_dynamictype_map_t m_dynamictypes;
 };
 
 } /* xmlparser */

--- a/src/cpp/xmlparser/XMLProfileManager.cpp
+++ b/src/cpp/xmlparser/XMLProfileManager.cpp
@@ -39,36 +39,45 @@ p_dynamictype_map_t XMLProfileManager::m_dynamictypes;
 
 BaseNode* XMLProfileManager::root = nullptr;
 
-XMLP_ret XMLProfileManager::fillParticipantAttributes(const std::string &profile_name, ParticipantAttributes &atts)
+XMLP_ret XMLProfileManager::fillParticipantAttributes(const std::string &profile_name, ParticipantAttributes &atts, bool log_error)
 {
     part_map_iterator_t it = m_participant_profiles.find(profile_name);
     if (it == m_participant_profiles.end())
     {
-        logError(XMLPARSER, "Profile '" << profile_name << "' not found '");
+        if (log_error)
+        {
+            logError(XMLPARSER, "Profile '" << profile_name << "' not found '");
+        }
         return XMLP_ret::XML_ERROR;
     }
     atts = *(it->second);
     return XMLP_ret::XML_OK;
 }
 
-XMLP_ret XMLProfileManager::fillPublisherAttributes(const std::string &profile_name, PublisherAttributes &atts)
+XMLP_ret XMLProfileManager::fillPublisherAttributes(const std::string &profile_name, PublisherAttributes &atts, bool log_error)
 {
     publ_map_iterator_t it = m_publisher_profiles.find(profile_name);
     if (it == m_publisher_profiles.end())
     {
-        logError(XMLPARSER, "Profile '" << profile_name << "' not found '");
+        if (log_error)
+        {
+            logError(XMLPARSER, "Profile '" << profile_name << "' not found '");
+        }
         return XMLP_ret::XML_ERROR;
     }
     atts = *(it->second);
     return XMLP_ret::XML_OK;
 }
 
-XMLP_ret XMLProfileManager::fillSubscriberAttributes(const std::string &profile_name, SubscriberAttributes &atts)
+XMLP_ret XMLProfileManager::fillSubscriberAttributes(const std::string &profile_name, SubscriberAttributes &atts, bool log_error)
 {
     subs_map_iterator_t it = m_subscriber_profiles.find(profile_name);
     if (it == m_subscriber_profiles.end())
     {
-        logError(XMLPARSER, "Profile '" << profile_name << "' not found");
+        if (log_error)
+        {
+            logError(XMLPARSER, "Profile '" << profile_name << "' not found");
+        }
         return XMLP_ret::XML_ERROR;
     }
     atts = *(it->second);

--- a/src/cpp/xmlparser/XMLProfileManager.cpp
+++ b/src/cpp/xmlparser/XMLProfileManager.cpp
@@ -27,19 +27,21 @@ using namespace ::xmlparser;
 
 std::map<std::string, up_participant_t> XMLProfileManager::m_participant_profiles;
 ParticipantAttributes default_participant_attributes;
-std::map<std::string, up_publisher_t>   XMLProfileManager::m_publisher_profiles;
+std::map<std::string, up_publisher_t> XMLProfileManager::m_publisher_profiles;
 PublisherAttributes default_publisher_attributes;
-std::map<std::string, up_subscriber_t>  XMLProfileManager::m_subscriber_profiles;
+std::map<std::string, up_subscriber_t> XMLProfileManager::m_subscriber_profiles;
 SubscriberAttributes default_subscriber_attributes;
-std::map<std::string, up_topic_t>       XMLProfileManager::m_topic_profiles;
+std::map<std::string, up_topic_t> XMLProfileManager::m_topic_profiles;
 TopicAttributes default_topic_attributes;
-std::map<std::string, XMLP_ret>         XMLProfileManager::m_xml_files;
+std::map<std::string, XMLP_ret> XMLProfileManager::m_xml_files;
 sp_transport_map_t XMLProfileManager::m_transport_profiles;
 p_dynamictype_map_t XMLProfileManager::m_dynamictypes;
-
 BaseNode* XMLProfileManager::root = nullptr;
 
-XMLP_ret XMLProfileManager::fillParticipantAttributes(const std::string &profile_name, ParticipantAttributes &atts, bool log_error)
+XMLP_ret XMLProfileManager::fillParticipantAttributes(
+        const std::string& profile_name,
+        ParticipantAttributes& atts,
+        bool log_error)
 {
     part_map_iterator_t it = m_participant_profiles.find(profile_name);
     if (it == m_participant_profiles.end())
@@ -54,7 +56,10 @@ XMLP_ret XMLProfileManager::fillParticipantAttributes(const std::string &profile
     return XMLP_ret::XML_OK;
 }
 
-XMLP_ret XMLProfileManager::fillPublisherAttributes(const std::string &profile_name, PublisherAttributes &atts, bool log_error)
+XMLP_ret XMLProfileManager::fillPublisherAttributes(
+        const std::string& profile_name,
+        PublisherAttributes& atts,
+        bool log_error)
 {
     publ_map_iterator_t it = m_publisher_profiles.find(profile_name);
     if (it == m_publisher_profiles.end())
@@ -69,7 +74,10 @@ XMLP_ret XMLProfileManager::fillPublisherAttributes(const std::string &profile_n
     return XMLP_ret::XML_OK;
 }
 
-XMLP_ret XMLProfileManager::fillSubscriberAttributes(const std::string &profile_name, SubscriberAttributes &atts, bool log_error)
+XMLP_ret XMLProfileManager::fillSubscriberAttributes(
+        const std::string& profile_name,
+        SubscriberAttributes& atts,
+        bool log_error)
 {
     subs_map_iterator_t it = m_subscriber_profiles.find(profile_name);
     if (it == m_subscriber_profiles.end())
@@ -84,7 +92,9 @@ XMLP_ret XMLProfileManager::fillSubscriberAttributes(const std::string &profile_
     return XMLP_ret::XML_OK;
 }
 
-XMLP_ret XMLProfileManager::fillTopicAttributes(const std::string& profile_name, TopicAttributes& atts)
+XMLP_ret XMLProfileManager::fillTopicAttributes(
+        const std::string& profile_name,
+        TopicAttributes& atts)
 {
     topic_map_iterator_t it = m_topic_profiles.find(profile_name);
     if (it == m_topic_profiles.end())
@@ -96,22 +106,26 @@ XMLP_ret XMLProfileManager::fillTopicAttributes(const std::string& profile_name,
     return XMLP_ret::XML_OK;
 }
 
-void XMLProfileManager::getDefaultParticipantAttributes(ParticipantAttributes& participant_attributes)
+void XMLProfileManager::getDefaultParticipantAttributes(
+        ParticipantAttributes& participant_attributes)
 {
     participant_attributes = default_participant_attributes;
 }
 
-void XMLProfileManager::getDefaultPublisherAttributes(PublisherAttributes& publisher_attributes)
+void XMLProfileManager::getDefaultPublisherAttributes(
+        PublisherAttributes& publisher_attributes)
 {
     publisher_attributes = default_publisher_attributes;
 }
 
-void XMLProfileManager::getDefaultSubscriberAttributes(SubscriberAttributes& subscriber_attributes)
+void XMLProfileManager::getDefaultSubscriberAttributes(
+        SubscriberAttributes& subscriber_attributes)
 {
     subscriber_attributes = default_subscriber_attributes;
 }
 
-void XMLProfileManager::getDefaultTopicAttributes(TopicAttributes& topic_attributes)
+void XMLProfileManager::getDefaultTopicAttributes(
+        TopicAttributes& topic_attributes)
 {
     topic_attributes = default_topic_attributes;
 }
@@ -137,7 +151,8 @@ void XMLProfileManager::loadDefaultXMLFile()
     loadXMLFile(DEFAULT_FASTRTPS_PROFILES);
 }
 
-XMLP_ret XMLProfileManager::loadXMLProfiles(tinyxml2::XMLElement& profiles)
+XMLP_ret XMLProfileManager::loadXMLProfiles(
+        tinyxml2::XMLElement& profiles)
 {
     up_base_node_t root_node;
     XMLParser::loadXMLProfiles(profiles, root_node);
@@ -169,12 +184,14 @@ XMLP_ret XMLProfileManager::loadXMLProfiles(tinyxml2::XMLElement& profiles)
     return XMLP_ret::XML_ERROR;
 }
 
-XMLP_ret XMLProfileManager::loadXMLDynamicTypes(tinyxml2::XMLElement& types)
+XMLP_ret XMLProfileManager::loadXMLDynamicTypes(
+        tinyxml2::XMLElement& types)
 {
     return XMLParser::loadXMLDynamicTypes(types);
 }
 
-XMLP_ret XMLProfileManager::loadXMLNode(tinyxml2::XMLDocument& doc)
+XMLP_ret XMLProfileManager::loadXMLNode(
+        tinyxml2::XMLDocument& doc)
 {
     up_base_node_t root_node;
     XMLParser::loadXML(doc, root_node);
@@ -206,7 +223,8 @@ XMLP_ret XMLProfileManager::loadXMLNode(tinyxml2::XMLDocument& doc)
     return XMLP_ret::XML_ERROR;
 }
 
-XMLP_ret XMLProfileManager::loadXMLFile(const std::string& filename)
+XMLP_ret XMLProfileManager::loadXMLFile(
+        const std::string& filename)
 {
     if (filename.empty())
     {
@@ -259,7 +277,9 @@ XMLP_ret XMLProfileManager::loadXMLFile(const std::string& filename)
     return XMLP_ret::XML_ERROR;
 }
 
-XMLP_ret XMLProfileManager::extractDynamicTypes(up_base_node_t profiles, const std::string& filename)
+XMLP_ret XMLProfileManager::extractDynamicTypes(
+        up_base_node_t profiles,
+        const std::string& filename)
 {
     if (nullptr == profiles)
     {
@@ -297,7 +317,9 @@ XMLP_ret XMLProfileManager::extractDynamicTypes(up_base_node_t profiles, const s
     return XMLP_ret::XML_OK;
 }
 
-XMLP_ret XMLProfileManager::extractProfiles(up_base_node_t profiles, const std::string& filename)
+XMLP_ret XMLProfileManager::extractProfiles(
+        up_base_node_t profiles,
+        const std::string& filename)
 {
     if (nullptr == profiles)
     {
@@ -357,7 +379,9 @@ XMLP_ret XMLProfileManager::extractProfiles(up_base_node_t profiles, const std::
     return XMLP_ret::XML_OK;
 }
 
-XMLP_ret XMLProfileManager::extractParticipantProfile(up_base_node_t& profile, const std::string& filename)
+XMLP_ret XMLProfileManager::extractParticipantProfile(
+        up_base_node_t& profile,
+        const std::string& filename)
 {
     (void)(filename);
     std::string profile_name = "";
@@ -388,7 +412,9 @@ XMLP_ret XMLProfileManager::extractParticipantProfile(up_base_node_t& profile, c
     return XMLP_ret::XML_OK;
 }
 
-XMLP_ret XMLProfileManager::extractPublisherProfile(up_base_node_t& profile, const std::string& filename)
+XMLP_ret XMLProfileManager::extractPublisherProfile(
+        up_base_node_t& profile,
+        const std::string& filename)
 {
     (void)(filename);
     std::string profile_name = "";
@@ -419,7 +445,9 @@ XMLP_ret XMLProfileManager::extractPublisherProfile(up_base_node_t& profile, con
     return XMLP_ret::XML_OK;
 }
 
-XMLP_ret XMLProfileManager::extractSubscriberProfile(up_base_node_t& profile, const std::string& filename)
+XMLP_ret XMLProfileManager::extractSubscriberProfile(
+        up_base_node_t& profile,
+        const std::string& filename)
 {
     (void)(filename);
     std::string profile_name = "";
@@ -450,7 +478,9 @@ XMLP_ret XMLProfileManager::extractSubscriberProfile(up_base_node_t& profile, co
     return XMLP_ret::XML_OK;
 }
 
-bool XMLProfileManager::insertTransportById(const std::string& sId, sp_transport_t transport)
+bool XMLProfileManager::insertTransportById(
+        const std::string& sId,
+        sp_transport_t transport)
 {
     if (m_transport_profiles.find(sId) == m_transport_profiles.end())
     {
@@ -461,7 +491,8 @@ bool XMLProfileManager::insertTransportById(const std::string& sId, sp_transport
     return false;
 }
 
-sp_transport_t XMLProfileManager::getTransportById(const std::string& sId)
+sp_transport_t XMLProfileManager::getTransportById(
+        const std::string& sId)
 {
     if (m_transport_profiles.find(sId) != m_transport_profiles.end())
     {
@@ -470,7 +501,9 @@ sp_transport_t XMLProfileManager::getTransportById(const std::string& sId)
     return nullptr;
 }
 
-bool XMLProfileManager::insertDynamicTypeByName(const std::string& sName, p_dynamictypebuilder_t type)
+bool XMLProfileManager::insertDynamicTypeByName(
+        const std::string& sName,
+        p_dynamictypebuilder_t type)
 {
     if (m_dynamictypes.find(sName) == m_dynamictypes.end())
     {
@@ -481,7 +514,8 @@ bool XMLProfileManager::insertDynamicTypeByName(const std::string& sName, p_dyna
     return false;
 }
 
-p_dynamictypebuilder_t XMLProfileManager::getDynamicTypeByName(const std::string& sName)
+p_dynamictypebuilder_t XMLProfileManager::getDynamicTypeByName(
+        const std::string& sName)
 {
     if (m_dynamictypes.find(sName) != m_dynamictypes.end())
     {
@@ -490,7 +524,9 @@ p_dynamictypebuilder_t XMLProfileManager::getDynamicTypeByName(const std::string
     return nullptr;
 }
 
-XMLP_ret XMLProfileManager::extractTopicProfile(up_base_node_t& profile, const std::string& filename)
+XMLP_ret XMLProfileManager::extractTopicProfile(
+        up_base_node_t& profile,
+        const std::string& filename)
 {
     (void)(filename);
     std::string profile_name = "";


### PR DESCRIPTION
This PR is linked with [ros2/rmw_fastrtps 355 PR](https://github.com/ros2/rmw_fastrtps/pull/335). It has been done so that the RMW layer does not show log errors when a profile is not found.
* Add an optional parameter `log_error` for only logging the error when user specifies on member functions:
    * `XMLProfileManager::fillParticipantAttributes`
    * `XMLProfileManager::fillPublisherAttributes`
    * `XMLProfileManager::fillSubscriberAttributes`
* Style compliance on:
    * XMLProfileManager.h
    * XMLProfileManager.cpp