### PR TITLE
[1.7.x] Fixing version file generation for correct 'fastrtpsgen -version' output

### DIFF
--- a/fastrtpsgen/build.gradle
+++ b/fastrtpsgen/build.gradle
@@ -17,6 +17,7 @@ apply plugin: 'java'
 apply plugin: 'eclipse' // Eclipse integration
 
 description = """"""
+def version_str = "0.0.0"
 
 repositories {
     mavenCentral()
@@ -41,11 +42,18 @@ task copyResources {
     }
 
     // Create version file
-    Properties pversion = new Properties()
-    project.hasProperty('customversion') ? pversion.setProperty('version', project.customversion.toString()) : pversion.setProperty('version', '0.0.0')
     File versionFile = new File("${project.buildDir}/resources/main/version")
-    versionFile.createNewFile();
-    pversion.store(versionFile.newWriter(), null)
+    outputs.file versionFile
+    doLast {
+        // Create version file
+        Properties pversion = new Properties()
+        project.hasProperty('customversion')
+            ? pversion.setProperty('version', project.customversion.toString())
+            : pversion.setProperty('version', version_str)
+        versionFile.withWriter {
+            pversion.store(it, null)
+        }
+    }
 }
 
 sourceSets {


### PR DESCRIPTION
Fixes https://github.com/eProsima/Fast-RTPS/issues/820, by applying https://github.com/eProsima/Fast-RTPS-Gen/pull/11.

Ouput:
```console
$ fastrtpsgen -version
openjdk version "11.0.4" 2019-07-16
OpenJDK Runtime Environment (build 11.0.4+11-post-Ubuntu-1ubuntu218.04.3)
OpenJDK 64-Bit Server VM (build 11.0.4+11-post-Ubuntu-1ubuntu218.04.3, mixed mode, sharing)
fastrtpsgen version 1.7.2
```