### PR TITLE
[1.9.x] Timed events refactor [6920]

### DIFF
--- a/include/fastrtps/rtps/builtin/discovery/participant/timedevent/DSClientEvent.h
+++ b/include/fastrtps/rtps/builtin/discovery/participant/timedevent/DSClientEvent.h
@@ -52,7 +52,7 @@ public:
         + matches the EDP endpoints when the servers are all aware of this client existence
 	* @param code Code representing the status of the event
 	*/
-	bool event(EventCode code);
+	bool event();
 	
 	//!Pointer to the PDPServer object.
     PDPClient* mp_PDP;

--- a/include/fastrtps/rtps/builtin/discovery/participant/timedevent/DSClientEvent.h
+++ b/include/fastrtps/rtps/builtin/discovery/participant/timedevent/DSClientEvent.h
@@ -50,7 +50,6 @@ public:
 	* This temporal event:
         + resends the client RTPSParticipantProxyData to all remote servers.
         + matches the EDP endpoints when the servers are all aware of this client existence
-	* @param code Code representing the status of the event
 	*/
 	bool event();
 	

--- a/include/fastrtps/rtps/builtin/discovery/participant/timedevent/DServerEvent.h
+++ b/include/fastrtps/rtps/builtin/discovery/participant/timedevent/DServerEvent.h
@@ -52,7 +52,7 @@ public:
         + matches the EDP endpoints when the servers are all aware of this client existence
     * @param code Code representing the status of the event
     */
-    bool event(EventCode code);
+    bool event();
 
     //!Pointer to the PDPServer object.
     PDPServer* mp_PDP;

--- a/include/fastrtps/rtps/builtin/discovery/participant/timedevent/DServerEvent.h
+++ b/include/fastrtps/rtps/builtin/discovery/participant/timedevent/DServerEvent.h
@@ -50,7 +50,6 @@ public:
     * This temporal event:
         + resends the client RTPSParticipantProxyData to all remote servers.
         + matches the EDP endpoints when the servers are all aware of this client existence
-    * @param code Code representing the status of the event
     */
     bool event();
 

--- a/include/fastrtps/rtps/resources/ResourceEvent.h
+++ b/include/fastrtps/rtps/resources/ResourceEvent.h
@@ -43,9 +43,9 @@ class ResourceEvent
 {
 public:
 
-    ResourceEvent();
+    ResourceEvent() = default;
 
-    virtual ~ResourceEvent();
+    ~ResourceEvent();
 
     /*!
      * @brief Method to initialize the internal thread.
@@ -97,7 +97,7 @@ public:
 private:
 
     //! Warns the internal thread can stop.
-    std::atomic<bool> stop_;
+    std::atomic<bool> stop_{ false };
 
     //! Protects internal data.
     TimedMutex mutex_;
@@ -106,13 +106,13 @@ private:
     TimedConditionVariable cv_manipulation_;
 
     //! Flag used to allow a thread to manipulate the timer collections when the execution thread is not using them.
-    bool allow_vector_manipulation_;
+    bool allow_vector_manipulation_ = false;
 
     //! Used to warn there are new TimedEventImpl objects to be processed.
     TimedConditionVariable cv_;
 
     //! The total number of created timers.
-    size_t timers_count_;
+    size_t timers_count_ = 0;
 
     //! Collection of events pending update action.
     std::vector<TimedEventImpl*> pending_timers_;

--- a/include/fastrtps/rtps/resources/ResourceEvent.h
+++ b/include/fastrtps/rtps/resources/ResourceEvent.h
@@ -57,8 +57,8 @@ public:
      * internal thread.
      *
      * This method has to be called before deleting the TimedEventImpl object.
-     * This method cancels any operation of the internal asio::steady_timer.
-     * Then it avoids the situation of asio calling the event handler when it was removed previously.
+     * This method cancels any operation of the timer.
+     * Then it avoids the situation of the execution thread calling the event handler when it was removed previously.
      * @param event TimedEventImpl object that will be deleted and we have to be sure all its operations are cancelled.
      */
     void unregister_timer(
@@ -99,16 +99,16 @@ private:
     //! Flag used to allow a thread to delete a TimedEventImpl because the main thread is not using asio::io_service.
     bool allow_to_delete_;
 
-    //! Collection of events pending update action
+    //! Collection of events pending update action.
     std::vector<TimedEventImpl*> pending_timers_;
 
-    //! Collection of registered events waiting completion
+    //! Collection of registered events waiting completion.
     std::vector<TimedEventImpl*> active_timers_;
 
-    //! Current time as seen by the execution thread
+    //! Current time as seen by the execution thread.
     std::chrono::steady_clock::time_point current_time_;
 
-    //! Thread
+    //! Execution thread.
     std::thread thread_;
 
     /*!

--- a/include/fastrtps/rtps/resources/ResourceEvent.h
+++ b/include/fastrtps/rtps/resources/ResourceEvent.h
@@ -97,8 +97,11 @@ private:
     //! Used to warn there are new TimedEventImpl objects to be processed.
     TimedConditionVariable cv_;
 
+    //! Collection of events pending update action
+    std::vector<TimedEventImpl*> pending_timers_;
+
     //! Collection of registered events waiting completion
-    std::vector<TimedEventImpl*> timers_;
+    std::vector<TimedEventImpl*> active_timers_;
 
     //! Current time as seen by the execution thread
     std::chrono::steady_clock::time_point current_time_;
@@ -120,6 +123,8 @@ private:
 
     void sort_timers();
     void update_current_time();
+    void activate_timer(
+            TimedEventImpl* event);
 
     void do_timer_actions();
 };

--- a/include/fastrtps/rtps/resources/ResourceEvent.h
+++ b/include/fastrtps/rtps/resources/ResourceEvent.h
@@ -53,6 +53,15 @@ public:
     void init_thread();
 
     /*!
+     * @brief This method informs that a TimedEventImpl has been created.
+     *
+     * This method has to be called when creating a TimedEventImpl object.
+     * @param event TimedEventImpl object that has been created.
+     */
+    void register_timer(
+            TimedEventImpl* event);
+
+    /*!
      * @brief This method removes a TimedEventImpl object in case it is waiting to be processed by ResourceEvent's
      * internal thread.
      *
@@ -93,11 +102,17 @@ private:
     //! Protects internal data.
     TimedMutex mutex_;
 
+    //! Used to warn about changes on allow_vector_manipulation_.
+    TimedConditionVariable cv_manipulation_;
+
+    //! Flag used to allow a thread to manipulate the timer collections when the execution thread is not using them.
+    bool allow_vector_manipulation_;
+
     //! Used to warn there are new TimedEventImpl objects to be processed.
     TimedConditionVariable cv_;
 
-    //! Flag used to allow a thread to delete a TimedEventImpl because the main thread is not using asio::io_service.
-    bool allow_to_delete_;
+    //! The total number of created timers.
+    size_t timers_count_;
 
     //! Collection of events pending update action.
     std::vector<TimedEventImpl*> pending_timers_;

--- a/include/fastrtps/rtps/resources/ResourceEvent.h
+++ b/include/fastrtps/rtps/resources/ResourceEvent.h
@@ -96,6 +96,9 @@ private:
     //! Used to warn there are new TimedEventImpl objects to be processed.
     TimedConditionVariable cv_;
 
+    //! Flag used to allow a thread to delete a TimedEventImpl because the main thread is not using asio::io_service.
+    bool allow_to_delete_;
+
     //! Collection of events pending update action
     std::vector<TimedEventImpl*> pending_timers_;
 

--- a/include/fastrtps/rtps/resources/ResourceEvent.h
+++ b/include/fastrtps/rtps/resources/ResourceEvent.h
@@ -28,7 +28,6 @@
 #include <thread>
 #include <atomic>
 #include <vector>
-#include <future>
 
 namespace eprosima {
 namespace fastrtps {

--- a/include/fastrtps/rtps/resources/ResourceEvent.h
+++ b/include/fastrtps/rtps/resources/ResourceEvent.h
@@ -19,6 +19,7 @@
 
 #ifndef _RTPS_RESOURCES_RESOURCEEVENT_H_
 #define _RTPS_RESOURCES_RESOURCEEVENT_H_
+
 #ifndef DOXYGEN_SHOULD_SKIP_THIS_PUBLIC
 
 #include "../../utils/TimedMutex.hpp"
@@ -136,8 +137,11 @@ private:
 
     std::promise<void> ready;
 };
-}
-}
+
+} /* namespace rtps */
+} /* namespace fastrtps */
 } /* namespace eprosima */
+
 #endif
+
 #endif //_RTPS_RESOURCES_RESOURCEEVENT_H_

--- a/include/fastrtps/rtps/resources/ResourceEvent.h
+++ b/include/fastrtps/rtps/resources/ResourceEvent.h
@@ -106,7 +106,7 @@ private:
     TimedConditionVariable cv_manipulation_;
 
     //! Flag used to allow a thread to manipulate the timer collections when the execution thread is not using them.
-    bool allow_vector_manipulation_ = false;
+    bool allow_vector_manipulation_ = true;
 
     //! Used to warn there are new TimedEventImpl objects to be processed.
     TimedConditionVariable cv_;
@@ -144,6 +144,12 @@ private:
             TimedEventImpl* event);
 
     void do_timer_actions();
+
+    void resize_collections()
+    {
+        pending_timers_.reserve(timers_count_);
+        active_timers_.reserve(timers_count_);
+    }
 };
 
 } /* namespace rtps */

--- a/include/fastrtps/rtps/resources/ResourceEvent.h
+++ b/include/fastrtps/rtps/resources/ResourceEvent.h
@@ -31,7 +31,7 @@
 #include <asio.hpp>
 
 namespace eprosima {
-namespace fastrtps{
+namespace fastrtps {
 namespace rtps {
 
 class TimedEventImpl;
@@ -43,90 +43,98 @@ class TimedEventImpl;
  */
 class ResourceEvent
 {
-    public:
+public:
 
-        ResourceEvent();
+    ResourceEvent();
 
-        virtual ~ResourceEvent();
+    virtual ~ResourceEvent();
 
-        /*!
-         * @brief Method to initialize the internal thread.
-         */
-        void init_thread();
+    /*!
+     * @brief Method to initialize the internal thread.
+     */
+    void init_thread();
 
-        /*!
-         * @brief This method removes a TimedEventImpl object in case it is waiting to be processed by ResourceEvent's
-         * internal thread.
-         *
-         * This method has to be called before deleting the TimedEventImpl object.
-         * This method cancels any operation of the internal asio::steady_timer.
-         * Then it avoids the situation of asio calling the event handler when it was removed previously.
-         * @param event TimedEventImpl object that will be deleted and we have to be sure all its operations are cancelled.
-         */
-        void unregister_timer(TimedEventImpl* event);
+    /*!
+     * @brief This method removes a TimedEventImpl object in case it is waiting to be processed by ResourceEvent's
+     * internal thread.
+     *
+     * This method has to be called before deleting the TimedEventImpl object.
+     * This method cancels any operation of the internal asio::steady_timer.
+     * Then it avoids the situation of asio calling the event handler when it was removed previously.
+     * @param event TimedEventImpl object that will be deleted and we have to be sure all its operations are cancelled.
+     */
+    void unregister_timer(
+            TimedEventImpl* event);
 
-        /*!
-         * @brief This method notifies to ResourceEvent that the TimedEventImpl object has operations to be scheduled.
-         *
-         * These operations can be the cancellation of the internal asio::steady_timer or starting another async_wait.
-         * @param event TimedEventImpl object that has operations to be scheduled.
-         */
-        void notify(TimedEventImpl* event);
+    /*!
+     * @brief This method notifies to ResourceEvent that the TimedEventImpl object has operations to be scheduled.
+     *
+     * These operations can be the cancellation of the internal asio::steady_timer or starting another async_wait.
+     * @param event TimedEventImpl object that has operations to be scheduled.
+     */
+    void notify(
+            TimedEventImpl* event);
 
-        /*!
-         * @brief This method notifies to ResourceEvent that the TimedEventImpl object has operations to be scheduled.
-         *
-         * These operations can be the cancellation of the internal asio::steady_timer or starting another async_wait.
-         * @note Non-blocking call version of the method.
-         * @param event TimedEventImpl object that has operations to be scheduled.
-         * @param timeout Maximum blocking time of the method.
-         */
-        void notify(TimedEventImpl* event, const std::chrono::steady_clock::time_point& timeout);
+    /*!
+     * @brief This method notifies to ResourceEvent that the TimedEventImpl object has operations to be scheduled.
+     *
+     * These operations can be the cancellation of the internal asio::steady_timer or starting another async_wait.
+     * @note Non-blocking call version of the method.
+     * @param event TimedEventImpl object that has operations to be scheduled.
+     * @param timeout Maximum blocking time of the method.
+     */
+    void notify(
+            TimedEventImpl* event,
+            const std::chrono::steady_clock::time_point& timeout);
 
-        /*!
-         * @brief Returns the internal asio::io_service.
-         * @return Associated asio::io_service.
-         */
-        asio::io_service& get_io_service() { return io_service_; }
+    /*!
+     * @brief Returns the internal asio::io_service.
+     * @return Associated asio::io_service.
+     */
+    asio::io_service& get_io_service()
+    {
+        return io_service_;
+    }
 
-    private:
+private:
 
-        //! Warns the internal thread can stop.
-        std::atomic<bool> stop_;
+    //! Warns the internal thread can stop.
+    std::atomic<bool> stop_;
 
-        //! Protects internal data.
-        TimedMutex mutex_;
+    //! Protects internal data.
+    TimedMutex mutex_;
 
-        //! Used to warn there are new TimedEventImpl objects to be processed.
-        TimedConditionVariable cv_;
+    //! Used to warn there are new TimedEventImpl objects to be processed.
+    TimedConditionVariable cv_;
 
-        //! Flag used to allow a thread to delete a TimedEventImpl because the main thread is not using asio::io_service.
-        bool allow_to_delete_;
+    //! Flag used to allow a thread to delete a TimedEventImpl because the main thread is not using asio::io_service.
+    bool allow_to_delete_;
 
-        //! Head of the list of TimedEventImpl objects that have to be processed.
-        TimedEventImpl* front_;
+    //! Head of the list of TimedEventImpl objects that have to be processed.
+    TimedEventImpl* front_;
 
-        //! Back of the list of TimedEventImpl objects that have to be processed.
-        TimedEventImpl* back_;
+    //! Back of the list of TimedEventImpl objects that have to be processed.
+    TimedEventImpl* back_;
 
-        //! Thread
-        std::thread thread_;
+    //! Thread
+    std::thread thread_;
 
-        //! IO service
-        asio::io_service io_service_;
+    //! IO service
+    asio::io_service io_service_;
 
-        /*!
-         * @brief Registers a new TimedEventImpl object in the internal queue to be processed.
-         * Non thread safe.
-         * @param event Event to be added in the queue.
-         * @return True value if the insertion was successful. In other case, it return False.
-         */
-        bool register_timer_nts(TimedEventImpl* event);
+    /*!
+     * @brief Registers a new TimedEventImpl object in the internal queue to be processed.
+     * Non thread safe.
+     * @param event Event to be added in the queue.
+     * @return True value if the insertion was successful. In other case, it return False.
+     */
+    bool register_timer_nts(
+            TimedEventImpl* event);
 
-        //! Method called by the internal thread.
-        void run_io_service();
+    //! Method called by the internal thread.
+    void run_io_service();
 
-        std::promise<void> ready;
+    std::promise<void> ready;
 };
 }
 }

--- a/include/fastrtps/rtps/resources/TimedEvent.h
+++ b/include/fastrtps/rtps/resources/TimedEvent.h
@@ -41,23 +41,15 @@ class ResourceEvent;
  * In the construct you can set the callback to be called when the expiration time expires.
  * @code
    TimedEvent* event = new TimedEvent(resource_event_,
-        [&](TimedEvent::EventCode code) -> bool
+        [&]() -> bool
         {
-            if(TimedEvent::EVENT_SUCCESS == code)
-            {
-                std::cout << "hello" << std::endl;
-                return true;
-            }
-
-            return false;
+            std::cout << "hello" << std::endl;
+            return true;
         },
         100);
  * @endcode
  *
  * The signature of the callback is:
- * - The parameter of TimedEvent::EventCode type tells the user if the event achieves the deadline timer or it was
- *   aborted.
- *
  * - The returned value tells if the event has to be scheduled again or not. true value tells to reschedule the event.
  *   false value doesn't.
  *
@@ -105,15 +97,6 @@ class TimedEvent
 {
 public:
 
-    /**
-     * Enum representing event statuses
-     */
-    enum EventCode
-    {
-        EVENT_SUCCESS,
-        EVENT_ABORT
-    };
-
     /*!
      * @brief Default constructor.
      *
@@ -124,7 +107,7 @@ public:
      */
     TimedEvent(
             ResourceEvent& service,
-            std::function<bool(EventCode)> callback,
+            std::function<bool()> callback,
             double milliseconds);
 
     //! Default destructor.

--- a/include/fastrtps/rtps/resources/TimedEvent.h
+++ b/include/fastrtps/rtps/resources/TimedEvent.h
@@ -28,7 +28,7 @@
 #include <cstdint>
 
 namespace eprosima {
-namespace fastrtps{
+namespace fastrtps {
 namespace rtps {
 
 class TimedEventImpl;
@@ -40,7 +40,7 @@ class ResourceEvent;
  *
  * In the construct you can set the callback to be called when the expiration time expires.
  * @code
-TimedEvent* event = new TimedEvent(resource_event_,
+   TimedEvent* event = new TimedEvent(resource_event_,
         [&](TimedEvent::EventCode code) -> bool
         {
             if(TimedEvent::EVENT_SUCCESS == code)
@@ -68,34 +68,34 @@ TimedEvent* event = new TimedEvent(resource_event_,
  * - The event is an attribute of the class. Then it has to be declared as the last member of the class. Then we assure
  *   it will be the last one on being constructed and the first one on being deleted.
  *   @code
-class Owner
-{
+   class Owner
+   {
     int attr1;
 
     long attr2;
 
     TimedEvent event;  // Declared as the last member of the class.
-};
+   };
  * @endcode
  *
  * - The class has a pointer to the event (TimedEvent is created in heap). Then the pointer has to be the first one on
  *   being freed in the destructor of the class.
  * @code
- class Owner
- {
+   class Owner
+   {
      int* attr1;
 
      TimedEvent* event;
 
      long attr2,
-};
+   };
 
-Owner::~Owner()
-{
+   Owner::~Owner()
+   {
     delete(event); // First pointer to be deleted;
 
     delete(attr1);
-}
+   }
  * @endcode
  *
  * @ingroup MANAGEMENT_MODULE
@@ -103,85 +103,88 @@ Owner::~Owner()
  */
 class TimedEvent
 {
-    public:
+public:
 
-        /**
-         * Enum representing event statuses
-         */
-        enum EventCode
-        {
-            EVENT_SUCCESS,
-            EVENT_ABORT
-        };
+    /**
+     * Enum representing event statuses
+     */
+    enum EventCode
+    {
+        EVENT_SUCCESS,
+        EVENT_ABORT
+    };
 
-        /*!
-         * @brief Default constructor.
-         *
-         * The event is not created scheduled.
-         * @param service ResourceEvent object that will operate with the event.
-         * @param callback Callback called when the event expires.
-         * @param milliseconds Expiration time in milliseconds.
-         */
-        TimedEvent(
-                ResourceEvent& service,
-                std::function<bool(EventCode)> callback,
-                double milliseconds);
+    /*!
+     * @brief Default constructor.
+     *
+     * The event is not created scheduled.
+     * @param service ResourceEvent object that will operate with the event.
+     * @param callback Callback called when the event expires.
+     * @param milliseconds Expiration time in milliseconds.
+     */
+    TimedEvent(
+            ResourceEvent& service,
+            std::function<bool(EventCode)> callback,
+            double milliseconds);
 
-        //! Default destructor.
-        virtual ~TimedEvent();
+    //! Default destructor.
+    virtual ~TimedEvent();
 
-        /*!
-         * @brief Cancels any previous scheduling of the event.
-         */
-        void cancel_timer();
+    /*!
+     * @brief Cancels any previous scheduling of the event.
+     */
+    void cancel_timer();
 
-        /*!
-         * @brief Schedules the event if there is not a previous scheduling.
-         */
-        void restart_timer();
+    /*!
+     * @brief Schedules the event if there is not a previous scheduling.
+     */
+    void restart_timer();
 
-        /*!
-         * @brief Schedules the event if there is not a previous scheduling.
-         * @note Non-blocking call version.
-         * @param timeout Time point in the future until the method can be blocked.
-         */
-        void restart_timer(const std::chrono::steady_clock::time_point& timeout);
+    /*!
+     * @brief Schedules the event if there is not a previous scheduling.
+     * @note Non-blocking call version.
+     * @param timeout Time point in the future until the method can be blocked.
+     */
+    void restart_timer(
+            const std::chrono::steady_clock::time_point& timeout);
 
-        /**
-         * Update event interval.
-         * When updating the interval, the timer is not restarted and the new interval will only be used the next time you call restart_timer().
-         *
-         * @param inter New interval for the timedEvent
-         * @return true on success
-         */
-        bool update_interval(const Duration_t& inter);
+    /**
+     * Update event interval.
+     * When updating the interval, the timer is not restarted and the new interval will only be used the next time you call restart_timer().
+     *
+     * @param inter New interval for the timedEvent
+     * @return true on success
+     */
+    bool update_interval(
+            const Duration_t& inter);
 
-        /**
-         * Update event interval.
-         * When updating the interval, the timer is not restarted and the new interval will only be used the next time you call restart_timer().
-         *
-         * @param time_millisec New interval for the timedEvent
-         * @return true on success
-         */
-        bool update_interval_millisec(double time_millisec);
+    /**
+     * Update event interval.
+     * When updating the interval, the timer is not restarted and the new interval will only be used the next time you call restart_timer().
+     *
+     * @param time_millisec New interval for the timedEvent
+     * @return true on success
+     */
+    bool update_interval_millisec(
+            double time_millisec);
 
-        /**
-         * Get the milliseconds interval
-         * @return Milliseconds interval
-         */
-        double getIntervalMilliSec();
+    /**
+     * Get the milliseconds interval
+     * @return Milliseconds interval
+     */
+    double getIntervalMilliSec();
 
-        /**
-         * Get the remaining milliseconds for the timer to expire
-         * @return Remaining milliseconds for the timer to expire
-         */
-        double getRemainingTimeMilliSec();
+    /**
+     * Get the remaining milliseconds for the timer to expire
+     * @return Remaining milliseconds for the timer to expire
+     */
+    double getRemainingTimeMilliSec();
 
-    private:
+private:
 
-        ResourceEvent& service_;
+    ResourceEvent& service_;
 
-        TimedEventImpl* impl_;
+    TimedEventImpl* impl_;
 };
 
 } /* namespace rtps */

--- a/src/cpp/publisher/PublisherImpl.cpp
+++ b/src/cpp/publisher/PublisherImpl.cpp
@@ -76,26 +76,16 @@ PublisherImpl::PublisherImpl(
     , lifespan_duration_us_(m_att.qos.m_lifespan.duration.to_ns() * 1e-3)
 {
     deadline_timer_ = new TimedEvent(mp_participant->get_resource_event(),
-            [&](TimedEvent::EventCode code) -> bool
+            [&]() -> bool
             {
-                if (TimedEvent::EVENT_SUCCESS == code)
-                {
-                    return deadline_missed();
-                }
-
-                return false;
+                return deadline_missed();
             },
             att.qos.m_deadline.period.to_ns() * 1e-6);
 
     lifespan_timer_ = new TimedEvent(mp_participant->get_resource_event(),
-            [&](TimedEvent::EventCode code) -> bool
+            [&]() -> bool
             {
-                if (TimedEvent::EVENT_SUCCESS == code)
-                {
-                    return lifespan_expired();
-                }
-
-                return false;
+                return lifespan_expired();
             },
             m_att.qos.m_lifespan.duration.to_ns() * 1e-6);
 }

--- a/src/cpp/rtps/builtin/discovery/participant/PDP.cpp
+++ b/src/cpp/rtps/builtin/discovery/participant/PDP.cpp
@@ -161,13 +161,9 @@ ParticipantProxyData* PDP::add_participant_proxy_data(
             if (participant_guid != mp_RTPSParticipant->getGuid())
             {
                 ret_val->lease_duration_event = new TimedEvent(mp_RTPSParticipant->getEventResource(),
-                        [this, ret_val](TimedEvent::EventCode code) -> bool
+                        [this, ret_val]() -> bool
                         {
-                            if (TimedEvent::EVENT_SUCCESS == code)
-                            {
-                                check_remote_participant_liveliness(ret_val);
-                            }
-
+                            check_remote_participant_liveliness(ret_val);
                             return false;
                         }, 0.0);
             }
@@ -328,28 +324,19 @@ bool PDP::initPDP(
     for (ParticipantProxyData* pool_item : participant_proxies_pool_)
     {
         pool_item->lease_duration_event = new TimedEvent(mp_RTPSParticipant->getEventResource(),
-                [this, pool_item](TimedEvent::EventCode code) -> bool
+                [this, pool_item]() -> bool
                 {
-                    if (TimedEvent::EVENT_SUCCESS == code)
-                    {
-                        check_remote_participant_liveliness(pool_item);
-                    }
-
+                    check_remote_participant_liveliness(pool_item);
                     return false;
                 }, 0.0);
     }
 
     resend_participant_info_event_ = new TimedEvent(mp_RTPSParticipant->getEventResource(),
-            [&](TimedEvent::EventCode code) -> bool
+            [&]() -> bool
             {
-                if (TimedEvent::EVENT_SUCCESS == code)
-                {
-                    announceParticipantState(false);
-                    set_next_announcement_interval();
-                    return true;
-                }
-
-                return false;
+                announceParticipantState(false);
+                set_next_announcement_interval();
+                return true;
             },
             0);
 

--- a/src/cpp/rtps/builtin/discovery/participant/timedevent/DSClientEvent.cpp
+++ b/src/cpp/rtps/builtin/discovery/participant/timedevent/DSClientEvent.cpp
@@ -38,9 +38,9 @@ DSClientEvent::DSClientEvent(
         PDPClient* p_PDP,
         double interval)
     : TimedEvent(p_PDP->getRTPSParticipant()->getEventResource(), 
-        [this](EventCode code)
+        [this]()
         {
-            return event(code);
+            return event();
         }, interval)
     , mp_PDP(p_PDP)
 {
@@ -50,45 +50,36 @@ DSClientEvent::DSClientEvent(
 {
 }
 
-bool DSClientEvent::event(EventCode code)
+bool DSClientEvent::event()
 {
-    if(code == EVENT_SUCCESS)
-    {
-        logInfo(CLIENT_PDP_THREAD, "Client " << mp_PDP->getRTPSParticipant()->getGuid() << " DSClientEvent Period");
-        bool restart = true;
+    logInfo(CLIENT_PDP_THREAD, "Client " << mp_PDP->getRTPSParticipant()->getGuid() << " DSClientEvent Period");
+    bool restart = true;
 
-        // Check if all servers received my discovery data
-        if (mp_PDP->all_servers_acknowledge_PDP())
+    // Check if all servers received my discovery data
+    if (mp_PDP->all_servers_acknowledge_PDP())
+    {
+        // Wait until we have received all network discovery info currently available
+        if (mp_PDP->is_all_servers_PDPdata_updated())
         {
-            // Wait until we have received all network discovery info currently available
-            if (mp_PDP->is_all_servers_PDPdata_updated())
-            {
-                restart = !mp_PDP->match_servers_EDP_endpoints();
-                // we must keep this TimedEvent alive to cope with servers' shutdown
-                // PDPClient::removeRemoteEndpoints would restart_timer if a server vanishes
-                logInfo(CLIENT_PDP_THREAD,"Client " << mp_PDP->getRTPSParticipant()->getGuid() << " matching servers EDP endpoints")
-            }
-            else
-            {
-                logInfo(CLIENT_PDP_THREAD, "Client " << mp_PDP->getRTPSParticipant()->getGuid() << " not all servers acknowledge PDP info")
-            }
+            restart = !mp_PDP->match_servers_EDP_endpoints();
+            // we must keep this TimedEvent alive to cope with servers' shutdown
+            // PDPClient::removeRemoteEndpoints would restart_timer if a server vanishes
+            logInfo(CLIENT_PDP_THREAD,"Client " << mp_PDP->getRTPSParticipant()->getGuid() << " matching servers EDP endpoints")
         }
         else
-        { 
-            // Not all servers have yet received our DATA(p) thus resend
-            mp_PDP->_serverPing = true;
-            mp_PDP->announceParticipantState(false);
-            logInfo(CLIENT_PDP_THREAD, "Client " << mp_PDP->getRTPSParticipant()->getGuid() << " PDP announcement")
+        {
+            logInfo(CLIENT_PDP_THREAD, "Client " << mp_PDP->getRTPSParticipant()->getGuid() << " not all servers acknowledge PDP info")
         }
-
-        return restart;
     }
-    else if(code == EVENT_ABORT)
-    {
-        logInfo(RTPS_PDP,"DSClientEvent aborted");
+    else
+    { 
+        // Not all servers have yet received our DATA(p) thus resend
+        mp_PDP->_serverPing = true;
+        mp_PDP->announceParticipantState(false);
+        logInfo(CLIENT_PDP_THREAD, "Client " << mp_PDP->getRTPSParticipant()->getGuid() << " PDP announcement")
     }
 
-    return false;
+    return restart;
 }
 
 }

--- a/src/cpp/rtps/builtin/discovery/participant/timedevent/DServerEvent.cpp
+++ b/src/cpp/rtps/builtin/discovery/participant/timedevent/DServerEvent.cpp
@@ -37,9 +37,9 @@ DServerEvent::DServerEvent(
         PDPServer* p_PDP,
         double interval)
     : TimedEvent(p_PDP->getRTPSParticipant()->getEventResource(), 
-        [this](EventCode code)
+        [this]()
         {
-            return event(code);
+            return event();
         }, interval)
     , mp_PDP(p_PDP)
     , messages_enabled_(false)
@@ -51,79 +51,69 @@ DServerEvent::~DServerEvent()
 {
 }
 
-bool DServerEvent::event(EventCode code)
+bool DServerEvent::event()
 {
-    if(code == EVENT_SUCCESS)
+    logInfo(SERVER_PDP_THREAD, "Server " << mp_PDP->getRTPSParticipant()->getGuid() << " DServerEvent Period");
+
+    bool restart = false;
+
+    // messges_enabled is only modified from this thread
+    if (!messages_enabled_)
     {
-        logInfo(SERVER_PDP_THREAD, "Server " << mp_PDP->getRTPSParticipant()->getGuid() << " DServerEvent Period");
+        messages_enabled_ = true;
+        mp_PDP->getRTPSParticipant()->enableReader(mp_PDP->mp_PDPReader);
+    }
 
-        bool restart = false;
-
-        // messges_enabled is only modified from this thread
-        if (!messages_enabled_)
+    // Check Server matching
+    if (mp_PDP->all_servers_acknowledge_PDP())
+    {
+        // Wait until we have received all network discovery info currently available
+        if (mp_PDP->is_all_servers_PDPdata_updated())
         {
-            messages_enabled_ = true;
-            mp_PDP->getRTPSParticipant()->enableReader(mp_PDP->mp_PDPReader);
-        }
-
-        // Check Server matching
-        if (mp_PDP->all_servers_acknowledge_PDP())
-        {
-            // Wait until we have received all network discovery info currently available
-            if (mp_PDP->is_all_servers_PDPdata_updated())
-            {
-                restart |= !mp_PDP->match_servers_EDP_endpoints();
-                // we must keep this TimedEvent alive to cope with servers' shutdown
-                // PDPServer::removeRemoteEndpoints would restart_timer if a server vanishes
-            }
-            else
-            {
-                logInfo(SERVER_PDP_THREAD, "Server " << mp_PDP->getRTPSParticipant()->getGuid() << " not all servers acknowledge PDP info")
-                restart = true;
-            }
+            restart |= !mp_PDP->match_servers_EDP_endpoints();
+            // we must keep this TimedEvent alive to cope with servers' shutdown
+            // PDPServer::removeRemoteEndpoints would restart_timer if a server vanishes
         }
         else
-        {   // awake the other servers
-            mp_PDP->announceParticipantState(false);
+        {
+            logInfo(SERVER_PDP_THREAD, "Server " << mp_PDP->getRTPSParticipant()->getGuid() << " not all servers acknowledge PDP info")
             restart = true;
         }
-
-        // Check EDP matching
-        if (mp_PDP->pendingEDPMatches())
-        {
-            if (mp_PDP->all_clients_acknowledge_PDP())
-            {
-                // Do the matching
-                mp_PDP->match_all_clients_EDP_endpoints();
-                // Whenever new clients appear restart_timer()
-                // see PDPServer::queueParticipantForEDPMatch
-
-                logInfo(SERVER_PDP_THREAD, "Server " << mp_PDP->getRTPSParticipant()->getGuid() << " clients EDP points matched")
-            }
-            else
-            {   // keep trying the match
-                restart = true;  
-
-                logInfo(SERVER_PDP_THREAD, "Server " << mp_PDP->getRTPSParticipant()->getGuid() << " not all clients acknowledge PDP info")
-            }
-        }  
-
-        if (mp_PDP->pendingHistoryCleaning())
-        {
-            restart |= !mp_PDP->trimWriterHistory();
-
-            logInfo(SERVER_PDP_THREAD, "trimming PDP history from removed endpoints")
-        }
-
-        return restart;
-
     }
-    else if(code == EVENT_ABORT)
+    else
+    {   // awake the other servers
+        mp_PDP->announceParticipantState(false);
+        restart = true;
+    }
+
+    // Check EDP matching
+    if (mp_PDP->pendingEDPMatches())
     {
-        logInfo(SERVER_PDP_THREAD,"DServerEvent aborted");
+        if (mp_PDP->all_clients_acknowledge_PDP())
+        {
+            // Do the matching
+            mp_PDP->match_all_clients_EDP_endpoints();
+            // Whenever new clients appear restart_timer()
+            // see PDPServer::queueParticipantForEDPMatch
+
+            logInfo(SERVER_PDP_THREAD, "Server " << mp_PDP->getRTPSParticipant()->getGuid() << " clients EDP points matched")
+        }
+        else
+        {   // keep trying the match
+            restart = true;  
+
+            logInfo(SERVER_PDP_THREAD, "Server " << mp_PDP->getRTPSParticipant()->getGuid() << " not all clients acknowledge PDP info")
+        }
+    }  
+
+    if (mp_PDP->pendingHistoryCleaning())
+    {
+        restart |= !mp_PDP->trimWriterHistory();
+
+        logInfo(SERVER_PDP_THREAD, "trimming PDP history from removed endpoints")
     }
 
-    return false;
+    return restart;
 }
 
 } /* namespace rtps */

--- a/src/cpp/rtps/builtin/liveliness/WLP.cpp
+++ b/src/cpp/rtps/builtin/liveliness/WLP.cpp
@@ -529,15 +529,10 @@ bool WLP::add_local_writer(RTPSWriter* W, const WriterQos& wqos)
         if (automatic_liveliness_assertion_ == nullptr)
         {
             automatic_liveliness_assertion_ = new TimedEvent(mp_participant->getEventResource(),
-                    [&](TimedEvent::EventCode code) -> bool
+                    [&]() -> bool
                     {
-                        if (TimedEvent::EVENT_SUCCESS == code)
-                        {
-                            automatic_liveliness_assertion();
-                            return true;
-                        }
-
-                        return false;
+                        automatic_liveliness_assertion();
+                        return true;
                     },
                     wAnnouncementPeriodMilliSec);
             automatic_liveliness_assertion_->restart_timer();
@@ -561,15 +556,10 @@ bool WLP::add_local_writer(RTPSWriter* W, const WriterQos& wqos)
         if(manual_liveliness_assertion_ == nullptr)
         {
             manual_liveliness_assertion_ = new TimedEvent(mp_participant->getEventResource(),
-                    [&](TimedEvent::EventCode code) -> bool
+                    [&]() -> bool
                     {
-                        if (TimedEvent::EVENT_SUCCESS == code)
-                        {
-                            participant_liveliness_assertion();
-                            return true;
-                        }
-
-                        return false;
+                        participant_liveliness_assertion();
+                        return true;
                     },
                     wAnnouncementPeriodMilliSec);
             manual_liveliness_assertion_->restart_timer();

--- a/src/cpp/rtps/reader/WriterProxy.cpp
+++ b/src/cpp/rtps/reader/WriterProxy.cpp
@@ -75,27 +75,23 @@ WriterProxy::WriterProxy(
     , is_on_same_process_(false)
 {
     //Create Events
-    heartbeat_response_ = new TimedEvent(reader_->getRTPSParticipant()->getEventResource(),
-                    [&](TimedEvent::EventCode code) -> bool
+    heartbeat_response_ =
+        new TimedEvent(reader_->getRTPSParticipant()->getEventResource(),
+                [&]() -> bool
                 {
-                    if (TimedEvent::EVENT_SUCCESS == code)
-                    {
-                        perform_heartbeat_response();
-                    }
-
+                    perform_heartbeat_response();
                     return false;
-                }, 0);
+                },
+                0);
 
-    initial_acknack_ = new TimedEvent(reader_->getRTPSParticipant()->getEventResource(),
-                    [&](TimedEvent::EventCode code) -> bool
+    initial_acknack_ =
+        new TimedEvent(reader_->getRTPSParticipant()->getEventResource(),
+                [&]() -> bool
                 {
-                    if (TimedEvent::EVENT_SUCCESS == code)
-                    {
-                        perform_initial_ack_nack();
-                    }
-
+                    perform_initial_ack_nack();
                     return false;
-                }, 0 );
+                },
+                0);
     clear();
     logInfo(RTPS_READER, "Writer Proxy created in reader: " << reader_->getGuid().entityId);
 }

--- a/src/cpp/rtps/resources/ResourceEvent.cpp
+++ b/src/cpp/rtps/resources/ResourceEvent.cpp
@@ -28,7 +28,7 @@
 #include <asio/steady_timer.hpp>
 
 namespace eprosima {
-namespace fastrtps{
+namespace fastrtps {
 namespace rtps {
 
 
@@ -39,11 +39,11 @@ ResourceEvent::ResourceEvent()
     , back_(nullptr)
     , io_service_(
 #if ASIO_VERSION >= 101200
-            ASIO_CONCURRENCY_HINT_UNSAFE_IO
+        ASIO_CONCURRENCY_HINT_UNSAFE_IO
 #else
-            1
+        1
 #endif
-            )
+        )
 {
 }
 
@@ -53,7 +53,7 @@ ResourceEvent::~ResourceEvent()
     assert(front_ == nullptr);
     assert(back_ == nullptr);
 
-    logInfo(RTPS_PARTICIPANT,"Removing event thread");
+    logInfo(RTPS_PARTICIPANT, "Removing event thread");
     stop_.store(true);
     io_service_.stop();
 
@@ -63,13 +63,14 @@ ResourceEvent::~ResourceEvent()
     }
 }
 
-bool ResourceEvent::register_timer_nts(TimedEventImpl* event)
+bool ResourceEvent::register_timer_nts(
+        TimedEventImpl* event)
 {
     TimedEventImpl* curr = front_;
 
-    while(curr != nullptr)
+    while (curr != nullptr)
     {
-        if(curr == event)
+        if (curr == event)
         {
             return false;
         }
@@ -77,7 +78,7 @@ bool ResourceEvent::register_timer_nts(TimedEventImpl* event)
         curr = curr->next();
     }
 
-    if(back_)
+    if (back_)
     {
         back_->next(event);
         back_ = event;
@@ -92,28 +93,29 @@ bool ResourceEvent::register_timer_nts(TimedEventImpl* event)
     return true;
 }
 
-void ResourceEvent::unregister_timer(TimedEventImpl* event)
+void ResourceEvent::unregister_timer(
+        TimedEventImpl* event)
 {
     assert(!stop_.load());
 
     std::unique_lock<TimedMutex> lock(mutex_);
 
     cv_.wait(lock, [&]()
-    {
-        return allow_to_delete_;
-    });
+                {
+                    return allow_to_delete_;
+                });
 
-    TimedEventImpl *prev = nullptr, *curr = front_;
+    TimedEventImpl* prev = nullptr, * curr = front_;
 
-    while(curr && curr != event && curr->next())
+    while (curr && curr != event && curr->next())
     {
         prev = curr;
         curr = curr->next();
     }
 
-    if(curr)
+    if (curr)
     {
-        if(prev)
+        if (prev)
         {
             prev->next(curr->next());
         }
@@ -122,7 +124,7 @@ void ResourceEvent::unregister_timer(TimedEventImpl* event)
             front_ = curr->next();
         }
 
-        if(!curr->next())
+        if (!curr->next())
         {
             back_ = prev;
         }
@@ -133,23 +135,26 @@ void ResourceEvent::unregister_timer(TimedEventImpl* event)
     }
 }
 
-void ResourceEvent::notify(TimedEventImpl* event)
+void ResourceEvent::notify(
+        TimedEventImpl* event)
 {
     std::unique_lock<TimedMutex> lock(mutex_);
 
-    if(register_timer_nts(event))
+    if (register_timer_nts(event))
     {
         cv_.notify_one();
     }
 }
 
-void ResourceEvent::notify(TimedEventImpl* event, const std::chrono::steady_clock::time_point& timeout)
+void ResourceEvent::notify(
+        TimedEventImpl* event,
+        const std::chrono::steady_clock::time_point& timeout)
 {
     std::unique_lock<TimedMutex> lock(mutex_, std::defer_lock);
 
     if (lock.try_lock_until(timeout))
     {
-        if(register_timer_nts(event))
+        if (register_timer_nts(event))
         {
             cv_.notify_one();
         }
@@ -173,13 +178,13 @@ void ResourceEvent::run_io_service()
         cv_.notify_one();
 
         if (cv_.wait_for(lock, std::chrono::nanoseconds(1000000), [&]()
-            {
-                return front_ != nullptr;
-            }))
+                    {
+                        return front_ != nullptr;
+                    }))
         {
             TimedEventImpl* curr = front_;
 
-            while(curr)
+            while (curr)
             {
                 curr->update();
                 curr = curr->next(nullptr);
@@ -198,9 +203,9 @@ void ResourceEvent::init_thread()
     thread_ = std::thread(&ResourceEvent::run_io_service, this);
     std::future<void> ready_fut = ready.get_future();
     io_service_.post([this]()
-        {
-            ready.set_value();
-        });
+                {
+                    ready.set_value();
+                });
     ready_fut.wait();
 }
 

--- a/src/cpp/rtps/resources/ResourceEvent.cpp
+++ b/src/cpp/rtps/resources/ResourceEvent.cpp
@@ -58,11 +58,6 @@ void ResourceEvent::register_timer(
 
     std::unique_lock<TimedMutex> lock(mutex_);
 
-    cv_manipulation_.wait(lock, [&]()
-    {
-        return allow_vector_manipulation_;
-    });
-
     ++timers_count_;
 
     // Notify the execution thread that something changed
@@ -200,8 +195,7 @@ void ResourceEvent::run_io_service()
 
         // Don't allow other threads to manipulate the timer collections
         allow_vector_manipulation_ = false;
-        pending_timers_.reserve(timers_count_);
-        active_timers_.reserve(timers_count_);
+        resize_collections();
     }
 }
 
@@ -268,6 +262,11 @@ void ResourceEvent::do_timer_actions()
 
 void ResourceEvent::init_thread()
 {
+    std::unique_lock<TimedMutex> lock(mutex_);
+
+    allow_vector_manipulation_ = false;
+    resize_collections();
+
     thread_ = std::thread(&ResourceEvent::run_io_service, this);
 }
 

--- a/src/cpp/rtps/resources/ResourceEvent.cpp
+++ b/src/cpp/rtps/resources/ResourceEvent.cpp
@@ -38,6 +38,7 @@ static bool event_compare(
 
 ResourceEvent::ResourceEvent()
     : stop_(false)
+    , allow_to_delete_(false)
 {
 }
 

--- a/src/cpp/rtps/resources/ResourceEvent.cpp
+++ b/src/cpp/rtps/resources/ResourceEvent.cpp
@@ -36,17 +36,11 @@ static bool event_compare(
     return lhs->next_trigger_time() < rhs->next_trigger_time();
 }
 
-ResourceEvent::ResourceEvent()
-    : stop_(false)
-    , allow_vector_manipulation_(false)
-    , timers_count_(0)
-{
-}
-
 ResourceEvent::~ResourceEvent()
 {
     // All timer should be unregistered before destroying this object.
     assert(pending_timers_.empty());
+    assert(timers_count_ == 0);
 
     logInfo(RTPS_PARTICIPANT, "Removing event thread");
     stop_.store(true);

--- a/src/cpp/rtps/resources/ResourceEvent.cpp
+++ b/src/cpp/rtps/resources/ResourceEvent.cpp
@@ -44,10 +44,7 @@ ResourceEvent::~ResourceEvent()
 
     logInfo(RTPS_PARTICIPANT, "Removing event thread");
     stop_.store(true);
-    {
-        std::lock_guard<TimedMutex> lock(mutex_);
-        cv_.notify_one();
-    }
+    cv_.notify_one();
 
     if (thread_.joinable())
     {

--- a/src/cpp/rtps/resources/ResourceEvent.cpp
+++ b/src/cpp/rtps/resources/ResourceEvent.cpp
@@ -87,21 +87,12 @@ void ResourceEvent::unregister_timer(
         should_notify = true;
     }
 
-    std::vector<TimedEventImpl*>::iterator end_it = active_timers_.end();
-
-    // Find with binary search
-    it = std::lower_bound(active_timers_.begin(), end_it, event, event_compare);
-
-    // Find the event on the list
-    for(; it != end_it; ++it)
+    // Remove from active
+    it = std::find(active_timers_.begin(), active_timers_.end(), event);
+    if (it != active_timers_.end())
     {
-        if (*it == event)
-        {
-            // Remove from list
-            active_timers_.erase(it);
-            should_notify = true;
-            break;
-        }
+        active_timers_.erase(it);
+        should_notify = true;
     }
 
     // Decrement counter of created timers

--- a/src/cpp/rtps/resources/TimedEvent.cpp
+++ b/src/cpp/rtps/resources/TimedEvent.cpp
@@ -34,8 +34,14 @@ TimedEvent::TimedEvent(
     : service_(service)
     , impl_(nullptr)
 {
+    if (milliseconds < 1)
+    {
+        milliseconds = 1;
+    }
+
     impl_ =
-            new TimedEventImpl(service_.get_io_service(), callback,
+            new TimedEventImpl(
+                    callback,
                     std::chrono::microseconds((int64_t)(milliseconds * 1000)));
 }
 
@@ -49,7 +55,7 @@ void TimedEvent::cancel_timer()
 {
     if (impl_->go_cancel())
     {
-        service_.notify(impl_);
+        service_.unregister_timer(impl_);
     }
 }
 
@@ -92,6 +98,6 @@ double TimedEvent::getRemainingTimeMilliSec()
     return impl_->getRemainingTimeMilliSec();
 }
 
-}
 } /* namespace rtps */
+} /* namespace fastrtps */
 } /* namespace eprosima */

--- a/src/cpp/rtps/resources/TimedEvent.cpp
+++ b/src/cpp/rtps/resources/TimedEvent.cpp
@@ -34,10 +34,9 @@ TimedEvent::TimedEvent(
     : service_(service)
     , impl_(nullptr)
 {
-    impl_ =
-            new TimedEventImpl(
-                    callback,
-                    std::chrono::microseconds((int64_t)(milliseconds * 1000)));
+    impl_ = new TimedEventImpl(
+        callback,
+        std::chrono::microseconds(static_cast<int64_t>(milliseconds * 1000)));
 }
 
 TimedEvent::~TimedEvent()

--- a/src/cpp/rtps/resources/TimedEvent.cpp
+++ b/src/cpp/rtps/resources/TimedEvent.cpp
@@ -34,11 +34,6 @@ TimedEvent::TimedEvent(
     : service_(service)
     , impl_(nullptr)
 {
-    if (milliseconds < 1)
-    {
-        milliseconds = 1;
-    }
-
     impl_ =
             new TimedEventImpl(
                     callback,
@@ -55,7 +50,7 @@ void TimedEvent::cancel_timer()
 {
     if (impl_->go_cancel())
     {
-        service_.unregister_timer(impl_);
+        service_.notify(impl_);
     }
 }
 

--- a/src/cpp/rtps/resources/TimedEvent.cpp
+++ b/src/cpp/rtps/resources/TimedEvent.cpp
@@ -24,7 +24,7 @@
 
 
 namespace eprosima {
-namespace fastrtps{
+namespace fastrtps {
 namespace rtps {
 
 TimedEvent::TimedEvent(
@@ -34,7 +34,9 @@ TimedEvent::TimedEvent(
     : service_(service)
     , impl_(nullptr)
 {
-    impl_ = new TimedEventImpl(service_.get_io_service(), callback, std::chrono::microseconds((int64_t)(milliseconds*1000)));
+    impl_ =
+            new TimedEventImpl(service_.get_io_service(), callback,
+                    std::chrono::microseconds((int64_t)(milliseconds * 1000)));
 }
 
 TimedEvent::~TimedEvent()
@@ -45,35 +47,37 @@ TimedEvent::~TimedEvent()
 
 void TimedEvent::cancel_timer()
 {
-    if(impl_->go_cancel())
+    if (impl_->go_cancel())
     {
         service_.notify(impl_);
     }
 }
-
 
 void TimedEvent::restart_timer()
 {
-    if(impl_->go_ready())
+    if (impl_->go_ready())
     {
         service_.notify(impl_);
     }
 }
 
-void TimedEvent::restart_timer(const std::chrono::steady_clock::time_point& timeout)
+void TimedEvent::restart_timer(
+        const std::chrono::steady_clock::time_point& timeout)
 {
-    if(impl_->go_ready())
+    if (impl_->go_ready())
     {
         service_.notify(impl_, timeout);
     }
 }
 
-bool TimedEvent::update_interval(const Duration_t& inter)
+bool TimedEvent::update_interval(
+        const Duration_t& inter)
 {
     return impl_->update_interval(inter);
 }
 
-bool TimedEvent::update_interval_millisec(double time_millisec)
+bool TimedEvent::update_interval_millisec(
+        double time_millisec)
 {
     return impl_->update_interval_millisec(time_millisec);
 }

--- a/src/cpp/rtps/resources/TimedEvent.cpp
+++ b/src/cpp/rtps/resources/TimedEvent.cpp
@@ -37,6 +37,7 @@ TimedEvent::TimedEvent(
     impl_ = new TimedEventImpl(
         callback,
         std::chrono::microseconds(static_cast<int64_t>(milliseconds * 1000)));
+    service_.register_timer(impl_);
 }
 
 TimedEvent::~TimedEvent()

--- a/src/cpp/rtps/resources/TimedEvent.cpp
+++ b/src/cpp/rtps/resources/TimedEvent.cpp
@@ -29,7 +29,7 @@ namespace rtps {
 
 TimedEvent::TimedEvent(
         ResourceEvent& service,
-        std::function<bool(EventCode)> callback,
+        std::function<bool()> callback,
         double milliseconds)
     : service_(service)
     , impl_(nullptr)

--- a/src/cpp/rtps/resources/TimedEventImpl.cpp
+++ b/src/cpp/rtps/resources/TimedEventImpl.cpp
@@ -37,7 +37,8 @@ TimedEventImpl::TimedEventImpl(
     : m_interval_microsec(interval)
     , timer_(service, interval)
     , callback_(callback)
-    , callback_ptr_(&callback, [](Callback*){})
+    , callback_ptr_(&callback, [](Callback*){
+})
     , state_(StateCode::INACTIVE)
     , cancel_(false)
     , next_(nullptr)
@@ -76,7 +77,7 @@ bool TimedEventImpl::go_cancel()
         cancel_.store(true);
         returned_value = true;
 
-        if(prev_code == StateCode::READY)
+        if (prev_code == StateCode::READY)
         {
             callback_(TimedEvent::EVENT_ABORT);
         }
@@ -106,17 +107,19 @@ void TimedEventImpl::update()
     }
 }
 
-bool TimedEventImpl::update_interval(const eprosima::fastrtps::Duration_t& inter)
+bool TimedEventImpl::update_interval(
+        const eprosima::fastrtps::Duration_t& inter)
 {
     std::unique_lock<std::mutex> lock(mutex_);
     m_interval_microsec = std::chrono::microseconds(TimeConv::Duration_t2MicroSecondsInt64(inter));
     return true;
 }
 
-bool TimedEventImpl::update_interval_millisec(double time_millisec)
+bool TimedEventImpl::update_interval_millisec(
+        double time_millisec)
 {
     std::unique_lock<std::mutex> lock(mutex_);
-    m_interval_microsec = std::chrono::microseconds((int64_t)(time_millisec*1000));
+    m_interval_microsec = std::chrono::microseconds((int64_t)(time_millisec * 1000));
     return true;
 }
 
@@ -126,9 +129,9 @@ void TimedEventImpl::event(
 {
     std::shared_ptr<Callback> callback_ptr = callback_weak_ptr.lock();
 
-    if(callback_ptr)
+    if (callback_ptr)
     {
-        if(ec != asio::error::operation_aborted)
+        if (ec != asio::error::operation_aborted)
         {
             StateCode expected = StateCode::WAITING;
             state_.compare_exchange_strong(expected, StateCode::INACTIVE);
@@ -146,7 +149,8 @@ void TimedEventImpl::event(
                         timer_.expires_from_now(m_interval_microsec);
                     }
 
-                    timer_.async_wait(std::bind(&TimedEventImpl::event, this, callback_weak_ptr, std::placeholders::_1));
+                    timer_.async_wait(std::bind(&TimedEventImpl::event, this, callback_weak_ptr,
+                            std::placeholders::_1));
                 }
             }
         }

--- a/src/cpp/rtps/resources/TimedEventImpl.cpp
+++ b/src/cpp/rtps/resources/TimedEventImpl.cpp
@@ -76,11 +76,6 @@ bool TimedEventImpl::go_cancel()
     {
         cancel_.store(true);
         returned_value = true;
-
-        if (prev_code == StateCode::READY)
-        {
-            callback_(TimedEvent::EVENT_ABORT);
-        }
     }
 
     return returned_value;
@@ -137,7 +132,7 @@ void TimedEventImpl::event(
             state_.compare_exchange_strong(expected, StateCode::INACTIVE);
 
             //Exec
-            bool restart = callback_(TimedEvent::EVENT_SUCCESS);
+            bool restart = callback_();
 
             if (restart)
             {
@@ -153,10 +148,6 @@ void TimedEventImpl::event(
                             std::placeholders::_1));
                 }
             }
-        }
-        else
-        {
-            callback_(TimedEvent::EVENT_ABORT);
         }
     }
 }

--- a/src/cpp/rtps/resources/TimedEventImpl.h
+++ b/src/cpp/rtps/resources/TimedEventImpl.h
@@ -134,8 +134,9 @@ public:
     /*!
      * @brief It updates the asio::steady_timer depending of the state of TimedEventImpl object.
      * @warning This method has to be called from ResourceEvent's internal thread.
+     * @return false if the event was canceled, true otherwise.
      */
-    void update(
+    bool update(
         std::chrono::steady_clock::time_point current_time,
         std::chrono::steady_clock::time_point cancel_time);
 

--- a/src/cpp/rtps/resources/TimedEventImpl.h
+++ b/src/cpp/rtps/resources/TimedEventImpl.h
@@ -48,6 +48,13 @@ class TimedEventImpl
 
 public:
 
+    typedef enum
+    {
+        INACTIVE = 0, //! The event is inactive. asio::io_service is not waiting for it.
+        READY, //! The event is ready for being processed by ResourceEvent and added to asio::io_service.
+        WAITING, //! The event is being waiting by asio::io_service to being triggered.
+    } StateCode;
+
     ~TimedEventImpl();
 
     /*!
@@ -132,6 +139,11 @@ public:
      * @brief It updates the asio::steady_timer depending of the state of TimedEventImpl object.
      * @warning This method has to be called from ResourceEvent's internal thread.
      */
+    void update(
+        std::chrono::steady_clock::time_point current_time,
+        std::chrono::steady_clock::time_point cancel_time);
+
+
     void trigger(
             std::chrono::steady_clock::time_point current_time,
             std::chrono::steady_clock::time_point cancel_time);
@@ -146,7 +158,7 @@ private:
 
     Callback callback_;
 
-    std::atomic<bool> enabled_;
+    std::atomic<StateCode> state_;
 
     std::mutex mutex_;
 };

--- a/src/cpp/rtps/resources/TimedEventImpl.h
+++ b/src/cpp/rtps/resources/TimedEventImpl.h
@@ -21,7 +21,7 @@
 
 #ifndef _RTPS_RESOURCES_TIMEDEVENTIMPL_H_
 #define _RTPS_RESOURCES_TIMEDEVENTIMPL_H_
-#ifndef DOXYGEN_SHOULD_SKIP_THIS_PUBLIC 
+#ifndef DOXYGEN_SHOULD_SKIP_THIS_PUBLIC
 #include <fastrtps/rtps/common/Time_t.h>
 #include <fastrtps/rtps/resources/TimedEvent.h>
 
@@ -48,9 +48,9 @@ namespace rtps {
  */
 class TimedEventImpl
 {
-    using Callback = std::function<bool(TimedEvent::EventCode)>;
+    using Callback = std::function<bool (TimedEvent::EventCode)>;
 
-    public:
+public:
 
     typedef enum
     {
@@ -72,12 +72,12 @@ class TimedEventImpl
             Callback callback,
             std::chrono::microseconds interval);
 
-    protected:
+protected:
 
     //! Expiration time in milliseconds of the event.
     std::chrono::microseconds m_interval_microsec;
 
-    public:
+public:
 
     /*!
      * @brief Return next linked TimedEventImpl object.
@@ -93,7 +93,8 @@ class TimedEventImpl
      * @param next TimedEventImpl object to be linked.
      * @return Previous linked TimedEventImpl object. Can be nullptr.
      */
-    TimedEventImpl* next(TimedEventImpl* next)
+    TimedEventImpl* next(
+            TimedEventImpl* next)
     {
         TimedEventImpl* old = next_;
         next_ = next;
@@ -108,7 +109,8 @@ class TimedEventImpl
      * @param time New expiration time.
      * @return true on success
      */
-    bool update_interval(const Duration_t& time);
+    bool update_interval(
+            const Duration_t& time);
 
     /*!
      * @brief Updates the expiration time of the event.
@@ -118,7 +120,8 @@ class TimedEventImpl
      * @param time_millisec New expiration time in milliseconds.
      * @return true on success
      */
-    bool update_interval_millisec(double time_millisec);
+    bool update_interval_millisec(
+            double time_millisec);
 
     /*!
      * @brief Returns current expiration time in milliseconds
@@ -138,7 +141,8 @@ class TimedEventImpl
     double getRemainingTimeMilliSec()
     {
         std::unique_lock<std::mutex> lock(mutex_);
-        return static_cast<double>(std::chrono::duration_cast<std::chrono::milliseconds>(timer_.expires_from_now()).count());
+        return static_cast<double>(std::chrono::duration_cast<std::chrono::milliseconds>(timer_.expires_from_now()).
+               count());
     }
 
     /*!
@@ -161,7 +165,7 @@ class TimedEventImpl
      */
     void update();
 
-    private:
+private:
 
     /*!
      * @brief Callback called by asio::steady_timer when it expires.

--- a/src/cpp/rtps/resources/TimedEventImpl.h
+++ b/src/cpp/rtps/resources/TimedEventImpl.h
@@ -25,16 +25,12 @@
 #include <fastrtps/rtps/common/Time_t.h>
 #include <fastrtps/rtps/resources/TimedEvent.h>
 
-#include <asio.hpp>
-
+#include <atomic>
 #include <thread>
 #include <memory>
 #include <functional>
 #include <mutex>
 #include <condition_variable>
-#include <system_error>
-
-
 
 namespace eprosima {
 namespace fastrtps {
@@ -52,13 +48,6 @@ class TimedEventImpl
 
 public:
 
-    typedef enum
-    {
-        INACTIVE = 0, //! The event is inactive. asio::io_service is not waiting for it.
-        READY, //! The event is ready for being processed by ResourceEvent and added to asio::io_service.
-        WAITING, //! The event is being waiting by asio::io_service to being triggered.
-    } StateCode;
-
     ~TimedEventImpl();
 
     /*!
@@ -68,38 +57,10 @@ public:
      * @param interval Expiration time in milliseconds of the event.
      */
     TimedEventImpl(
-            asio::io_service& service,
             Callback callback,
             std::chrono::microseconds interval);
 
-protected:
-
-    //! Expiration time in milliseconds of the event.
-    std::chrono::microseconds m_interval_microsec;
-
 public:
-
-    /*!
-     * @brief Return next linked TimedEventImpl object.
-     * @return Next linked TimedEventImpl object. Can be nullptr.
-     */
-    TimedEventImpl* next() const
-    {
-        return next_;
-    }
-
-    /*!
-     * @brief Links the passed TimedEventImpl object.
-     * @param next TimedEventImpl object to be linked.
-     * @return Previous linked TimedEventImpl object. Can be nullptr.
-     */
-    TimedEventImpl* next(
-            TimedEventImpl* next)
-    {
-        TimedEventImpl* old = next_;
-        next_ = next;
-        return old;
-    }
 
     /*!
      * @brief Updates the expiration time of the event.
@@ -130,7 +91,7 @@ public:
     double getIntervalMsec()
     {
         std::unique_lock<std::mutex> lock(mutex_);
-        auto total_milliseconds = std::chrono::duration_cast<std::chrono::milliseconds>(m_interval_microsec);
+        auto total_milliseconds = std::chrono::duration_cast<std::chrono::milliseconds>(interval_microsec_);
         return static_cast<double>(total_milliseconds.count());
     }
 
@@ -141,8 +102,16 @@ public:
     double getRemainingTimeMilliSec()
     {
         std::unique_lock<std::mutex> lock(mutex_);
-        return static_cast<double>(std::chrono::duration_cast<std::chrono::milliseconds>(timer_.expires_from_now()).
+        return static_cast<double>(
+            std::chrono::duration_cast<std::chrono::milliseconds>(
+                next_trigger_time_ - std::chrono::steady_clock::now()).
                count());
+    }
+
+    std::chrono::steady_clock::time_point next_trigger_time()
+    {
+        std::unique_lock<std::mutex> lock(mutex_);
+        return next_trigger_time_;
     }
 
     /*!
@@ -163,31 +132,21 @@ public:
      * @brief It updates the asio::steady_timer depending of the state of TimedEventImpl object.
      * @warning This method has to be called from ResourceEvent's internal thread.
      */
-    void update();
+    void trigger(
+            std::chrono::steady_clock::time_point current_time,
+            std::chrono::steady_clock::time_point cancel_time);
 
 private:
 
-    /*!
-     * @brief Callback called by asio::steady_timer when it expires.
-     * @param callback_weak_ptr Weak shared pointer to the callback.
-     * Used to verify the TimedEventImpl object is still alive.
-     * @param ec Error code provided by asio::steady_timer.
-     */
-    void event(
-            std::weak_ptr<Callback> callback_weak_ptr,
-            const std::error_code& ec);
+    //! Expiration time in milliseconds of the event.
+    std::chrono::microseconds interval_microsec_;
 
-    asio::steady_timer timer_;
+    //! Next time to update this event
+    std::chrono::steady_clock::time_point next_trigger_time_;
 
     Callback callback_;
 
-    std::shared_ptr<Callback> callback_ptr_;
-
-    std::atomic<StateCode> state_;
-
-    std::atomic<bool> cancel_;
-
-    TimedEventImpl* next_;
+    std::atomic<bool> enabled_;
 
     std::mutex mutex_;
 };

--- a/src/cpp/rtps/resources/TimedEventImpl.h
+++ b/src/cpp/rtps/resources/TimedEventImpl.h
@@ -48,7 +48,7 @@ namespace rtps {
  */
 class TimedEventImpl
 {
-    using Callback = std::function<bool (TimedEvent::EventCode)>;
+    using Callback = std::function<bool ()>;
 
 public:
 

--- a/src/cpp/rtps/resources/TimedEventImpl.h
+++ b/src/cpp/rtps/resources/TimedEventImpl.h
@@ -48,14 +48,12 @@ class TimedEventImpl
 
 public:
 
-    typedef enum
+    enum StateCode
     {
         INACTIVE = 0, //! The event is inactive. asio::io_service is not waiting for it.
         READY, //! The event is ready for being processed by ResourceEvent and added to asio::io_service.
         WAITING, //! The event is being waiting by asio::io_service to being triggered.
-    } StateCode;
-
-    ~TimedEventImpl();
+    };
 
     /*!
      * @brief Default constructor.
@@ -66,8 +64,6 @@ public:
     TimedEventImpl(
             Callback callback,
             std::chrono::microseconds interval);
-
-public:
 
     /*!
      * @brief Updates the expiration time of the event.
@@ -163,8 +159,8 @@ private:
     std::mutex mutex_;
 };
 
-}
-}
+} // namespace rtps
+} // namespace fastrtps
 } // namespace eprosima
 
 #endif

--- a/src/cpp/rtps/security/SecurityManager.cpp
+++ b/src/cpp/rtps/security/SecurityManager.cpp
@@ -840,13 +840,9 @@ bool SecurityManager::on_process_handshake(
                         remote_participant_info->expected_sequence_number_ = expected_sequence_number;
                         const GUID_t guid = participant_data.m_guid;
                         remote_participant_info->event_ = new TimedEvent(participant_->getEventResource(),
-                                [&, guid](TimedEvent::EventCode code) -> bool
+                                [&, guid]() -> bool
                                 {
-                                    if (TimedEvent::EVENT_SUCCESS == code)
-                                    {
-                                        resend_handshake_message_token(guid);
-                                    }
-
+                                    resend_handshake_message_token(guid);
                                     return true;
                                 },
                                 500); // TODO (Ricardo) Configurable

--- a/src/cpp/rtps/writer/LivelinessManager.cpp
+++ b/src/cpp/rtps/writer/LivelinessManager.cpp
@@ -22,14 +22,9 @@ LivelinessManager::LivelinessManager(
     , timer_owner_(nullptr)
     , timer_(
             service,
-            [this](TimedEvent::EventCode code) -> bool
+            [this]() -> bool
             {
-                if (TimedEvent::EVENT_SUCCESS == code)
-                {
-                    return timer_expired();
-                }
-
-                return false;
+                return timer_expired();
             },
             0)
 {

--- a/src/cpp/rtps/writer/ReaderProxy.cpp
+++ b/src/cpp/rtps/writer/ReaderProxy.cpp
@@ -52,30 +52,23 @@ ReaderProxy::ReaderProxy(
     , last_acknack_count_(0)
     , last_nackfrag_count_(0)
 {
-    nack_supression_event_ = new TimedEvent(writer_->getRTPSParticipant()->getEventResource(),
-                    [&](TimedEvent::EventCode code) -> bool
+    nack_supression_event_ =
+        new TimedEvent(writer_->getRTPSParticipant()->getEventResource(),
+                [&]() -> bool
                 {
-                    if (TimedEvent::EVENT_SUCCESS == code)
-                    {
-                        writer_->perform_nack_supression(reader_attributes_.guid());
-                    }
-
+                    writer_->perform_nack_supression(reader_attributes_.guid());
                     return false;
                 },
-                    TimeConv::Time_t2MilliSecondsDouble(times.nackSupressionDuration));
+                TimeConv::Time_t2MilliSecondsDouble(times.nackSupressionDuration));
 
     initial_heartbeat_event_ =
-            new TimedEvent(writer->getRTPSParticipant()->getEventResource(), [&](
-                        TimedEvent::EventCode code) -> bool
+        new TimedEvent(writer->getRTPSParticipant()->getEventResource(),
+                [&]() -> bool
                 {
-                    if (TimedEvent::EVENT_SUCCESS == code)
-                    {
-                        writer_->intraprocess_heartbeat(this);
-                    }
-
+                    writer_->intraprocess_heartbeat(this);
                     return false;
                 },
-                    0);
+                0);
 
     stop();
 }

--- a/src/cpp/rtps/writer/ReaderProxy.cpp
+++ b/src/cpp/rtps/writer/ReaderProxy.cpp
@@ -101,7 +101,10 @@ void ReaderProxy::start(
     reader_attributes_ = reader_attributes;
 
     timers_enabled_.store(is_remote_and_reliable());
-    initial_heartbeat_event_->restart_timer();
+    if (is_local_reader())
+    {
+        initial_heartbeat_event_->restart_timer();
+    }
 
     logInfo(RTPS_WRITER, "Reader Proxy started");
 }

--- a/src/cpp/rtps/writer/StatefulWriter.cpp
+++ b/src/cpp/rtps/writer/StatefulWriter.cpp
@@ -82,43 +82,29 @@ StatefulWriter::StatefulWriter(
 
     const RTPSParticipantAttributes& part_att = pimpl->getRTPSParticipantAttributes();
 
-    periodic_hb_event_ = new TimedEvent(pimpl->getEventResource(), [&](TimedEvent::EventCode code) -> bool
-    {
-        if (TimedEvent::EVENT_SUCCESS == code)
+    periodic_hb_event_ = new TimedEvent(pimpl->getEventResource(),
+        [&]() -> bool
         {
-            if (send_periodic_heartbeat())
-            {
-                return true;
-            }
-        }
+            return send_periodic_heartbeat();
+        },
+        TimeConv::Time_t2MilliSecondsDouble(m_times.heartbeatPeriod));
 
-        return false;
-    },
-                    TimeConv::Time_t2MilliSecondsDouble(m_times.heartbeatPeriod));
-
-    nack_response_event_ = new TimedEvent(pimpl->getEventResource(), [&](TimedEvent::EventCode code) -> bool
-    {
-        if (TimedEvent::EVENT_SUCCESS == code)
+    nack_response_event_ = new TimedEvent(pimpl->getEventResource(),
+        [&]() -> bool
         {
             perform_nack_response();
-        }
-
-        return false;
-    },
-                    TimeConv::Time_t2MilliSecondsDouble(m_times.nackResponseDelay));
+            return false;
+        },
+        TimeConv::Time_t2MilliSecondsDouble(m_times.nackResponseDelay));
 
     if (disable_positive_acks_)
     {
-        ack_event_ = new TimedEvent(pimpl->getEventResource(), [&](TimedEvent::EventCode code) -> bool
-        {
-            if (TimedEvent::EVENT_SUCCESS == code)
+        ack_event_ = new TimedEvent(pimpl->getEventResource(),
+            [&]() -> bool
             {
                 return ack_timer_expired();
-            }
-
-            return false;
-        },
-                        att.keep_duration.to_ns() * 1e-6); // in milliseconds
+            },
+            att.keep_duration.to_ns() * 1e-6); // in milliseconds
     }
 
     for (size_t n = 0; n < att.matched_readers_allocation.initial; ++n)

--- a/src/cpp/subscriber/SubscriberImpl.cpp
+++ b/src/cpp/subscriber/SubscriberImpl.cpp
@@ -58,26 +58,16 @@ SubscriberImpl::SubscriberImpl(
     , lifespan_duration_us_(m_att.qos.m_lifespan.duration.to_ns() * 1e-3)
 {
     deadline_timer_ = new TimedEvent(mp_participant->get_resource_event(),
-            [&](TimedEvent::EventCode code) -> bool
+            [&]() -> bool
             {
-                if (TimedEvent::EVENT_SUCCESS == code)
-                {
-                    return deadline_missed();
-                }
-
-                return false;
+                return deadline_missed();
             },
             att.qos.m_deadline.period.to_ns() * 1e-6);
 
     lifespan_timer_ = new TimedEvent(mp_participant->get_resource_event(),
-            [&](TimedEvent::EventCode code) -> bool
+            [&]() -> bool
             {
-                if (TimedEvent::EVENT_SUCCESS == code)
-                {
-                    return lifespan_expired();
-                }
-
-                return false;
+                return lifespan_expired();
             },
             att.qos.m_lifespan.duration.to_ns() * 1e-6);
 }

--- a/test/mock/rtps/TimedEvent/fastrtps/rtps/resources/TimedEvent.h
+++ b/test/mock/rtps/TimedEvent/fastrtps/rtps/resources/TimedEvent.h
@@ -31,15 +31,9 @@ class TimedEvent
 {
     public:
 
-        enum EventCode
-        {
-            EVENT_SUCCESS,
-            EVENT_ABORT
-        };
-
         TimedEvent(
                 ResourceEvent&,
-                std::function<bool(EventCode)>,
+                std::function<bool()>,
                 double)
         {
         }

--- a/test/unittest/rtps/resources/timedevent/mock/MockEvent.cpp
+++ b/test/unittest/rtps/resources/timedevent/mock/MockEvent.cpp
@@ -24,7 +24,7 @@ MockEvent::MockEvent(
     , cancelled_(0)
     , sem_count_(0)
     , autorestart_(autorestart)
-    , event_(service, std::bind(&MockEvent::callback, this, std::placeholders::_1), milliseconds)
+    , event_(service, std::bind(&MockEvent::callback, this), milliseconds)
 {
 }
 
@@ -32,22 +32,15 @@ MockEvent::~MockEvent()
 {
 }
 
-bool MockEvent::callback(TimedEvent::EventCode code)
+bool MockEvent::callback()
 {
     bool restart = false;
 
-    if(code == TimedEvent::EventCode::EVENT_SUCCESS)
-    {
-        successed_.fetch_add(1, std::memory_order_relaxed);
+    successed_.fetch_add(1, std::memory_order_relaxed);
 
-        if(autorestart_)
-        {
-            restart = true;
-        }
-    }
-    else if(code == TimedEvent::EventCode::EVENT_ABORT)
+    if(autorestart_)
     {
-        cancelled_.fetch_add(1, std::memory_order_relaxed);
+        restart = true;
     }
 
     sem_mutex_.lock();

--- a/test/unittest/rtps/resources/timedevent/mock/MockEvent.cpp
+++ b/test/unittest/rtps/resources/timedevent/mock/MockEvent.cpp
@@ -21,7 +21,6 @@ MockEvent::MockEvent(
         double milliseconds,
         bool autorestart)
     : successed_(0)
-    , cancelled_(0)
     , sem_count_(0)
     , autorestart_(autorestart)
     , event_(service, std::bind(&MockEvent::callback, this), milliseconds)

--- a/test/unittest/rtps/resources/timedevent/mock/MockEvent.h
+++ b/test/unittest/rtps/resources/timedevent/mock/MockEvent.h
@@ -35,7 +35,7 @@ class MockEvent
 
         eprosima::fastrtps::rtps::TimedEvent& event() { return event_; }
 
-        bool callback(eprosima::fastrtps::rtps::TimedEvent::EventCode code);
+        bool callback();
 
         void wait();
 

--- a/test/unittest/rtps/resources/timedevent/mock/MockEvent.h
+++ b/test/unittest/rtps/resources/timedevent/mock/MockEvent.h
@@ -44,7 +44,6 @@ class MockEvent
         bool wait(unsigned int milliseconds);
 
         std::atomic<int> successed_;
-        std::atomic<int> cancelled_;
 
     private:
 


### PR DESCRIPTION
This PR aims to reduce dynamic allocations spotted when calling `async_wait` on an asio::steady_timer.

It is a refactor of the `ResourceEvent` and `TimedEventImpl` classes that drops the usage of asio for the timed events.
