### PR TITLE
Fix deadlock between PDP and StatefulReader

### DIFF
--- a/src/cpp/rtps/builtin/discovery/participant/PDP.cpp
+++ b/src/cpp/rtps/builtin/discovery/participant/PDP.cpp
@@ -1017,7 +1017,7 @@ CDRMessage_t PDP::get_participant_proxy_data_serialized(Endianness_t endian)
 void PDP::check_remote_participant_liveliness(
         ParticipantProxyData* remote_participant)
 {
-    std::lock_guard<std::recursive_mutex> guard(*this->mp_mutex);
+    std::unique_lock<std::recursive_mutex> guard(*this->mp_mutex);
 
     if(GUID_t::unknown() != remote_participant->m_guid)
     {
@@ -1028,7 +1028,9 @@ void PDP::check_remote_participant_liveliness(
                 std::chrono::microseconds(TimeConv::Duration_t2MicroSecondsInt64(remote_participant->m_leaseDuration));
         if (now > real_lease_tm)
         {
+            guard.unlock();
             remove_remote_participant(remote_participant->m_guid, ParticipantDiscoveryInfo::DROPPED_PARTICIPANT);
+            guard.lock();
             return;
         }
 

--- a/src/cpp/rtps/builtin/discovery/participant/PDP.cpp
+++ b/src/cpp/rtps/builtin/discovery/participant/PDP.cpp
@@ -1030,7 +1030,6 @@ void PDP::check_remote_participant_liveliness(
         {
             guard.unlock();
             remove_remote_participant(remote_participant->m_guid, ParticipantDiscoveryInfo::DROPPED_PARTICIPANT);
-            guard.lock();
             return;
         }
 


### PR DESCRIPTION
This is intended to fix a deadlock that causes tests to hang on the ROS 2 buildfarm (ros2/build_cop#248) using Fast-RTPS `v1.9.2`. There's more info here: https://github.com/ros2/build_cop/issues/248#issuecomment-555625379.

This PR avoids deadlock by releasing the PDP mutex before calling `remove_remote_participant()`. It seems like a reasonable thing to do since `remove_remote_participant()` [acquires the lock internally](https://github.com/eProsima/Fast-RTPS/blob/daabbc72b79b094cb9fe684655726105f27bdc7d/src/cpp/rtps/builtin/discovery/participant/PDP.cpp#L856), though I don't know if releasing the lock momentarily breaks any assumptions in `check_remote_participant_lifeliness()`.