### PR TITLE
Improvement in consecutives History::get_change [1.9.x]

### DIFF
--- a/include/fastrtps/rtps/history/History.h
+++ b/include/fastrtps/rtps/history/History.h
@@ -193,7 +193,7 @@ public:
             const GUID_t& guid,
             CacheChange_t** change) const;
 
-    RTPS_DllAPI const_iterator get_change_nts(
+    const_iterator get_change_nts(
             const SequenceNumber_t& seq,
             const GUID_t& guid,
             CacheChange_t** change,

--- a/include/fastrtps/rtps/history/History.h
+++ b/include/fastrtps/rtps/history/History.h
@@ -32,7 +32,7 @@
 #include <cassert>
 
 namespace eprosima {
-namespace fastrtps{
+namespace fastrtps {
 namespace rtps {
 
 /**
@@ -41,151 +41,187 @@ namespace rtps {
  */
 class History
 {
-    protected:
-        History(const HistoryAttributes&  att);
-        virtual ~History();
-    public:
-        //!Attributes of the History
-        HistoryAttributes m_att;
-        /**
-         * Reserve a CacheChange_t from the CacheChange pool.
-         * @param[out] change Pointer to pointer to the CacheChange_t to reserve
-         * @param[in] calculateSizeFunc Function to calculate the size of the change.
-         * @return True is reserved
-         */
-        RTPS_DllAPI inline bool reserve_Cache(
-                CacheChange_t** change,
-                const std::function<uint32_t()>& calculateSizeFunc)
-        {
-            std::lock_guard<RecursiveTimedMutex> guard(*mp_mutex);
-            return m_changePool.reserve_Cache(change, calculateSizeFunc);
-        }
+protected:
 
-        RTPS_DllAPI inline bool reserve_Cache(CacheChange_t** change, uint32_t dataSize)
-        {
-            std::lock_guard<RecursiveTimedMutex> guard(*mp_mutex);
-            return m_changePool.reserve_Cache(change, dataSize);
-        }
+    History(
+            const HistoryAttributes&  att);
+    virtual ~History();
 
-        /**
-         * release a previously reserved CacheChange_t.
-         * @param ch Pointer to the CacheChange_t.
-         */
-        RTPS_DllAPI inline void release_Cache(CacheChange_t* ch)
-        {
-            std::lock_guard<RecursiveTimedMutex> guard(*mp_mutex);
-            return m_changePool.release_Cache(ch);
-        }
+public:
 
-        /**
-         * Check if the history is full
-         * @return true if the History is full.
-         */
-        RTPS_DllAPI bool isFull() { return m_isHistoryFull; }
+    //!Attributes of the History
+    HistoryAttributes m_att;
+    /**
+     * Reserve a CacheChange_t from the CacheChange pool.
+     * @param[out] change Pointer to pointer to the CacheChange_t to reserve
+     * @param[in] calculateSizeFunc Function to calculate the size of the change.
+     * @return True is reserved
+     */
+    RTPS_DllAPI inline bool reserve_Cache(
+            CacheChange_t** change,
+            const std::function<uint32_t()>& calculateSizeFunc)
+    {
+        std::lock_guard<RecursiveTimedMutex> guard(*mp_mutex);
+        return m_changePool.reserve_Cache(change, calculateSizeFunc);
+    }
 
-        /**
-         * Get the History size.
-         * @return Size of the history.
-         */
-        RTPS_DllAPI size_t getHistorySize() 
-        { 
-            std::lock_guard<RecursiveTimedMutex> guard(*mp_mutex);
-            return m_changes.size();
-        }
+    RTPS_DllAPI inline bool reserve_Cache(
+            CacheChange_t** change,
+            uint32_t dataSize)
+    {
+        std::lock_guard<RecursiveTimedMutex> guard(*mp_mutex);
+        return m_changePool.reserve_Cache(change, dataSize);
+    }
 
-        /**
-         * Remove all changes from the History
-         * @return True if everything was correctly removed.
-         */
-        RTPS_DllAPI bool remove_all_changes();
+    /**
+     * release a previously reserved CacheChange_t.
+     * @param ch Pointer to the CacheChange_t.
+     */
+    RTPS_DllAPI inline void release_Cache(
+            CacheChange_t* ch)
+    {
+        std::lock_guard<RecursiveTimedMutex> guard(*mp_mutex);
+        return m_changePool.release_Cache(ch);
+    }
 
-        /**
-         * Update the maximum and minimum sequenceNumbers.
-         */
-        virtual void updateMaxMinSeqNum()=0;
+    /**
+     * Check if the history is full
+     * @return true if the History is full.
+     */
+    RTPS_DllAPI bool isFull()
+    {
+        return m_isHistoryFull;
+    }
 
-        /**
-         * Remove a specific change from the history.
-         * @param ch Pointer to the CacheChange_t.
-         * @return True if removed.
-         */
-        virtual bool remove_change(CacheChange_t* ch) = 0;
+    /**
+     * Get the History size.
+     * @return Size of the history.
+     */
+    RTPS_DllAPI size_t getHistorySize()
+    {
+        std::lock_guard<RecursiveTimedMutex> guard(*mp_mutex);
+        return m_changes.size();
+    }
 
-        /**
-         * Get the beginning of the changes history iterator.
-         * @return Iterator to the beginning of the vector.
-         */
-        RTPS_DllAPI std::vector<CacheChange_t*>::iterator changesBegin(){ return m_changes.begin(); }
-        RTPS_DllAPI std::vector<CacheChange_t*>::reverse_iterator changesRbegin() { return m_changes.rbegin(); }
-        /**
-         * Get the end of the changes history iterator.
-         * @return Iterator to the end of the vector.
-         */
-        RTPS_DllAPI std::vector<CacheChange_t*>::iterator changesEnd(){ return m_changes.end(); }
-        RTPS_DllAPI std::vector<CacheChange_t*>::reverse_iterator changesRend() { return m_changes.rend(); }
-        /**
-         * Get the minimum CacheChange_t.
-         * @param min_change Pointer to pointer to the minimum change.
-         * @return True if correct.
-         */
-        RTPS_DllAPI bool get_min_change(CacheChange_t** min_change);
+    /**
+     * Remove all changes from the History
+     * @return True if everything was correctly removed.
+     */
+    RTPS_DllAPI bool remove_all_changes();
 
-        /**
-         * Get the maximum CacheChange_t.
-         * @param max_change Pointer to pointer to the maximum change.
-         * @return True if correct.
-         */
-        RTPS_DllAPI bool get_max_change(CacheChange_t** max_change);
+    /**
+     * Update the maximum and minimum sequenceNumbers.
+     */
+    virtual void updateMaxMinSeqNum() = 0;
 
-        /**
-         * Get the maximum serialized payload size
-         * @return Maximum serialized payload size
-         */
-        RTPS_DllAPI inline uint32_t getTypeMaxSerialized(){ return m_changePool.getInitialPayloadSize(); }
+    /**
+     * Remove a specific change from the history.
+     * @param ch Pointer to the CacheChange_t.
+     * @return True if removed.
+     */
+    virtual bool remove_change(
+            CacheChange_t* ch) = 0;
 
-        /*!
-         * Get the mutex
-         * @return Mutex
-         */
-        RTPS_DllAPI inline RecursiveTimedMutex* getMutex() { assert(mp_mutex != nullptr); return mp_mutex; }
+    /**
+     * Get the beginning of the changes history iterator.
+     * @return Iterator to the beginning of the vector.
+     */
+    RTPS_DllAPI std::vector<CacheChange_t*>::iterator changesBegin()
+    {
+        return m_changes.begin();
+    }
 
-        RTPS_DllAPI bool get_change(
-                const SequenceNumber_t& seq,
-                const GUID_t& guid,
-                CacheChange_t** change) const;
+    RTPS_DllAPI std::vector<CacheChange_t*>::reverse_iterator changesRbegin()
+    {
+        return m_changes.rbegin();
+    }
 
-        /**
-         * @brief A method to get the change with the earliest timestamp
-         * @param change Pointer to pointer to earliest change
-         * @return True on success
-         */
-        bool get_earliest_change(CacheChange_t** change);
+    /**
+     * Get the end of the changes history iterator.
+     * @return Iterator to the end of the vector.
+     */
+    RTPS_DllAPI std::vector<CacheChange_t*>::iterator changesEnd()
+    {
+        return m_changes.end();
+    }
 
-    protected:
+    RTPS_DllAPI std::vector<CacheChange_t*>::reverse_iterator changesRend()
+    {
+        return m_changes.rend();
+    }
 
-        //!Vector of pointers to the CacheChange_t.
-        std::vector<CacheChange_t*> m_changes;
+    /**
+     * Get the minimum CacheChange_t.
+     * @param min_change Pointer to pointer to the minimum change.
+     * @return True if correct.
+     */
+    RTPS_DllAPI bool get_min_change(
+            CacheChange_t** min_change);
 
-        //!Variable to know if the history is full without needing to block the History mutex.
-        bool m_isHistoryFull;
+    /**
+     * Get the maximum CacheChange_t.
+     * @param max_change Pointer to pointer to the maximum change.
+     * @return True if correct.
+     */
+    RTPS_DllAPI bool get_max_change(
+            CacheChange_t** max_change);
 
-        //!Pointer to and invalid cacheChange used to return the maximum and minimum when no changes are stored in the history.
-        CacheChange_t* mp_invalidCache;
+    /**
+     * Get the maximum serialized payload size
+     * @return Maximum serialized payload size
+     */
+    RTPS_DllAPI inline uint32_t getTypeMaxSerialized()
+    {
+        return m_changePool.getInitialPayloadSize();
+    }
 
-        //!Pool of cache changes reserved when the History is created.
-        CacheChangePool m_changePool;
+    /*!
+     * Get the mutex
+     * @return Mutex
+     */
+    RTPS_DllAPI inline RecursiveTimedMutex* getMutex()
+    {
+        assert(mp_mutex != nullptr); return mp_mutex;
+    }
 
-        //!Pointer to the minimum sequeceNumber CacheChange.
-        CacheChange_t* mp_minSeqCacheChange;
+    RTPS_DllAPI bool get_change(
+            const SequenceNumber_t& seq,
+            const GUID_t& guid,
+            CacheChange_t** change) const;
 
-        //!Pointer to the maximum sequeceNumber CacheChange.
-        CacheChange_t* mp_maxSeqCacheChange;
+    /**
+     * @brief A method to get the change with the earliest timestamp
+     * @param change Pointer to pointer to earliest change
+     * @return True on success
+     */
+    bool get_earliest_change(
+            CacheChange_t** change);
 
-        //!Print the seqNum of the changes in the History (for debuggisi, mng purposes).
-        void print_changes_seqNum2();
+protected:
 
-        //!Mutex for the History.
-        RecursiveTimedMutex* mp_mutex;
+    //!Vector of pointers to the CacheChange_t.
+    std::vector<CacheChange_t*> m_changes;
+
+    //!Variable to know if the history is full without needing to block the History mutex.
+    bool m_isHistoryFull;
+
+    //!Pointer to and invalid cacheChange used to return the maximum and minimum when no changes are stored in the history.
+    CacheChange_t* mp_invalidCache;
+
+    //!Pool of cache changes reserved when the History is created.
+    CacheChangePool m_changePool;
+
+    //!Pointer to the minimum sequeceNumber CacheChange.
+    CacheChange_t* mp_minSeqCacheChange;
+
+    //!Pointer to the maximum sequeceNumber CacheChange.
+    CacheChange_t* mp_maxSeqCacheChange;
+
+    //!Print the seqNum of the changes in the History (for debuggisi, mng purposes).
+    void print_changes_seqNum2();
+
+    //!Mutex for the History.
+    RecursiveTimedMutex* mp_mutex;
 
 };
 

--- a/include/fastrtps/rtps/history/History.h
+++ b/include/fastrtps/rtps/history/History.h
@@ -49,6 +49,10 @@ protected:
 
 public:
 
+    using iterator = std::vector<CacheChange_t*>::iterator;
+    using reverse_iterator = std::vector<CacheChange_t*>::reverse_iterator;
+    using const_iterator = std::vector<CacheChange_t*>::const_iterator;
+
     //!Attributes of the History
     HistoryAttributes m_att;
     /**
@@ -126,12 +130,12 @@ public:
      * Get the beginning of the changes history iterator.
      * @return Iterator to the beginning of the vector.
      */
-    RTPS_DllAPI std::vector<CacheChange_t*>::iterator changesBegin()
+    RTPS_DllAPI iterator changesBegin()
     {
         return m_changes.begin();
     }
 
-    RTPS_DllAPI std::vector<CacheChange_t*>::reverse_iterator changesRbegin()
+    RTPS_DllAPI reverse_iterator changesRbegin()
     {
         return m_changes.rbegin();
     }
@@ -140,12 +144,12 @@ public:
      * Get the end of the changes history iterator.
      * @return Iterator to the end of the vector.
      */
-    RTPS_DllAPI std::vector<CacheChange_t*>::iterator changesEnd()
+    RTPS_DllAPI iterator changesEnd()
     {
         return m_changes.end();
     }
 
-    RTPS_DllAPI std::vector<CacheChange_t*>::reverse_iterator changesRend()
+    RTPS_DllAPI reverse_iterator changesRend()
     {
         return m_changes.rend();
     }
@@ -188,6 +192,12 @@ public:
             const SequenceNumber_t& seq,
             const GUID_t& guid,
             CacheChange_t** change) const;
+
+    RTPS_DllAPI const_iterator get_change_nts(
+            const SequenceNumber_t& seq,
+            const GUID_t& guid,
+            CacheChange_t** change,
+            const_iterator hint) const;
 
     /**
      * @brief A method to get the change with the earliest timestamp

--- a/include/fastrtps/rtps/history/ReaderHistory.h
+++ b/include/fastrtps/rtps/history/ReaderHistory.h
@@ -73,6 +73,16 @@ public:
             CacheChange_t* a_change) override;
 
     /**
+     * Remove a specific change from the history.
+     * @param ch Pointer to the CacheChange_t.
+     * @param hint Iterator where the CacheChange_t is located in the history.
+     * @return An iterator pointing to the new location of the element that followed the removed CacheChange_t.
+     */
+    const_iterator remove_change_nts(
+            CacheChange_t* ch,
+            const_iterator position);
+
+    /**
      * Remove all changes from the History that have a certain guid.
      * @param a_guid Pointer to the target guid to search for.
      * @return True if succesful, even if no changes have been removed.

--- a/include/fastrtps/rtps/reader/RTPSReader.h
+++ b/include/fastrtps/rtps/reader/RTPSReader.h
@@ -229,24 +229,6 @@ public:
     }
 
     /*!
-     * @brief Search if there is a CacheChange_t, giving SequenceNumber_t and writer GUID_t,
-     * waiting to be completed because it is fragmented.
-     * @param sequence_number SequenceNumber_t of the searched CacheChange_t.
-     * @param writer_guid writer GUID_t of the searched CacheChange_t.
-     * @param change If a CacheChange_t was found, this argument will fill with its pointer.
-     * In other case nullptr is returned.
-     * @param hint Iterator since the search will start.
-     * Used to improve the search.
-     * @return Iterator pointing to the position were CacheChange_t was found.
-     * It can be used to improve next search.
-     */
-    History::const_iterator findCacheInFragmentedProcess(
-            const SequenceNumber_t& sequence_number,
-            const GUID_t& writer_guid,
-            CacheChange_t** change,
-            History::const_iterator hint) const;
-
-    /*!
      * @brief Returns there is a clean state with all Writers.
      * It occurs when the Reader received all samples sent by Writers. In other words,
      * its WriterProxies are up to date.
@@ -319,6 +301,24 @@ protected:
     virtual void set_last_notified(
             const GUID_t& persistence_guid,
             const SequenceNumber_t& seq);
+
+    /*!
+     * @brief Search if there is a CacheChange_t, giving SequenceNumber_t and writer GUID_t,
+     * waiting to be completed because it is fragmented.
+     * @param sequence_number SequenceNumber_t of the searched CacheChange_t.
+     * @param writer_guid writer GUID_t of the searched CacheChange_t.
+     * @param change If a CacheChange_t was found, this argument will fill with its pointer.
+     * In other case nullptr is returned.
+     * @param hint Iterator since the search will start.
+     * Used to improve the search.
+     * @return Iterator pointing to the position were CacheChange_t was found.
+     * It can be used to improve next search.
+     */
+    History::const_iterator findCacheInFragmentedProcess(
+            const SequenceNumber_t& sequence_number,
+            const GUID_t& writer_guid,
+            CacheChange_t** change,
+            History::const_iterator hint) const;
 
     //!ReaderHistory
     ReaderHistory* mp_history;

--- a/include/fastrtps/rtps/reader/RTPSReader.h
+++ b/include/fastrtps/rtps/reader/RTPSReader.h
@@ -28,6 +28,7 @@
 #include "../common/Time_t.h"
 #include <fastrtps/rtps/builtin/data/WriterProxyData.h>
 #include "../../utils/TimedConditionVariable.hpp"
+#include "../history/ReaderHistory.h"
 
 namespace eprosima {
 namespace fastrtps {
@@ -35,7 +36,6 @@ namespace rtps {
 
 // Forward declarations
 class LivelinessManager;
-class ReaderHistory;
 class ReaderListener;
 class WriterProxy;
 class FragmentedChangePitStop;
@@ -233,11 +233,18 @@ public:
      * waiting to be completed because it is fragmented.
      * @param sequence_number SequenceNumber_t of the searched CacheChange_t.
      * @param writer_guid writer GUID_t of the searched CacheChange_t.
-     * @return If a CacheChange_t was found, it will be returned. In other case nullptr is returned.
+     * @param change If a CacheChange_t was found, this argument will fill with its pointer.
+     * In other case nullptr is returned.
+     * @param hint Iterator since the search will start.
+     * Used to improve the search.
+     * @return Iterator pointing to the position were CacheChange_t was found.
+     * It can be used to improve next search.
      */
-    CacheChange_t* findCacheInFragmentedProcess(
+    History::const_iterator findCacheInFragmentedProcess(
             const SequenceNumber_t& sequence_number,
-            const GUID_t& writer_guid) const;
+            const GUID_t& writer_guid,
+            CacheChange_t** change,
+            History::const_iterator hint) const;
 
     /*!
      * @brief Returns there is a clean state with all Writers.

--- a/include/fastrtps/rtps/reader/RTPSReader.h
+++ b/include/fastrtps/rtps/reader/RTPSReader.h
@@ -226,7 +226,7 @@ public:
     RTPS_DllAPI inline ReaderHistory* getHistory()
     {
         return mp_history;
-    };
+    }
 
     /*!
      * @brief Search if there is a CacheChange_t, giving SequenceNumber_t and writer GUID_t,
@@ -340,7 +340,7 @@ protected:
 
 private:
 
-    RTPSReader& operator=(
+    RTPSReader& operator =(
             const RTPSReader&) = delete;
 };
 

--- a/src/cpp/rtps/history/History.cpp
+++ b/src/cpp/rtps/history/History.cpp
@@ -116,24 +116,36 @@ bool History::get_change(
     }
 
     std::lock_guard<RecursiveTimedMutex> guard(*mp_mutex);
+    get_change_nts(seq, guid, change, m_changes.cbegin());
+    return *change != nullptr;
+}
 
-    for (CacheChange_t* it : m_changes)
+History::const_iterator History::get_change_nts(
+        const SequenceNumber_t& seq,
+        const GUID_t& guid,
+        CacheChange_t** change,
+        History::const_iterator hint) const
+{
+    const_iterator returned_value = hint;
+    *change = nullptr;
+
+    for (; returned_value != m_changes.end(); ++returned_value)
     {
-        if (it->writerGUID == guid)
+        if ((*returned_value)->writerGUID == guid)
         {
-            if (it->sequenceNumber == seq)
+            if ((*returned_value)->sequenceNumber == seq)
             {
-                *change = it;
-                return true;
+                *change = *returned_value;
+                break;
             }
-            else if (it->sequenceNumber > seq)
+            else if ((*returned_value)->sequenceNumber > seq)
             {
                 break;
             }
         }
     }
 
-    return false;
+    return returned_value;
 }
 
 bool History::get_earliest_change(

--- a/src/cpp/rtps/history/History.cpp
+++ b/src/cpp/rtps/history/History.cpp
@@ -28,47 +28,47 @@
 #include <mutex>
 
 namespace eprosima {
-namespace fastrtps{
+namespace fastrtps {
 namespace rtps {
 
-History::History(const HistoryAttributes & att)
+History::History(
+        const HistoryAttributes& att)
     : m_att(att)
     , m_isHistoryFull(false)
     , mp_invalidCache(nullptr)
-    , m_changePool(att.initialReservedCaches,att.payloadMaxSize,att.maximumReservedCaches,att.memoryPolicy)
+    , m_changePool(att.initialReservedCaches, att.payloadMaxSize, att.maximumReservedCaches, att.memoryPolicy)
     , mp_minSeqCacheChange(nullptr)
     , mp_maxSeqCacheChange(nullptr)
     , mp_mutex(nullptr)
 
-    {
-        m_changes.reserve((uint32_t)abs(att.initialReservedCaches));
-        mp_invalidCache = new CacheChange_t();
-        mp_invalidCache->writerGUID = c_Guid_Unknown;
-        mp_invalidCache->sequenceNumber = c_SequenceNumber_Unknown;
-        mp_minSeqCacheChange = mp_invalidCache;
-        mp_maxSeqCacheChange = mp_invalidCache;
-    }
+{
+    m_changes.reserve((uint32_t)abs(att.initialReservedCaches));
+    mp_invalidCache = new CacheChange_t();
+    mp_invalidCache->writerGUID = c_Guid_Unknown;
+    mp_invalidCache->sequenceNumber = c_SequenceNumber_Unknown;
+    mp_minSeqCacheChange = mp_invalidCache;
+    mp_maxSeqCacheChange = mp_invalidCache;
+}
 
 History::~History()
 {
-    logInfo(RTPS_HISTORY,"");
+    logInfo(RTPS_HISTORY, "");
     delete(mp_invalidCache);
 }
-
 
 bool History::remove_all_changes()
 {
 
-    if(mp_mutex == nullptr)
+    if (mp_mutex == nullptr)
     {
-        logError(RTPS_HISTORY,"You need to create a RTPS Entity with this History before using it");
+        logError(RTPS_HISTORY, "You need to create a RTPS Entity with this History before using it");
         return false;
     }
 
     std::lock_guard<RecursiveTimedMutex> guard(*mp_mutex);
-    if(!m_changes.empty())
+    if (!m_changes.empty())
     {
-        while(!m_changes.empty())
+        while (!m_changes.empty())
         {
             remove_change(m_changes.front());
         }
@@ -80,9 +80,10 @@ bool History::remove_all_changes()
     return false;
 }
 
-bool History::get_min_change(CacheChange_t** min_change)
+bool History::get_min_change(
+        CacheChange_t** min_change)
 {
-    if(mp_minSeqCacheChange->sequenceNumber != mp_invalidCache->sequenceNumber)
+    if (mp_minSeqCacheChange->sequenceNumber != mp_invalidCache->sequenceNumber)
     {
         *min_change = mp_minSeqCacheChange;
         return true;
@@ -90,9 +91,11 @@ bool History::get_min_change(CacheChange_t** min_change)
     return false;
 
 }
-bool History::get_max_change(CacheChange_t** max_change)
+
+bool History::get_max_change(
+        CacheChange_t** max_change)
 {
-    if(mp_maxSeqCacheChange->sequenceNumber != mp_invalidCache->sequenceNumber)
+    if (mp_maxSeqCacheChange->sequenceNumber != mp_invalidCache->sequenceNumber)
     {
         *max_change = mp_maxSeqCacheChange;
         return true;
@@ -108,7 +111,7 @@ bool History::get_change(
 
     if (mp_mutex == nullptr)
     {
-        logError(RTPS_HISTORY,"You need to create a RTPS Entity with this History before using it");
+        logError(RTPS_HISTORY, "You need to create a RTPS Entity with this History before using it");
         return false;
     }
 
@@ -123,7 +126,7 @@ bool History::get_change(
                 *change = it;
                 return true;
             }
-            else if(it->sequenceNumber > seq)
+            else if (it->sequenceNumber > seq)
             {
                 break;
             }
@@ -133,11 +136,12 @@ bool History::get_change(
     return false;
 }
 
-bool History::get_earliest_change(CacheChange_t **change)
+bool History::get_earliest_change(
+        CacheChange_t** change)
 {
     if (mp_mutex == nullptr)
     {
-        logError(RTPS_HISTORY,"You need to create a RTPS Entity with this History before using it");
+        logError(RTPS_HISTORY, "You need to create a RTPS Entity with this History before using it");
         return false;
     }
 
@@ -160,22 +164,21 @@ bool History::get_earliest_change(CacheChange_t **change)
 //TODO Remove if you want.
 #include <sstream>
 
-namespace eprosima{
-namespace fastrtps{
-namespace rtps{
+namespace eprosima {
+namespace fastrtps {
+namespace rtps {
 
 void History::print_changes_seqNum2()
 {
     std::stringstream ss;
-    for(std::vector<CacheChange_t*>::iterator it = m_changes.begin();
-            it!=m_changes.end();++it)
+    for (std::vector<CacheChange_t*>::iterator it = m_changes.begin();
+            it != m_changes.end(); ++it)
     {
         ss << (*it)->sequenceNumber << "-";
     }
     ss << std::endl;
     std::cout << ss.str();
 }
-
 
 }
 } /* namespace rtps */

--- a/src/cpp/rtps/history/ReaderHistory.cpp
+++ b/src/cpp/rtps/history/ReaderHistory.cpp
@@ -125,6 +125,16 @@ bool ReaderHistory::remove_change(
     return false;
 }
 
+History::const_iterator ReaderHistory::remove_change_nts(
+        CacheChange_t* a_change,
+        History::const_iterator position)
+{
+    (void)a_change;
+    assert(nullptr != a_change);
+    assert((*position) == a_change);
+    return m_changes.erase(position);
+}
+
 bool ReaderHistory::remove_changes_with_guid(
         const GUID_t& a_guid)
 {

--- a/src/cpp/rtps/reader/RTPSReader.cpp
+++ b/src/cpp/rtps/reader/RTPSReader.cpp
@@ -91,16 +91,20 @@ bool RTPSReader::setListener(
     return true;
 }
 
-CacheChange_t* RTPSReader::findCacheInFragmentedProcess(
+History::const_iterator RTPSReader::findCacheInFragmentedProcess(
         const SequenceNumber_t& sequence_number,
-        const GUID_t& writer_guid) const
+        const GUID_t& writer_guid,
+        CacheChange_t** change,
+        History::const_iterator hint) const
 {
-    CacheChange_t* ret_val = nullptr;
-    if (mp_history->get_change(sequence_number, writer_guid, &ret_val))
+    History::const_iterator ret_val = mp_history->get_change_nts(sequence_number, writer_guid, change, hint);
+
+    if (nullptr != *change && (*change)->is_fully_assembled())
     {
-        return ret_val->is_fully_assembled() ? nullptr : ret_val;
+        *change = nullptr;
     }
-    return nullptr;
+
+    return ret_val;
 }
 
 void RTPSReader::add_persistence_guid(

--- a/src/cpp/rtps/reader/RTPSReader.cpp
+++ b/src/cpp/rtps/reader/RTPSReader.cpp
@@ -15,7 +15,7 @@
 /*
  * RTPSReader.cpp
  *
-*/
+ */
 
 #include <fastrtps/rtps/reader/RTPSReader.h>
 #include <fastrtps/rtps/history/ReaderHistory.h>
@@ -55,25 +55,26 @@ RTPSReader::RTPSReader(
     mp_history->mp_reader = this;
     mp_history->mp_mutex = &mp_mutex;
 
-    logInfo(RTPS_READER,"RTPSReader created correctly");
+    logInfo(RTPS_READER, "RTPSReader created correctly");
 }
 
 RTPSReader::~RTPSReader()
 {
-    logInfo(RTPS_READER,"Removing reader "<<this->getGuid().entityId;);
+    logInfo(RTPS_READER, "Removing reader " << this->getGuid().entityId; );
     delete history_state_;
     mp_history->mp_reader = nullptr;
     mp_history->mp_mutex = nullptr;
 }
 
 bool RTPSReader::reserveCache(
-        CacheChange_t** change, 
+        CacheChange_t** change,
         uint32_t dataCdrSerializedSize)
 {
     return mp_history->reserve_Cache(change, dataCdrSerializedSize);
 }
 
-void RTPSReader::releaseCache(CacheChange_t* change)
+void RTPSReader::releaseCache(
+        CacheChange_t* change)
 {
     return mp_history->release_Cache(change);
 }
@@ -83,7 +84,8 @@ ReaderListener* RTPSReader::getListener() const
     return mp_listener;
 }
 
-bool RTPSReader::setListener(ReaderListener *target)
+bool RTPSReader::setListener(
+        ReaderListener* target)
 {
     mp_listener = target;
     return true;
@@ -156,7 +158,8 @@ SequenceNumber_t RTPSReader::update_last_notified(
     return ret_val;
 }
 
-SequenceNumber_t RTPSReader::get_last_notified(const GUID_t& guid)
+SequenceNumber_t RTPSReader::get_last_notified(
+        const GUID_t& guid)
 {
     SequenceNumber_t ret_val;
     std::lock_guard<RecursiveTimedMutex> guard(mp_mutex);
@@ -177,27 +180,26 @@ SequenceNumber_t RTPSReader::get_last_notified(const GUID_t& guid)
 }
 
 void RTPSReader::set_last_notified(
-        const GUID_t& peristence_guid, 
+        const GUID_t& peristence_guid,
         const SequenceNumber_t& seq)
 {
     history_state_->history_record[peristence_guid] = seq;
 }
 
-
 bool RTPSReader::wait_for_unread_cache(
-        const eprosima::fastrtps::Duration_t &timeout)
+        const eprosima::fastrtps::Duration_t& timeout)
 {
     auto time_out = std::chrono::steady_clock::now() + std::chrono::seconds(timeout.seconds) +
-        std::chrono::nanoseconds(timeout.nanosec);
+            std::chrono::nanoseconds(timeout.nanosec);
 
     std::unique_lock<RecursiveTimedMutex> lock(mp_mutex, std::defer_lock);
 
-    if(lock.try_lock_until(time_out))
+    if (lock.try_lock_until(time_out))
     {
-        if(new_notification_cv_.wait_until(lock, time_out, [&]()
-            {
-                return total_unread_ > 0;
-            }))
+        if (new_notification_cv_.wait_until(lock, time_out, [&]()
+                    {
+                        return total_unread_ > 0;
+                    }))
         {
             return true;
         }

--- a/src/cpp/rtps/reader/StatefulReader.cpp
+++ b/src/cpp/rtps/reader/StatefulReader.cpp
@@ -596,7 +596,7 @@ bool StatefulReader::processGapMsg(
                 auto ret_iterator = findCacheInFragmentedProcess(auxSN, pWP->guid(), &to_remove, history_iterator);
                 if (to_remove != nullptr)
                 {
-                    ret_iterator = mp_history->remove_change_nts(to_remove, ret_iterator);
+                    history_iterator = mp_history->remove_change_nts(to_remove, ret_iterator);
                 }
                 else if (ret_iterator != mp_history->changesEnd())
                 {
@@ -613,7 +613,7 @@ bool StatefulReader::processGapMsg(
                 auto ret_iterator = findCacheInFragmentedProcess(auxSN, pWP->guid(), &to_remove, history_iterator);
                 if (to_remove != nullptr)
                 {
-                    ret_iterator = mp_history->remove_change_nts(to_remove, ret_iterator);
+                    history_iterator = mp_history->remove_change_nts(to_remove, ret_iterator);
                 }
                 else if (ret_iterator != mp_history->changesEnd())
                 {

--- a/src/cpp/rtps/reader/StatefulReader.cpp
+++ b/src/cpp/rtps/reader/StatefulReader.cpp
@@ -594,13 +594,13 @@ bool StatefulReader::processGapMsg(
             {
                 CacheChange_t* to_remove = nullptr;
                 auto ret_iterator = findCacheInFragmentedProcess(auxSN, pWP->guid(), &to_remove, history_iterator);
-                if (ret_iterator != mp_history->changesEnd())
-                {
-                    history_iterator = ret_iterator;
-                }
                 if (to_remove != nullptr)
                 {
-                    mp_history->remove_change(to_remove);
+                    ret_iterator = mp_history->remove_change_nts(to_remove, ret_iterator);
+                }
+                else if (ret_iterator != mp_history->changesEnd())
+                {
+                    history_iterator = ret_iterator;
                 }
             }
         }
@@ -611,13 +611,13 @@ bool StatefulReader::processGapMsg(
             {
                 CacheChange_t* to_remove = nullptr;
                 auto ret_iterator = findCacheInFragmentedProcess(auxSN, pWP->guid(), &to_remove, history_iterator);
-                if (ret_iterator != mp_history->changesEnd())
-                {
-                    history_iterator = ret_iterator;
-                }
                 if (to_remove != nullptr)
                 {
-                    mp_history->remove_change(to_remove);
+                    ret_iterator = mp_history->remove_change_nts(to_remove, ret_iterator);
+                }
+                else if (ret_iterator != mp_history->changesEnd())
+                {
+                    history_iterator = ret_iterator;
                 }
             }
         });


### PR DESCRIPTION
Added a mechanism to improve the performance with consecutive calls to `History::get_change()`.