### PR TITLE
[master] clean ReaderProxy cache on acked_changes_set [6947]

### DIFF
--- a/src/cpp/rtps/writer/ReaderProxy.cpp
+++ b/src/cpp/rtps/writer/ReaderProxy.cpp
@@ -253,6 +253,21 @@ void ReaderProxy::acked_changes_set(
     {
         ChangeIterator chit = find_change(seq_num, false);
         changes_for_reader_.erase(changes_for_reader_.begin(), chit);
+
+        // The low mark is advanced while the corresponding change is acknowledged
+        bool check_acknowledged_changes = true;
+        while (check_acknowledged_changes)
+        {
+            check_acknowledged_changes = false;
+            ChangeIterator it = find_change(future_low_mark, true);
+            if (it != changes_for_reader_.end() && it->getStatus() == ACKNOWLEDGED)
+            {
+                assert(it == changes_for_reader_.begin());
+                changes_for_reader_.erase(it);
+                ++future_low_mark;
+                check_acknowledged_changes = true;
+            }
+        }
     }
     else
     {


### PR DESCRIPTION
More details on internal issue [6947]

If publisher starts sending data BEFORE the EDP is finished, and we configured reliable sending to resend previous changes to newly discovered endopoints, it may occur that a new change is sent before the older ones. This new change will be ACK'd automatically on intraprocess.

Once the old changes are sent, the new already ACK'd change will get stuck on the ReaderProxy history. From then on, no change in the ReaderProxy will ever be removed.

On non-intraprocess, the ACK mechanism depends on acknacks, and is not done automatically, so the problem does not occur.

This PR tries to further clean the change history on the ReaderProxy to avoid the issue. 