### PR TITLE
[1.9.x] Increase recv buffer on PubSubAsNonReliableData300kb

### DIFF
--- a/test/blackbox/BlackboxTestsPubSubFragments.cpp
+++ b/test/blackbox/BlackboxTestsPubSubFragments.cpp
@@ -59,7 +59,8 @@ TEST_P(PubSubFragments, PubSubAsNonReliableData300kb)
     PubSubReader<Data1mbType> reader(TEST_TOPIC_NAME);
     PubSubWriter<Data1mbType> writer(TEST_TOPIC_NAME);
 
-    reader.init();
+    //Increasing reception buffer to accomodate large and fast fragments
+    reader.socket_buffer_size(1048576).init();
 
     ASSERT_TRUE(reader.isInitialized());
 

--- a/test/blackbox/PubSubReader.hpp
+++ b/test/blackbox/PubSubReader.hpp
@@ -636,6 +636,12 @@ public:
         return *this;
     }
 
+    PubSubReader& socket_buffer_size(uint32_t sockerBufferSize)
+    {
+        participant_attr_.rtps.listenSocketBufferSize = sockerBufferSize;
+        return *this;
+    }
+
     PubSubReader& durability_kind(const eprosima::fastrtps::DurabilityQosPolicyKind kind)
     {
         subscriber_attr_.qos.m_durability.kind = kind;

--- a/test/blackbox/PubSubWriter.hpp
+++ b/test/blackbox/PubSubWriter.hpp
@@ -780,6 +780,12 @@ class PubSubWriter
         return *this;
     }
 
+    PubSubWriter& socket_buffer_size(uint32_t sockerBufferSize)
+    {
+        participant_attr_.rtps.listenSocketBufferSize = sockerBufferSize;
+        return *this;
+    }
+
     PubSubWriter& participant_id(int32_t participantId)
     {
         participant_attr_.rtps.participantID = participantId;


### PR DESCRIPTION
This PR increases the reception buffer on the test.

The test is failing a lot after allowing fragment delivery on synchronized transport, because we are now sending 5 packets per change, each packet with max size, at fast rate, and the receiving buffer gets full.
