### PR TITLE
Refs #6763 SOSS-DDS Xtypes

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -257,14 +257,7 @@ endif()
 ###############################################################################
 # Compile library.
 ###############################################################################
-# Used exclusively in this commit
-option(EPROSIMA_BUILD_XTYPES_STANDALONE "Only compiles dds-core-xtypes part" ON)
-
-if(NOT EPROSIMA_BUILD_XTYPES_STANDALONE)
-    add_subdirectory(src/cpp)
-else()
-    add_subdirectory(src/cpp/dds/core/xtypes)
-endif()
+add_subdirectory(src/cpp)
 
 ###############################################################################
 # Testing options

--- a/include/dds/core/xtypes/DynamicData.hpp
+++ b/include/dds/core/xtypes/DynamicData.hpp
@@ -474,22 +474,24 @@ public:
         type_.construct_instance(instance_);
     }
 
-    /// \brief Construct a DynamicData from another DynamicData with a compatible type.
-    /// (see DynamicType::is_compatible())
-    /// \param[in] other A compatible DynamicData from which de data will be copies.
-    /// \param[in] type DynamicType from which the DynamicData is created.
+    /// \brief Copy constructor from a ReadableDynamicDataRef
     DynamicData(
             const ReadableDynamicDataRef& other)
         : WritableDynamicDataRef(other)
     {
     }
 
+    /// \brief Move constructor from a WritableDynamicDataRef
     DynamicData(
             WritableDynamicDataRef&& other)
         : WritableDynamicDataRef(std::move(other))
     {
     }
 
+    /// \brief Construct a DynamicData from another DynamicData with a compatible type.
+    /// (see DynamicType::is_compatible())
+    /// \param[in] other A compatible DynamicData from which de data will be copies.
+    /// \param[in] type DynamicType from which the DynamicData is created.
     DynamicData(
             const ReadableDynamicDataRef& other,
             const DynamicType& type)

--- a/include/dds/core/xtypes/DynamicData.hpp
+++ b/include/dds/core/xtypes/DynamicData.hpp
@@ -450,6 +450,11 @@ protected:
 
     /// \brief Internal cast from readable to writable
     WritableDynamicDataRef(
+            const ReadableDynamicDataRef& other)
+        : ReadableDynamicDataRef(other)
+    {}
+
+    WritableDynamicDataRef(
             ReadableDynamicDataRef&& other)
         : ReadableDynamicDataRef(std::move(other))
     {}
@@ -473,6 +478,18 @@ public:
     /// (see DynamicType::is_compatible())
     /// \param[in] other A compatible DynamicData from which de data will be copies.
     /// \param[in] type DynamicType from which the DynamicData is created.
+    DynamicData(
+            const ReadableDynamicDataRef& other)
+        : WritableDynamicDataRef(other)
+    {
+    }
+
+    DynamicData(
+            WritableDynamicDataRef&& other)
+        : WritableDynamicDataRef(std::move(other))
+    {
+    }
+
     DynamicData(
             const ReadableDynamicDataRef& other,
             const DynamicType& type)

--- a/src/cpp/CMakeLists.txt
+++ b/src/cpp/CMakeLists.txt
@@ -386,6 +386,11 @@ set_public_headers_directory(${PROJECT_SOURCE_DIR}/include fastdds
     COMPONENT headers
     INSTALL
     )
+set_public_headers_directory(${PROJECT_SOURCE_DIR}/include dds
+    DESTINATION ${INCLUDE_INSTALL_DIR}
+    COMPONENT headers
+    INSTALL
+    )
 
 # Install config.h header
 set_public_header(${PROJECT_BINARY_DIR}/include ${PROJECT_NAME} config.h


### PR DESCRIPTION
- Removed EPROSIMA_BUILD_XTYPES_STANDALONE option. 
- DDS headers are now installed always.
- Added new hierarchical copy and move constructors for DynamicData.