### PR TITLE
Fixed assertion in foonathan library on Debug. [6903]

### DIFF
--- a/include/fastrtps/utils/collections/foonathan_memory_helpers.hpp
+++ b/include/fastrtps/utils/collections/foonathan_memory_helpers.hpp
@@ -50,9 +50,10 @@ std::size_t memory_pool_block_size(
         num_elems = 1u;
     }
 
-    return num_elems * (node_size                                                  // Room for elements
-           + 2 * (foonathan::memory::detail::debug_fence_size ? node_size : 0))    // Room for debug info
-           + foonathan::memory::detail::memory_block_stack::implementation_offset; // Room for padding
+    return num_elems
+           * ((node_size > MemoryPool::min_node_size ? node_size : MemoryPool::min_node_size) // Room for elements
+           + 2 * (foonathan::memory::detail::debug_fence_size ? node_size : 0))               // Room for debug info
+           + foonathan::memory::detail::memory_block_stack::implementation_offset;            // Room for padding
 }
 
 }  // namespace fastrtps

--- a/include/fastrtps/utils/collections/foonathan_memory_helpers.hpp
+++ b/include/fastrtps/utils/collections/foonathan_memory_helpers.hpp
@@ -52,7 +52,7 @@ std::size_t memory_pool_block_size(
 
     return num_elems
            * ((node_size > MemoryPool::min_node_size ? node_size : MemoryPool::min_node_size) // Room for elements
-           * (foonathan::memory::detail::debug_fence_size ? 3 : 1))               // Room for debug info
+           * (foonathan::memory::detail::debug_fence_size ? 3 : 1))                           // Room for debug info
            + foonathan::memory::detail::memory_block_stack::implementation_offset;            // Room for padding
 }
 

--- a/include/fastrtps/utils/collections/foonathan_memory_helpers.hpp
+++ b/include/fastrtps/utils/collections/foonathan_memory_helpers.hpp
@@ -21,6 +21,7 @@
 #define FASTRTPS_UTILS_COLLECTIONS_FOONATHAN_MEMORY_HELPERS_HPP_
 
 #include <foonathan/memory/memory_pool.hpp>
+#include <foonathan/memory/detail/debug_helpers.hpp>
 
 #include "ResourceLimitedContainerConfig.hpp"
 
@@ -49,12 +50,9 @@ std::size_t memory_pool_block_size(
         num_elems = 1u;
     }
 
-    // Make room for debug fence
-    num_elems += 2u;
-
-    return node_size * num_elems       // Room for elements
-        + MemoryPool::min_node_size    // Room for free_list nodes
-        + 16u;                         // Additional fence space
+    return num_elems * (node_size                                                  // Room for elements
+           + 2 * (foonathan::memory::detail::debug_fence_size ? node_size : 0))    // Room for debug info
+           + foonathan::memory::detail::memory_block_stack::implementation_offset; // Room for padding
 }
 
 }  // namespace fastrtps

--- a/include/fastrtps/utils/collections/foonathan_memory_helpers.hpp
+++ b/include/fastrtps/utils/collections/foonathan_memory_helpers.hpp
@@ -52,7 +52,7 @@ std::size_t memory_pool_block_size(
 
     return num_elems
            * ((node_size > MemoryPool::min_node_size ? node_size : MemoryPool::min_node_size) // Room for elements
-           + 2 * (foonathan::memory::detail::debug_fence_size ? node_size : 0))               // Room for debug info
+           * (foonathan::memory::detail::debug_fence_size ? 3 : 1))               // Room for debug info
            + foonathan::memory::detail::memory_block_stack::implementation_offset;            // Room for padding
 }
 

--- a/src/cpp/rtps/builtin/data/ProxyHashTables.hpp
+++ b/src/cpp/rtps/builtin/data/ProxyHashTables.hpp
@@ -52,15 +52,12 @@ public:
             std::size_t nodes_to_allocate,
             const bool& flag,
             std::size_t padding = foonathan::memory::detail::memory_block_stack::implementation_offset)
-        : block_size_(nodes_to_allocate * (node_size
+        : block_size_(nodes_to_allocate
+                * ((node_size > allocator_type::min_node_size ? node_size : allocator_type::min_node_size)
                 // Needs more space in debug info. It allocates space to detect overflow.
                 + 2 * (foonathan::memory::detail::debug_fence_size ? node_size : 0))
                 + padding)
-        , node_allocator_(new allocator_type(node_size,
-                nodes_to_allocate * (node_size
-                // Needs more space in debug info. It allocates space to detect overflow.
-                + 2 * (foonathan::memory::detail::debug_fence_size ? node_size : 0))
-                + padding))
+        , node_allocator_(new allocator_type(node_size, block_size_))
         , initialization_is_done_(flag)
     {
     }

--- a/src/cpp/rtps/builtin/data/ProxyHashTables.hpp
+++ b/src/cpp/rtps/builtin/data/ProxyHashTables.hpp
@@ -55,7 +55,7 @@ public:
         : block_size_(nodes_to_allocate
                 * ((node_size > allocator_type::min_node_size ? node_size : allocator_type::min_node_size)
                 // Needs more space in debug info. It allocates space to detect overflow.
-                + 2 * (foonathan::memory::detail::debug_fence_size ? node_size : 0))
+                * (foonathan::memory::detail::debug_fence_size ? 3 : 1))
                 + padding)
         , node_allocator_(new allocator_type(node_size, block_size_))
         , initialization_is_done_(flag)


### PR DESCRIPTION
This PR fixes a failed assertion in foonathan library:
```
[foonathan::memory] Assertion failure in function insert_impl (/home/ricardo/workspace/eprosima/fastrtps/master/build/Debug/foonathan_memory_vendor/foo_mem-ext-prefix/src/foo_mem-ext/src/detail/free_list.cpp:239): Assertion "no_nodes > 0" failed.
```
The reason is `memory_pool` needs more space because foonathan uses space for debug purposes.
