### PR TITLE
Improve sending GAP [1.9.x]

### DIFF
--- a/include/fastrtps/rtps/writer/StatefulWriter.h
+++ b/include/fastrtps/rtps/writer/StatefulWriter.h
@@ -311,7 +311,8 @@ private:
     void send_heartbeat_piggyback_nts_(
             ReaderProxy* reader,
             RTPSMessageGroup& message_group,
-            uint32_t& last_bytes_processed);
+            uint32_t& last_bytes_processed,
+            bool force = false);
 
     void send_heartbeat_nts_(
             size_t number_of_readers,

--- a/src/cpp/rtps/writer/StatefulWriter.cpp
+++ b/src/cpp/rtps/writer/StatefulWriter.cpp
@@ -599,6 +599,7 @@ void StatefulWriter::send_any_unsent_changes()
         RTPSWriterCollector<ReaderProxy*> relevantChanges;
         StatefulWriterOrganizer notRelevantChanges;
         bool at_least_one_remote = false;
+        bool force_piggyback_hb = false; // Force piggyback HB if old samples not acknowledged.
 
         NetworkFactory& network = mp_RTPSParticipant->network_factory();
         locator_selector_.reset(true);
@@ -656,7 +657,15 @@ void StatefulWriter::send_any_unsent_changes()
                             }
                             else
                             {
-                                notRelevantChanges.add_sequence_number(seq_num, remoteReader);
+                                if (seq_num >= get_seq_num_min())
+                                {
+                                    notRelevantChanges.add_sequence_number(seq_num, remoteReader);
+                                }
+                                else
+                                {
+                                    force_piggyback_hb = true;
+                                }
+
                                 remoteReader->set_change_to_status(seq_num, UNDERWAY, true);
                             }
                         }
@@ -782,7 +791,7 @@ void StatefulWriter::send_any_unsent_changes()
                     }
 
                     // Heartbeat piggyback.
-                    send_heartbeat_piggyback_nts_(nullptr, group, lastBytesProcessed);
+                    send_heartbeat_piggyback_nts_(nullptr, group, lastBytesProcessed, force_piggyback_hb);
 
                     for (std::pair<std::vector<ReaderProxy*>,
                             std::set<SequenceNumber_t> > pair : notRelevantChanges.elements())
@@ -1474,12 +1483,13 @@ void StatefulWriter::send_heartbeat_nts_(
 void StatefulWriter::send_heartbeat_piggyback_nts_(
         ReaderProxy* reader,
         RTPSMessageGroup& message_group,
-        uint32_t& last_bytes_processed)
+        uint32_t& last_bytes_processed,
+        bool force)
 {
     if (!disable_heartbeat_piggyback_)
     {
         size_t number_of_readers = reader == nullptr ? all_remote_readers_.size() : 1u;
-        if (mp_history->isFull())
+        if (force || mp_history->isFull())
         {
             if (reader == nullptr)
             {

--- a/src/cpp/rtps/writer/StatefulWriter.cpp
+++ b/src/cpp/rtps/writer/StatefulWriter.cpp
@@ -614,6 +614,7 @@ void StatefulWriter::send_any_unsent_changes()
             }
 
             SequenceNumber_t max_ack_seq = SequenceNumber_t::unknown();
+            SequenceNumber_t min_history_seq = get_seq_num_min();
             auto unsent_change_process = [&](const SequenceNumber_t& seq_num, const ChangeForReader_t* unsentChange)
                     {
                         if (unsentChange != nullptr && unsentChange->isRelevant() && unsentChange->isValid())
@@ -657,7 +658,7 @@ void StatefulWriter::send_any_unsent_changes()
                             }
                             else
                             {
-                                if (seq_num >= get_seq_num_min())
+                                if (seq_num >= min_history_seq)
                                 {
                                     notRelevantChanges.add_sequence_number(seq_num, remoteReader);
                                 }


### PR DESCRIPTION
Improvement sending only GAP for sequence number greater/equal than history minimum sequence number. In other case, force to send a piggyback heartbeat.