### PR TITLE
Refs #6789 Added alias for ResponseCode compatibility.

### DIFF
--- a/include/fastrtps/types/TypesBase.h
+++ b/include/fastrtps/types/TypesBase.h
@@ -257,6 +257,9 @@ private:
     uint32_t value_ = ReturnCode_t::RETCODE_OK.value_;
 };
 
+// TODO Remove this alias when Fast-RTPS reaches version 2
+using ResponseCode = ReturnCode_t;
+
 typedef uint32_t MemberId;
 #define MEMBER_ID_INVALID 0X0FFFFFFF
 #define INDEX_INVALID UINT32_MAX


### PR DESCRIPTION
This PR adds the alias `ResponseCode` for the new enum `ReturnCode_t` which replaces the old enum `ResponseCode`.