### PR TITLE
[master] Templating MessageReceiver::findAllReaders [6913]

### DIFF
--- a/include/fastdds/rtps/messages/MessageReceiver.h
+++ b/include/fastdds/rtps/messages/MessageReceiver.h
@@ -134,7 +134,10 @@ class MessageReceiver
          * Find all readers (in AssociatedReaders), with the given entity ID, and call the
          * callback provided.
          */
-        void findAllReaders(const EntityId_t & readerID, std::function<void(RTPSReader*)>);
+        template<typename Functor>
+        void findAllReaders(
+                const EntityId_t & readerID,
+                const Functor & callback);
 
         /**
          *

--- a/src/cpp/rtps/messages/MessageReceiver.cpp
+++ b/src/cpp/rtps/messages/MessageReceiver.cpp
@@ -457,9 +457,10 @@ bool MessageReceiver::willAReaderAcceptMsgDirectedTo(
     return false;
 }
 
+template<typename Functor>
 void MessageReceiver::findAllReaders(
         const EntityId_t& readerID,
-        std::function<void(RTPSReader*)> callback)
+        const Functor& callback)
 {
     if (readerID != c_EntityId_Unknown)
     {


### PR DESCRIPTION
This PR converts MessageReceiver::findAllReaders into a templated method, in order to avoid dynamic memory allocations when the std::function object is copied.