### PR TITLE
Only call find_package for TinyXML2 if thirdparty options are off

### DIFF
--- a/cmake/modules/FindTinyXML2.cmake
+++ b/cmake/modules/FindTinyXML2.cmake
@@ -4,7 +4,10 @@
 
 option(TINYXML2_FROM_SOURCE "Integrate TinyXML2 source code inside Fast RTPS" OFF)
 
-find_package(TinyXML2 CONFIG QUIET)
+if(NOT (TINYXML2_FROM_SOURCE OR THIRDPARTY))
+    find_package(TinyXML2 CONFIG QUIET)
+endif()
+
 if(TinyXML2_FOUND AND NOT THIRDPARTY)
     message(STATUS "Found TinyXML2: ${TinyXML2_DIR}")
     if(NOT TINYXML2_LIBRARY)


### PR DESCRIPTION
FindTinyXML2.cmake's current behavior is to always call `find_package` even if the options for `THIRDPARTY` or `TINYXML2_FROM_SOURCE` aren't set. So on systems with a TinyXML2 installation this means that those options are effectively ignored as find_package will pick up the system level install.

This PR does a simple check to only call find_package if those options aren't set without modifying any of the fallback code.