### PR TITLE
Improving piggyback heartbeat sending. [1.9.x]

### DIFF
--- a/src/cpp/rtps/writer/StatefulWriter.cpp
+++ b/src/cpp/rtps/writer/StatefulWriter.cpp
@@ -744,10 +744,10 @@ void StatefulWriter::send_any_unsent_changes()
                                 logError(RTPS_WRITER, "Error sending change " << changeToSend.sequenceNumber);
                             }
                         }
-
-                        // Heartbeat piggyback.
-                        send_heartbeat_piggyback_nts_(nullptr, group, lastBytesProcessed);
                     }
+
+                    // Heartbeat piggyback.
+                    send_heartbeat_piggyback_nts_(nullptr, group, lastBytesProcessed);
 
                     for (std::pair<std::vector<ReaderProxy*>,
                             std::set<SequenceNumber_t> > pair : notRelevantChanges.elements())


### PR DESCRIPTION
Avoid sending several piggyback heartbeat in a RTPS message with several DATA. This behavior occurs when `StatefulWriter::send_any_unsent_changes()` packs several DATA.