### PR TITLE
Updating std::hast<EntityId_t> to get a better unordered containers distribution [6895]

### DIFF
--- a/include/fastrtps/rtps/common/EntityId_t.hpp
+++ b/include/fastrtps/rtps/common/EntityId_t.hpp
@@ -325,7 +325,7 @@ template <>
 struct hash<eprosima::fastrtps::rtps::EntityId_t>
 {
     std::size_t operator()(
-        const eprosima::fastrtps::rtps::EntityId_t& k) const
+            const eprosima::fastrtps::rtps::EntityId_t& k) const
     {
         // recover the participant entity counter
         eprosima::fastrtps::rtps::octet value[4];
@@ -344,6 +344,7 @@ struct hash<eprosima::fastrtps::rtps::EntityId_t>
         return static_cast<std::size_t>(*reinterpret_cast<const uint32_t*>(&value));
     }
 };
+
 } // namespace std
 
 

--- a/include/fastrtps/rtps/common/EntityId_t.hpp
+++ b/include/fastrtps/rtps/common/EntityId_t.hpp
@@ -325,13 +325,25 @@ template <>
 struct hash<eprosima::fastrtps::rtps::EntityId_t>
 {
     std::size_t operator()(
-            const eprosima::fastrtps::rtps::EntityId_t& k) const
+        const eprosima::fastrtps::rtps::EntityId_t& k) const
     {
-        const uint32_t* aux = reinterpret_cast<const uint32_t*>(k.value);
-        return static_cast<std::size_t>(*aux);
+        // recover the participant entity counter
+        eprosima::fastrtps::rtps::octet value[4];
+
+#if __BIG_ENDIAN__
+        value[3] = k.value[2];
+        value[2] = k.value[1];
+        value[1] = k.value[0];
+        value[0] = 0;
+#else
+        value[3] = 0;
+        value[2] = k.value[0];
+        value[1] = k.value[1];
+        value[0] = k.value[2];
+#endif
+        return static_cast<std::size_t>(*reinterpret_cast<const uint32_t*>(&value));
     }
 };
-
 } // namespace std
 
 


### PR DESCRIPTION
Internally STL implementation of hash tables (unordered_map and set) use modulus operation to choose in which bucket put each element. Using an uniform distributed hash guarantees that the buckets get evenly filled and access time is minimum.
Until now we were using the whole EntityId_t interpret as a number as hash. That led to a non-uniform, unsuitable distribution because within each EntityId_t are kept flags not merely a counter. Now, only the counter value is used solving the speed issue. 