### PR TITLE
Identity id alias fixes [7489]

### DIFF
--- a/include/fastdds/rtps/common/EntityId_t.hpp
+++ b/include/fastdds/rtps/common/EntityId_t.hpp
@@ -81,8 +81,7 @@ struct RTPS_DllAPI EntityId_t
     EntityId_t(
             uint32_t id)
     {
-        uint32_t* aux = (uint32_t*)(value);
-        *aux = id;
+        memcpy(value, &id, size);
 #if !__BIG_ENDIAN__
         reverse();
 #endif
@@ -127,8 +126,7 @@ struct RTPS_DllAPI EntityId_t
     EntityId_t& operator =(
             uint32_t id)
     {
-        uint32_t* aux = (uint32_t*)(value);
-        *aux = id;
+        memcpy(value, &id, size);
 #if !__BIG_ENDIAN__
         reverse();
 #endif
@@ -169,16 +167,7 @@ inline bool operator ==(
 #if !__BIG_ENDIAN__
     id1.reverse();
 #endif
-    uint32_t* aux1 = (uint32_t*)(id1.value);
-    bool result = true;
-    if (*aux1 == id2)
-    {
-        result = true;
-    }
-    else
-    {
-        result = false;
-    }
+    const bool result = 0 == memcmp(id1.value, &id2, sizeof(id2));
 #if !__BIG_ENDIAN__
     id1.reverse();
 #endif

--- a/include/fastdds/rtps/messages/CDRMessage.h
+++ b/include/fastdds/rtps/messages/CDRMessage.h
@@ -49,7 +49,7 @@ namespace CDRMessage{
     /// @{
     inline bool readEntityId(
             CDRMessage_t* msg,
-            const EntityId_t*id);
+            EntityId_t*id);
 
     inline bool readData(
             CDRMessage_t* msg,

--- a/include/fastdds/rtps/messages/CDRMessage.hpp
+++ b/include/fastdds/rtps/messages/CDRMessage.hpp
@@ -20,6 +20,7 @@
  */
 
 #include <cassert>
+#include <cstring>
 #include <algorithm>
 #include <vector>
 
@@ -66,12 +67,10 @@ inline bool CDRMessage::appendMsg(CDRMessage_t*first, CDRMessage_t*second) {
 }
 
 
-inline bool CDRMessage::readEntityId(CDRMessage_t* msg,const EntityId_t* id) {
+inline bool CDRMessage::readEntityId(CDRMessage_t* msg, EntityId_t* id) {
     if(msg->pos+4>msg->length)
         return false;
-    uint32_t* aux1 = (uint32_t*) id->value;
-    uint32_t* aux2 = (uint32_t*) &msg->buffer[msg->pos];
-    *aux1 = *aux2;
+    memcpy(id->value, &msg->buffer[msg->pos], id->size);
     msg->pos+=4;
     return true;
 }
@@ -509,11 +508,7 @@ inline bool CDRMessage::addEntityId(CDRMessage_t* msg, const EntityId_t*ID) {
     {
         return false;
     }
-    int* aux1;
-    int* aux2;
-    aux1 = (int*)(&msg->buffer[msg->pos]);
-    aux2 = (int*) ID->value;
-    *aux1 = *aux2;
+    memcpy(&msg->buffer[msg->pos], ID->value, ID->size);
     msg->pos +=4;
     msg->length+=4;
     return true;

--- a/src/cpp/fastrtps_deprecated/utils/IPFinder.cpp
+++ b/src/cpp/fastrtps_deprecated/utils/IPFinder.cpp
@@ -38,6 +38,8 @@
 #include <net/if.h>
 #endif
 
+#include <cstddef>
+#include <cstring>
 
 using namespace eprosima::fastrtps::rtps;
 
@@ -173,14 +175,14 @@ bool IPFinder::getIPs(std::vector<info_IP>* vec_name, bool return_loopback)
                 freeifaddrs(ifaddr);
                 exit(EXIT_FAILURE);
             }
-            struct sockaddr_in6 * so = (struct sockaddr_in6 *)ifa->ifa_addr;
             info_IP info;
             info.type = IP6;
             info.name = std::string(host);
             info.dev = std::string(ifa->ifa_name);
             if(parseIP6(info))
             {
-                info.scope_id = so->sin6_scope_id;
+                const int offset = offsetof(sockaddr_in6, sin6_scope_id);
+                memcpy(&info.scope_id, ifa->ifa_addr + offset, sizeof(info.scope_id));
 
                 if (return_loopback || info.type != IP6_LOCAL)
                     vec_name->push_back(info);

--- a/test/blackbox/BlackboxTestsPersistence.cpp
+++ b/test/blackbox/BlackboxTestsPersistence.cpp
@@ -16,14 +16,15 @@
 
 #if HAVE_SQLITE3
 
+#include <cstring>
+#include <thread>
+
 #include "RTPSAsSocketReader.hpp"
 #include "RTPSAsSocketWriter.hpp"
 #include "RTPSWithRegistrationReader.hpp"
 #include "RTPSWithRegistrationWriter.hpp"
 
 #include <gtest/gtest.h>
-
-#include <thread>
 
 using namespace eprosima::fastrtps;
 using namespace eprosima::fastrtps::rtps;
@@ -112,9 +113,10 @@ protected:
         db_file_name_ = ss.str();
 
         // Fill guid prefix
-        int32_t* p_value = (int32_t*)guid_prefix_.value;
-        *p_value++ = info->line();
-        *p_value = GET_PID();
+        const int32_t info_line = info->line();
+        memcpy(guid_prefix_.value, &info_line, sizeof(info_line));
+        const int32_t pid = GET_PID();
+        memcpy(guid_prefix_.value + 4, &pid, sizeof(pid));
         guid_prefix_.value[8] = HAVE_SECURITY;
         guid_prefix_.value[9] = 3; //PREALLOCATED_MEMORY_MODE
         eprosima::fastrtps::rtps::LocatorList_t loc;

--- a/test/performance/latency/LatencyTestTypes.cpp
+++ b/test/performance/latency/LatencyTestTypes.cpp
@@ -19,6 +19,8 @@
 
 #include "LatencyTestTypes.hpp"
 
+#include <cstring>
+
 using namespace eprosima::fastrtps;
 using namespace eprosima::fastrtps::rtps;
 
@@ -26,9 +28,9 @@ bool LatencyDataType::serialize(void*data,SerializedPayload_t* payload)
 {
     LatencyType* lt = (LatencyType*)data;
 
-
-    *(uint32_t*)payload->data = lt->seqnum;
-    *(uint32_t*)(payload->data+4) = (uint32_t)lt->data.size();
+    memcpy(payload->data, &lt->seqnum, sizeof(lt->seqnum));
+    const auto size = static_cast<uint32_t>(lt->data.size());
+    memcpy(payload->data + 4, &size, sizeof(size));
 
     //std::copy(lt->data.begin(),lt->data.end(),payload->data+8);
     memcpy(payload->data + 8, lt->data.data(), lt->data.size());
@@ -39,9 +41,10 @@ bool LatencyDataType::serialize(void*data,SerializedPayload_t* payload)
 bool LatencyDataType::deserialize(SerializedPayload_t* payload,void * data)
 {
     LatencyType* lt = (LatencyType*)data;
-    lt->seqnum = *(uint32_t*)payload->data;
-    uint32_t siz = *(uint32_t*)(payload->data+4);
-    std::copy(payload->data+8,payload->data+8+siz,lt->data.begin());
+    memcpy(&lt->seqnum, payload->data, sizeof(lt->seqnum));
+    uint32_t size;
+    memcpy(&size, payload->data+4, sizeof(size));
+    std::copy(payload->data+8,payload->data+8+size,lt->data.begin());
     return true;
 }
 
@@ -73,7 +76,7 @@ void LatencyDataType::deleteData(void* data)
 bool TestCommandDataType::serialize(void*data,SerializedPayload_t* payload)
 {
     TestCommandType* t = (TestCommandType*)data;
-    *(TESTCOMMAND*)payload->data = t->m_command;
+    memcpy(payload->data, &t->m_command, sizeof(t->m_command));
     payload->length = 4;
     return true;
 }
@@ -82,7 +85,7 @@ bool TestCommandDataType::deserialize(SerializedPayload_t* payload,void * data)
     TestCommandType* t = (TestCommandType*)data;
     //	cout << "PAYLOAD LENGTH: "<<payload->length << endl;
     //	cout << "PAYLOAD FIRST BYTE: "<< (int)payload->data[0] << endl;
-    t->m_command = *(TESTCOMMAND*)payload->data;
+    memcpy(&t->m_command, payload->data, sizeof(payload->length));
     //	cout << "COMMAND: "<<t->m_command<< endl;
     return true;
 }


### PR DESCRIPTION
I was experimenting with ubsan on your test examples and noticed it found an aliasing issue on these lines. When I compile this code, the aliasing isn't 4 byte aligned so the assignment might behavior strangely. `memcpy` may make more sense in this case.

Here's a [code sample](https://godbolt.org/#g:!((g:!((g:!((h:codeEditor,i:(fontScale:14,j:1,lang:c%2B%2B,source:'%23include+%3Ccstdlib%3E%0A%23include+%3Ccstdint%3E%0A%23include+%3Ciostream%3E%0A%0Atypedef+unsigned+char+octet%3B%0A%0Astruct+MyClass%0A%7B%0A++++static+constexpr+unsigned+int+size+%3D+4%3B%0A++++char+offset%3B%0A++++octet+value%5Bsize%5D%3B%0A++++MyClass(const+uint32_t+id)%0A++++%7B%0A++++++uint32_t*+aux+%3D+(uint32_t*)(value)%3B%0A++++++*aux+%3D+id%3B%0A++++%7D%0A%7D%3B%0A%0Aint+main()+%7B%0A++MyClass+my_class(42)%3B%0A++std::cout+%3C%3C+my_class.value+%3C%3C+!'%5Cn!'%3B%0A++return+EXIT_SUCCESS%3B%0A%7D'),l:'5',n:'0',o:'C%2B%2B+source+%231',t:'0')),k:50,l:'4',n:'0',o:'',s:0,t:'0'),(g:!((g:!((h:compiler,i:(compiler:clang_trunk,filters:(b:'0',binary:'1',commentOnly:'0',demangle:'0',directives:'0',execute:'1',intel:'0',libraryCode:'1',trim:'1'),fontScale:14,lang:c%2B%2B,libs:!(),options:'-Wcast-align',source:1),l:'5',n:'0',o:'x86-64+clang+(trunk)+(Editor+%231,+Compiler+%231)+C%2B%2B',t:'0')),k:50,l:'4',m:62.5,n:'0',o:'',s:0,t:'0'),(g:!((h:output,i:(compiler:1,editor:1,fontScale:14,wrap:'1'),l:'5',n:'0',o:'%231+with+x86-64+clang+(trunk)',t:'0')),header:(),l:'4',m:37.5,n:'0',o:'',s:0,t:'0')),k:50,l:'3',n:'0',o:'',t:'0')),l:'2',n:'0',o:'',t:'0')),version:4) with a warning in clang that shows off the issue better.