### PR TITLE
Transport Refactor: Send receives LocatorsIterator instead Locator_t <master> [7005]

### DIFF
--- a/include/fastdds/rtps/common/Locator.h
+++ b/include/fastdds/rtps/common/Locator.h
@@ -208,6 +208,64 @@ typedef std::vector<Locator_t>::iterator LocatorListIterator;
 typedef std::vector<Locator_t>::const_iterator LocatorListConstIterator;
 
 /**
+ * Provides a Locator's iterator interface that can by used by different Locator's
+ * containers
+ */
+class LocatorsIterator
+{
+public:
+
+    virtual LocatorsIterator& operator++() = 0;
+    virtual bool operator==(
+            const LocatorsIterator& other) const = 0;
+    virtual bool operator!=(
+            const LocatorsIterator& other) const = 0;
+    virtual const Locator_t& operator*() const = 0;
+};
+
+/**
+ * Adapter class that provides a LocatorsIterator interface from a LocatorListConstIterator
+ */
+class Locators : public LocatorsIterator
+{
+public:
+
+    Locators(
+            LocatorListConstIterator it)
+        : it_(it)
+    {
+    }
+
+    LocatorsIterator& operator++()
+    {
+        ++it_;
+        return *this;
+    }
+
+    bool operator==(
+            const LocatorsIterator& other) const
+    {
+        return it_ == static_cast<const Locators&>(other).it_;
+    }
+
+    bool operator!=(
+            const LocatorsIterator& other) const
+    {
+        return it_ != static_cast<const Locators&>(other).it_;
+    }
+
+    const Locator_t& operator*() const
+    {
+        return (*it_);
+    }
+
+private:
+
+    LocatorListConstIterator it_;
+};
+
+
+/**
     * Class LocatorList_t, a Locator_t vector that doesn't avoid duplicates.
     * @ingroup COMMON_MODULE
     */

--- a/include/fastdds/rtps/common/Locator.h
+++ b/include/fastdds/rtps/common/Locator.h
@@ -231,10 +231,16 @@ class Locators : public LocatorsIterator
 public:
 
     Locators(
-            LocatorListConstIterator it)
+            const LocatorListConstIterator& it)
         : it_(it)
     {
     }
+
+	Locators(
+		const Locators& other)
+		: it_(other.it_)
+	{
+	}
 
     LocatorsIterator& operator++()
     {

--- a/include/fastdds/rtps/common/LocatorSelector.hpp
+++ b/include/fastdds/rtps/common/LocatorSelector.hpp
@@ -280,6 +280,164 @@ public:
         }
     }
 
+    struct IteratorIndex
+    {
+        size_t selections_index;
+        size_t state_index;
+        bool state_multicast_done;
+        Locator_t* locator;
+    };
+
+    class iterator : public std::iterator<
+            std::input_iterator_tag,                    // iterator_category
+            Locator_t,                                  // value_type
+            IteratorIndex,                              // difference_type
+            Locator_t*,                                 // pointer
+            Locator_t&>,                                 // reference
+        public LocatorsIterator
+    {
+        const LocatorSelector& locator_selector_;
+        IteratorIndex current_;
+
+        void go_to_next_entry()
+        {
+            // While entries selected
+            while (++current_.selections_index < locator_selector_.selections_.size())
+            {
+                LocatorSelectorEntry* entry =
+                        locator_selector_.entries_.at(locator_selector_.selections_[current_.selections_index]);
+
+                // No multicast locators in this entry
+                if (entry->state.multicast.size() == 0)
+                {
+                    // But there's unicast
+                    if (entry->state.unicast.size() > 0)
+                    {
+                        current_.locator = &entry->unicast[entry->state.unicast.at(0)];
+                        return;
+                    }
+                }
+                else     // process multicast
+                {
+                    current_.state_multicast_done = false;
+                    current_.locator = &entry->multicast[entry->state.multicast.at(0)];
+                    return;
+                }
+            }
+
+            current_.locator = nullptr;
+        }
+
+    public:
+
+        enum class Position
+        {
+            Begin,
+            End
+        };
+
+        explicit iterator(
+                const LocatorSelector& locator_selector,
+                Position index_pos)
+            : locator_selector_(locator_selector)
+        {
+            current_ = {std::numeric_limits<size_t>::max(),0,true, nullptr};
+
+            if (index_pos == Position::Begin)
+            {
+                go_to_next_entry();
+            }
+        }
+
+        iterator& operator++()
+        {
+            // Shouldn't call ++ when index already at the end
+            assert(current_.selections_index < locator_selector_.selections_.size());
+
+            LocatorSelectorEntry* entry =
+                    locator_selector_.entries_.at(locator_selector_.selections_[current_.selections_index]);
+
+            // Index at unicast locators
+            if (current_.state_multicast_done)
+            {
+                // No more unicast locators selected
+                if (++current_.state_index >= entry->state.unicast.size())
+                {
+                    current_.state_index = 0;
+                    go_to_next_entry();
+                }
+                else     // current unicast locator
+                {
+                    current_.locator = &entry->unicast[entry->state.unicast.at(current_.state_index)];
+                }
+            }
+            else     // Index at multicast locators
+            {
+                // No more multicast locators selected
+                if (++current_.state_index >= entry->state.multicast.size())
+                {
+                    // Reset index to process unicast
+                    current_.state_multicast_done = true;
+                    current_.state_index = 0;
+                    // No unicast locators
+                    if (current_.state_index >= entry->state.unicast.size())
+                    {
+                        go_to_next_entry();
+                    }
+                    else     // current unicast locator
+                    {
+                        current_.locator = &entry->unicast[entry->state.unicast.at(current_.state_index)];
+                    }
+                }
+                else     // current multicast locator
+                {
+                    current_.locator = &entry->multicast[entry->state.multicast.at(current_.state_index)];
+                }
+            }
+
+            return *this;
+        }
+
+        bool operator==(
+                const LocatorsIterator& other) const
+        {
+            return *this == static_cast<const iterator&>(other);
+        }
+
+        bool operator!=(
+                const LocatorsIterator& other) const
+        {
+            return !(*this == other);
+        }
+
+        bool operator==(
+                const iterator& other) const
+        {
+            return (current_.locator == other.current_.locator);
+        }
+
+        bool operator!=(
+                const iterator& other) const
+        {
+            return !(*this == other);
+        }
+
+        reference operator*() const
+        {
+            return *current_.locator;
+        }
+    };
+
+    iterator begin() const
+    {
+        return iterator(*this, iterator::Position::Begin);
+    }
+
+    iterator end() const
+    {
+        return iterator(*this, iterator::Position::End);
+    }
+
 private:
     //! Entries collection.
     ResourceLimitedVector<LocatorSelectorEntry*> entries_;

--- a/include/fastdds/rtps/common/LocatorSelector.hpp
+++ b/include/fastdds/rtps/common/LocatorSelector.hpp
@@ -349,6 +349,12 @@ public:
             }
         }
 
+		iterator(const iterator& other)
+			: locator_selector_(other.locator_selector_)
+			, current_(other.current_)
+		{
+		}
+
         iterator& operator++()
         {
             // Shouldn't call ++ when index already at the end

--- a/include/fastdds/rtps/common/LocatorSelector.hpp
+++ b/include/fastdds/rtps/common/LocatorSelector.hpp
@@ -428,6 +428,11 @@ public:
             return !(*this == other);
         }
 
+        pointer operator->() const
+        {
+            return current_.locator;
+        }
+
         reference operator*() const
         {
             return *current_.locator;

--- a/include/fastdds/rtps/network/SenderResource.h
+++ b/include/fastdds/rtps/network/SenderResource.h
@@ -45,7 +45,7 @@ public:
      * the previous parameter.
      * @param destination_locators_begin destination endpoint Locators iterator begin.
      * @param destination_locators_end destination endpoint Locators iterator end.
-     * @param timeout If transport supports it then it will use it as maximum blocking time.
+     * @param max_blocking_time_point If transport supports it then it will use it as maximum blocking time.
      * @return Success of the send operation.
      */
     bool send(
@@ -53,13 +53,13 @@ public:
         uint32_t dataLength,
         LocatorsIterator& destination_locators_begin,
         LocatorsIterator& destination_locators_end,
-        const std::chrono::microseconds& timeout)
+        const std::chrono::steady_clock::time_point& max_blocking_time_point)
     {
         bool returned_value = false;
 
         if (send_lambda_)
         {
-            returned_value = send_lambda_(data, dataLength, destination_locators_begin, destination_locators_end, timeout);
+            returned_value = send_lambda_(data, dataLength, destination_locators_begin, destination_locators_end, max_blocking_time_point);
         }
 
         return returned_value;
@@ -91,7 +91,7 @@ protected:
             uint32_t,
             LocatorsIterator& destination_locators_begin,
             LocatorsIterator& destination_locators_end,
-            const std::chrono::microseconds&)> send_lambda_;
+            const std::chrono::steady_clock::time_point&)> send_lambda_;
 
 private:
 

--- a/include/fastdds/rtps/network/SenderResource.h
+++ b/include/fastdds/rtps/network/SenderResource.h
@@ -51,8 +51,8 @@ public:
     bool send(
         const octet* data,
         uint32_t dataLength,
-        LocatorsIterator& destination_locators_begin,
-        LocatorsIterator& destination_locators_end,
+        LocatorsIterator* destination_locators_begin,
+        LocatorsIterator* destination_locators_end,
         const std::chrono::steady_clock::time_point& max_blocking_time_point)
     {
         bool returned_value = false;
@@ -89,8 +89,8 @@ protected:
     std::function<bool(
             const octet*,
             uint32_t,
-            LocatorsIterator& destination_locators_begin,
-            LocatorsIterator& destination_locators_end,
+            LocatorsIterator* destination_locators_begin,
+            LocatorsIterator* destination_locators_end,
             const std::chrono::steady_clock::time_point&)> send_lambda_;
 
 private:

--- a/include/fastdds/rtps/network/SenderResource.h
+++ b/include/fastdds/rtps/network/SenderResource.h
@@ -43,20 +43,23 @@ public:
      * @param data Raw data slice to be sent.
      * @param dataLength Length of the data to be sent. Will be used as a boundary for
      * the previous parameter.
-     * @param destination_locator Locator describing the destination endpoint.
+     * @param destination_locators_begin destination endpoint Locators iterator begin.
+     * @param destination_locators_end destination endpoint Locators iterator end.
      * @param timeout If transport supports it then it will use it as maximum blocking time.
      * @return Success of the send operation.
      */
-    bool send(const octet* data,
-              uint32_t dataLength,
-              const Locator_t& destination_locator,
-              const std::chrono::microseconds& timeout)
+    bool send(
+        const octet* data,
+        uint32_t dataLength,
+        LocatorsIterator& destination_locators_begin,
+        LocatorsIterator& destination_locators_end,
+        const std::chrono::microseconds& timeout)
     {
         bool returned_value = false;
 
         if (send_lambda_)
         {
-            returned_value = send_lambda_(data, dataLength, destination_locator, timeout);
+            returned_value = send_lambda_(data, dataLength, destination_locators_begin, destination_locators_end, timeout);
         }
 
         return returned_value;
@@ -83,7 +86,12 @@ protected:
     int32_t transport_kind_;
 
     std::function<void()> clean_up;
-    std::function<bool(const octet*, uint32_t, const Locator_t&, const std::chrono::microseconds&)> send_lambda_;
+    std::function<bool(
+            const octet*,
+            uint32_t,
+            LocatorsIterator& destination_locators_begin,
+            LocatorsIterator& destination_locators_end,
+            const std::chrono::microseconds&)> send_lambda_;
 
 private:
 

--- a/include/fastdds/rtps/reader/StatefulReader.h
+++ b/include/fastdds/rtps/reader/StatefulReader.h
@@ -237,14 +237,16 @@ class StatefulReader : public RTPSReader
                 bool heartbeat_was_final);
 
         /**
-         * Use the participant of this reader to send a message to certain locator.
-         * @param message Message to be sent.
-         * @param locator Destination locator.
-         * @param max_blocking_time_point Future time point where any blocking should end.
-         */
+        *Use the participant of this reader to send a message to certain locator.
+        *@param message Message to be sent.
+        *@param locators_begin Destination locators iterator begin.
+        *@param locators_end Destination locators iterator end.
+        *@param max_blocking_time_point Future time point where any blocking should end.
+        */
         bool send_sync_nts(
                 CDRMessage_t* message,
-                const Locator_t& locator,
+                LocatorsIterator& locators_begin,
+                LocatorsIterator& locators_end,
                 std::chrono::steady_clock::time_point& max_blocking_time_point);
 
     private:

--- a/include/fastdds/rtps/reader/StatefulReader.h
+++ b/include/fastdds/rtps/reader/StatefulReader.h
@@ -245,8 +245,8 @@ class StatefulReader : public RTPSReader
         */
         bool send_sync_nts(
                 CDRMessage_t* message,
-                LocatorsIterator& locators_begin,
-                LocatorsIterator& locators_end,
+				const Locators& locators_begin,
+				const Locators& locators_end,
                 std::chrono::steady_clock::time_point& max_blocking_time_point);
 
     private:

--- a/include/fastdds/rtps/transport/TCPTransportInterface.h
+++ b/include/fastdds/rtps/transport/TCPTransportInterface.h
@@ -172,6 +172,15 @@ protected:
      */
     std::string get_password() const;
 
+    /**
+     * Send a buffer to a destination
+     */
+    bool send(
+            const fastrtps::rtps::octet* send_buffer,
+            uint32_t send_buffer_size,
+            std::shared_ptr<TCPChannelResource>& channel,
+            const fastrtps::rtps::Locator_t& remote_locator);
+
 public:
     friend class RTCPMessageManager;
 
@@ -292,13 +301,15 @@ public:
     * @param send_buffer_size Size of the raw data. It will be used as a bounds check for the previous argument.
     * It must not exceed the send_buffer_size fed to this class during construction.
     * @param channel channel we're sending from.
-    * @param remote_locator Locator describing the remote destination we're sending to.
+    * @param destination_locators_begin destination locators iterator begin.
+    * @param destination_locators_end destination locators iterator end.
     */
     bool send(
         const fastrtps::rtps::octet* send_buffer,
         uint32_t send_buffer_size,
         std::shared_ptr<TCPChannelResource>& channel,
-        const fastrtps::rtps::Locator_t& remote_locator);
+        fastrtps::rtps::LocatorsIterator& destination_locators_begin,
+        fastrtps::rtps::LocatorsIterator& destination_locators_end);
 
     /**
      * Performs the locator selection algorithm for this transport.

--- a/include/fastdds/rtps/transport/TCPTransportInterface.h
+++ b/include/fastdds/rtps/transport/TCPTransportInterface.h
@@ -301,15 +301,17 @@ public:
     * @param send_buffer_size Size of the raw data. It will be used as a bounds check for the previous argument.
     * It must not exceed the send_buffer_size fed to this class during construction.
     * @param channel channel we're sending from.
-    * @param destination_locators_begin destination locators iterator begin.
-    * @param destination_locators_end destination locators iterator end.
+    * @param destination_locators_begin pointer to destination locators iterator begin, the iterator can be advanced inside this fuction
+    * so should not be reuse.
+    * @param destination_locators_end pointer to destination locators iterator end, the iterator can be advanced inside this fuction
+    * so should not be reuse.
     */
     bool send(
         const fastrtps::rtps::octet* send_buffer,
         uint32_t send_buffer_size,
         std::shared_ptr<TCPChannelResource>& channel,
-        fastrtps::rtps::LocatorsIterator& destination_locators_begin,
-        fastrtps::rtps::LocatorsIterator& destination_locators_end);
+        fastrtps::rtps::LocatorsIterator* destination_locators_begin,
+        fastrtps::rtps::LocatorsIterator* destination_locators_end);
 
     /**
      * Performs the locator selection algorithm for this transport.

--- a/include/fastdds/rtps/transport/UDPTransportInterface.h
+++ b/include/fastdds/rtps/transport/UDPTransportInterface.h
@@ -93,8 +93,10 @@ public:
    * @param send_buffer_size Size of the raw data. It will be used as a bounds check for the previous argument.
    * It must not exceed the send_buffer_size fed to this class during construction.
    * @param socket channel we're sending from.
-   * @param destination_locators_begin destination locators iterator begin.
-   * @param destination_locators_end destination locators iterator end.
+   * @param destination_locators_begin pointer to destination locators iterator begin, the iterator can be advanced inside this fuction
+   * so should not be reuse.
+   * @param destination_locators_end pointer to destination locators iterator end, the iterator can be advanced inside this fuction
+   * so should not be reuse.
    * @param only_multicast_purpose
    * @param max_blocking_time_point maximum blocking time.
    */
@@ -102,8 +104,8 @@ public:
            const fastrtps::rtps::octet* send_buffer,
            uint32_t send_buffer_size,
            eProsimaUDPSocket& socket,
-           fastrtps::rtps::LocatorsIterator& destination_locators_begin,
-           fastrtps::rtps::LocatorsIterator& destination_locators_end,
+           fastrtps::rtps::LocatorsIterator* destination_locators_begin,
+           fastrtps::rtps::LocatorsIterator* destination_locators_end,
            bool only_multicast_purpose,
            const std::chrono::steady_clock::time_point& max_blocking_time_point);
 

--- a/include/fastdds/rtps/transport/UDPTransportInterface.h
+++ b/include/fastdds/rtps/transport/UDPTransportInterface.h
@@ -96,7 +96,7 @@ public:
    * @param destination_locators_begin destination locators iterator begin.
    * @param destination_locators_end destination locators iterator end.
    * @param only_multicast_purpose
-   * @param timeout Maximum time this function will block
+   * @param max_blocking_time_point maximum blocking time.
    */
    virtual bool send(
            const fastrtps::rtps::octet* send_buffer,
@@ -105,7 +105,7 @@ public:
            fastrtps::rtps::LocatorsIterator& destination_locators_begin,
            fastrtps::rtps::LocatorsIterator& destination_locators_end,
            bool only_multicast_purpose,
-           const std::chrono::microseconds& timeout);
+           const std::chrono::steady_clock::time_point& max_blocking_time_point);
 
     /**
      * Performs the locator selection algorithm for this transport.

--- a/include/fastdds/rtps/transport/UDPTransportInterface.h
+++ b/include/fastdds/rtps/transport/UDPTransportInterface.h
@@ -93,7 +93,8 @@ public:
    * @param send_buffer_size Size of the raw data. It will be used as a bounds check for the previous argument.
    * It must not exceed the send_buffer_size fed to this class during construction.
    * @param socket channel we're sending from.
-   * @param remote_locator Locator describing the remote destination we're sending to.
+   * @param destination_locators_begin destination locators iterator begin.
+   * @param destination_locators_end destination locators iterator end.
    * @param only_multicast_purpose
    * @param timeout Maximum time this function will block
    */
@@ -101,7 +102,8 @@ public:
            const fastrtps::rtps::octet* send_buffer,
            uint32_t send_buffer_size,
            eProsimaUDPSocket& socket,
-           const fastrtps::rtps::Locator_t& remote_locator,
+           fastrtps::rtps::LocatorsIterator& destination_locators_begin,
+           fastrtps::rtps::LocatorsIterator& destination_locators_end,
            bool only_multicast_purpose,
            const std::chrono::microseconds& timeout);
 
@@ -182,6 +184,17 @@ protected:
     virtual void set_receive_buffer_size(uint32_t size) = 0;
     virtual void set_send_buffer_size(uint32_t size) = 0;
     virtual void SetSocketOutboundInterface(eProsimaUDPSocket&, const std::string&) = 0;
+
+    /**
+     * Send a buffer to a destination
+     */
+    bool send(
+        const fastrtps::rtps::octet* send_buffer,
+        uint32_t send_buffer_size,
+        eProsimaUDPSocket& socket,
+        const fastrtps::rtps::Locator_t& remote_locator,
+        bool only_multicast_purpose,
+        const std::chrono::microseconds& timeout);
 };
 
 } // namespace rtps

--- a/include/fastdds/rtps/transport/test_UDPv4Transport.h
+++ b/include/fastdds/rtps/transport/test_UDPv4Transport.h
@@ -41,8 +41,8 @@ public:
            const fastrtps::rtps::octet* send_buffer,
            uint32_t send_buffer_size,
            eProsimaUDPSocket& socket,
-           fastrtps::rtps::LocatorsIterator& destination_locators_begin,
-           fastrtps::rtps::LocatorsIterator& destination_locators_end,
+           fastrtps::rtps::LocatorsIterator* destination_locators_begin,
+           fastrtps::rtps::LocatorsIterator* destination_locators_end,
            bool only_multicast_purpose,
            const std::chrono::steady_clock::time_point& max_blocking_time_point) override;
 

--- a/include/fastdds/rtps/transport/test_UDPv4Transport.h
+++ b/include/fastdds/rtps/transport/test_UDPv4Transport.h
@@ -44,7 +44,7 @@ public:
            fastrtps::rtps::LocatorsIterator& destination_locators_begin,
            fastrtps::rtps::LocatorsIterator& destination_locators_end,
            bool only_multicast_purpose,
-           const std::chrono::microseconds& timeout) override;
+           const std::chrono::steady_clock::time_point& max_blocking_time_point) override;
 
     RTPS_DllAPI static bool test_UDPv4Transport_ShutdownAllNetwork;
     // Handle to a persistent log of dropped packets. Defaults to length 0 (no logging) to prevent wasted resources.

--- a/include/fastdds/rtps/transport/test_UDPv4Transport.h
+++ b/include/fastdds/rtps/transport/test_UDPv4Transport.h
@@ -41,7 +41,8 @@ public:
            const fastrtps::rtps::octet* send_buffer,
            uint32_t send_buffer_size,
            eProsimaUDPSocket& socket,
-           const fastrtps::rtps::Locator_t& remote_locator,
+           fastrtps::rtps::LocatorsIterator& destination_locators_begin,
+           fastrtps::rtps::LocatorsIterator& destination_locators_end,
            bool only_multicast_purpose,
            const std::chrono::microseconds& timeout) override;
 
@@ -79,6 +80,14 @@ private:
     bool packet_should_drop(const fastrtps::rtps::octet* send_buffer, uint32_t send_buffer_size);
     bool random_chance_drop();
     bool should_be_dropped(PercentageData* percentage);
+
+    bool send(
+           const fastrtps::rtps::octet* send_buffer,
+           uint32_t send_buffer_size,
+           eProsimaUDPSocket& socket,
+           const fastrtps::rtps::Locator_t& remote_locator,
+           bool only_multicast_purpose,
+           const std::chrono::microseconds& timeout);
 };
 
 } // namespace rtps

--- a/src/cpp/rtps/builtin/discovery/participant/DirectMessageSender.cpp
+++ b/src/cpp/rtps/builtin/discovery/participant/DirectMessageSender.cpp
@@ -98,9 +98,7 @@ bool DirectMessageSender::send(
         CDRMessage_t* message,
         std::chrono::steady_clock::time_point& max_blocking_time_point) const
 {
-    Locators locators_begin(locators_->begin());
-    Locators locators_end(locators_->end());
-    return participant_->sendSync(message, locators_begin, locators_end, max_blocking_time_point);
+    return participant_->sendSync(message, Locators(locators_->begin()), Locators(locators_->end()), max_blocking_time_point);
 }
 
 } /* namespace rtps */

--- a/src/cpp/rtps/builtin/discovery/participant/DirectMessageSender.cpp
+++ b/src/cpp/rtps/builtin/discovery/participant/DirectMessageSender.cpp
@@ -98,15 +98,9 @@ bool DirectMessageSender::send(
         CDRMessage_t* message,
         std::chrono::steady_clock::time_point& max_blocking_time_point) const
 {
-    for (const Locator_t& loc : *locators_)
-    {
-        if (!participant_->sendSync(message, loc, max_blocking_time_point))
-        {
-            return false;
-        }
-    }
-
-    return true;
+    Locators locators_begin(locators_->begin());
+    Locators locators_end(locators_->end());
+    return participant_->sendSync(message, locators_begin, locators_end, max_blocking_time_point);
 }
 
 } /* namespace rtps */

--- a/src/cpp/rtps/participant/RTPSParticipantImpl.cpp
+++ b/src/cpp/rtps/participant/RTPSParticipantImpl.cpp
@@ -1137,7 +1137,8 @@ std::vector<std::string> RTPSParticipantImpl::getParticipantNames() const
 
 bool RTPSParticipantImpl::sendSync(
         CDRMessage_t* msg,
-        const Locator_t& destination_loc,
+        LocatorsIterator& destination_locators_begin,
+        LocatorsIterator& destination_locators_end,
         std::chrono::steady_clock::time_point& max_blocking_time_point)
 {
     bool ret_code = false;
@@ -1154,7 +1155,8 @@ bool RTPSParticipantImpl::sendSync(
                     std::chrono::duration_cast<std::chrono::microseconds>(
                 max_blocking_time_point - std::chrono::steady_clock::now());
 
-            send_resource->send(msg->buffer, msg->length, destination_loc, timeout);
+            send_resource->send(msg->buffer, msg->length, destination_locators_begin, destination_locators_end,
+                    timeout);
         }
     }
 

--- a/src/cpp/rtps/participant/RTPSParticipantImpl.cpp
+++ b/src/cpp/rtps/participant/RTPSParticipantImpl.cpp
@@ -1135,29 +1135,6 @@ std::vector<std::string> RTPSParticipantImpl::getParticipantNames() const
     return participant_names;
 }
 
-bool RTPSParticipantImpl::sendSync(
-        CDRMessage_t* msg,
-        LocatorsIterator& destination_locators_begin,
-        LocatorsIterator& destination_locators_end,
-        std::chrono::steady_clock::time_point& max_blocking_time_point)
-{
-    bool ret_code = false;
-    std::unique_lock<std::timed_mutex> lock(m_send_resources_mutex_, std::defer_lock);
-
-    if (lock.try_lock_until(max_blocking_time_point))
-    {
-        ret_code = true;
-
-        for (auto& send_resource : send_resource_list_)
-        {
-            send_resource->send(msg->buffer, msg->length, destination_locators_begin, destination_locators_end,
-                    max_blocking_time_point);
-        }
-    }
-
-    return ret_code;
-}
-
 void RTPSParticipantImpl::setGuid(
         GUID_t& guid)
 {

--- a/src/cpp/rtps/participant/RTPSParticipantImpl.cpp
+++ b/src/cpp/rtps/participant/RTPSParticipantImpl.cpp
@@ -79,8 +79,8 @@ static bool should_be_intraprocess_only(
 {
     return
         xmlparser::XMLProfileManager::library_settings().intraprocess_delivery == INTRAPROCESS_FULL &&
-        att.builtin.discovery_config.ignoreParticipantFlags == 
-            (ParticipantFilteringFlags::FILTER_DIFFERENT_HOST | ParticipantFilteringFlags::FILTER_DIFFERENT_PROCESS);
+        att.builtin.discovery_config.ignoreParticipantFlags ==
+        (ParticipantFilteringFlags::FILTER_DIFFERENT_HOST | ParticipantFilteringFlags::FILTER_DIFFERENT_PROCESS);
 }
 
 Locator_t& RTPSParticipantImpl::applyLocatorAdaptRule(
@@ -128,19 +128,19 @@ RTPSParticipantImpl::RTPSParticipantImpl(
         case DiscoveryProtocol::CLIENT:
         case DiscoveryProtocol::SERVER:
         case DiscoveryProtocol::BACKUP:
-            // Verify if listening ports are provided
-            for (auto& transportDescriptor : PParam.userTransports)
+        // Verify if listening ports are provided
+        for (auto& transportDescriptor : PParam.userTransports)
+        {
+            TCPTransportDescriptor* pT = dynamic_cast<TCPTransportDescriptor*>(transportDescriptor.get());
+            if (pT && pT->listening_ports.empty())
             {
-                TCPTransportDescriptor* pT = dynamic_cast<TCPTransportDescriptor*>(transportDescriptor.get());
-                if (pT && pT->listening_ports.empty())
-                {
-                    logError(RTPS_PARTICIPANT,
-                            "Participant " << m_att.getName() << " with GUID " << m_guid
-                            << " tries to use discovery server over TCP without providing a proper listening port");
-                }
+                logError(RTPS_PARTICIPANT,
+                        "Participant " << m_att.getName() << " with GUID " << m_guid
+                                       << " tries to use discovery server over TCP without providing a proper listening port");
             }
-        default:
-            break;
+        }
+    default:
+        break;
     }
 
     // User defined transports
@@ -257,7 +257,8 @@ RTPSParticipantImpl::RTPSParticipantImpl(
 #if HAVE_SECURITY
     // Start security
     // TODO(Ricardo) Get returned value in future.
-    m_security_manager_initialized = m_security_manager.init(security_attributes_, PParam.properties, m_is_security_active);
+    m_security_manager_initialized = m_security_manager.init(security_attributes_, PParam.properties,
+                    m_is_security_active);
     if (!m_security_manager_initialized)
     {
         // Participant will be deleted, no need to allocate buffers or create builtin endpoints
@@ -279,7 +280,7 @@ RTPSParticipantImpl::RTPSParticipantImpl(
 
     bool allow_growing_buffers = m_att.allocation.send_buffers.dynamic;
     size_t num_send_buffers = m_att.allocation.send_buffers.preallocated_number;
-    if(num_send_buffers == 0)
+    if (num_send_buffers == 0)
     {
         // Three buffers (user, events and async writer threads)
         num_send_buffers = 3;
@@ -307,7 +308,7 @@ RTPSParticipantImpl::RTPSParticipantImpl(
     mp_builtinProtocols = new BuiltinProtocols();
 
     //Start reception
-    for(auto& receiver : m_receiverResourcelist)
+    for (auto& receiver : m_receiverResourcelist)
     {
         receiver.Receiver->RegisterReceiver(receiver.mp_receiver);
     }
@@ -333,7 +334,7 @@ void RTPSParticipantImpl::enable()
     }
 
     //Start reception
-    for(auto& receiver : m_receiverResourcelist)
+    for (auto& receiver : m_receiverResourcelist)
     {
         receiver.Receiver->RegisterReceiver(receiver.mp_receiver);
     }
@@ -1337,7 +1338,8 @@ std::unique_ptr<RTPSMessageGroup_t> RTPSParticipantImpl::get_send_buffer()
     return send_buffers_->get_buffer(this);
 }
 
-void RTPSParticipantImpl::return_send_buffer(std::unique_ptr <RTPSMessageGroup_t>&& buffer)
+void RTPSParticipantImpl::return_send_buffer(
+        std::unique_ptr <RTPSMessageGroup_t>&& buffer)
 {
     send_buffers_->return_buffer(std::move(buffer));
 }

--- a/src/cpp/rtps/participant/RTPSParticipantImpl.cpp
+++ b/src/cpp/rtps/participant/RTPSParticipantImpl.cpp
@@ -1150,13 +1150,8 @@ bool RTPSParticipantImpl::sendSync(
 
         for (auto& send_resource : send_resource_list_)
         {
-            // Calculate next timeout.
-            std::chrono::microseconds timeout =
-                    std::chrono::duration_cast<std::chrono::microseconds>(
-                max_blocking_time_point - std::chrono::steady_clock::now());
-
             send_resource->send(msg->buffer, msg->length, destination_locators_begin, destination_locators_end,
-                    timeout);
+                    max_blocking_time_point);
         }
     }
 

--- a/src/cpp/rtps/participant/RTPSParticipantImpl.h
+++ b/src/cpp/rtps/participant/RTPSParticipantImpl.h
@@ -244,12 +244,12 @@ public:
         return mp_event_thr;
     }
 
-    //!Send Method - Deprecated - Stays here for reference purposes
     bool sendSync(
-            CDRMessage_t* msg,
-            const Locator_t& destination_loc,
-            std::chrono::steady_clock::time_point& max_blocking_time_point);
-
+        CDRMessage_t* msg,
+        LocatorsIterator& destination_locators_begin,
+        LocatorsIterator& destination_locators_end,
+        std::chrono::steady_clock::time_point& max_blocking_time_point);
+  
     //!Get the participant Mutex
     std::recursive_mutex* getParticipantMutex() const
     {

--- a/src/cpp/rtps/participant/RTPSParticipantImpl.h
+++ b/src/cpp/rtps/participant/RTPSParticipantImpl.h
@@ -244,39 +244,39 @@ public:
         return mp_event_thr;
     }
 
-	/**
-	 * Send a message to several locations
-	 * @param msg Message to send.
-	 * @param destination_locators_begin Iterator at the first destination locator.
-	 * @param destination_locators_end Iterator at the end destination locator.
-	 * @param max_blocking_time_point execution time limit timepoint.
-	 * @return true if at least one locator has been sent.
-	 */
-	template<class LocatorIteratorT>
+    /**
+     * Send a message to several locations
+     * @param msg Message to send.
+     * @param destination_locators_begin Iterator at the first destination locator.
+     * @param destination_locators_end Iterator at the end destination locator.
+     * @param max_blocking_time_point execution time limit timepoint.
+     * @return true if at least one locator has been sent.
+     */
+    template<class LocatorIteratorT>
     bool sendSync(
-        CDRMessage_t* msg,
-		const LocatorIteratorT& destination_locators_begin,
-		const LocatorIteratorT& destination_locators_end,
-        std::chrono::steady_clock::time_point& max_blocking_time_point)
-	{
-		bool ret_code = false;
-		std::unique_lock<std::timed_mutex> lock(m_send_resources_mutex_, std::defer_lock);
+            CDRMessage_t* msg,
+            const LocatorIteratorT& destination_locators_begin,
+            const LocatorIteratorT& destination_locators_end,
+            std::chrono::steady_clock::time_point& max_blocking_time_point)
+    {
+        bool ret_code = false;
+        std::unique_lock<std::timed_mutex> lock(m_send_resources_mutex_, std::defer_lock);
 
-		if (lock.try_lock_until(max_blocking_time_point))
-		{
-			ret_code = true;
+        if (lock.try_lock_until(max_blocking_time_point))
+        {
+            ret_code = true;
 
-			for (auto& send_resource : send_resource_list_)
-			{
-				LocatorIteratorT locators_begin = destination_locators_begin;
-				LocatorIteratorT locators_end = destination_locators_end;
-				send_resource->send(msg->buffer, msg->length, &locators_begin, &locators_end,
-					max_blocking_time_point);
-			}
-		}
+            for (auto& send_resource : send_resource_list_)
+            {
+                LocatorIteratorT locators_begin = destination_locators_begin;
+                LocatorIteratorT locators_end = destination_locators_end;
+                send_resource->send(msg->buffer, msg->length, &locators_begin, &locators_end,
+                        max_blocking_time_point);
+            }
+        }
 
-		return ret_code;
-	}
+        return ret_code;
+    }
 
     //!Get the participant Mutex
     std::recursive_mutex* getParticipantMutex() const
@@ -428,7 +428,8 @@ public:
     }
 
     std::unique_ptr<RTPSMessageGroup_t> get_send_buffer();
-    void return_send_buffer(std::unique_ptr <RTPSMessageGroup_t>&& buffer);
+    void return_send_buffer(
+            std::unique_ptr <RTPSMessageGroup_t>&& buffer);
 
 private:
 

--- a/src/cpp/rtps/participant/RTPSParticipantImpl.h
+++ b/src/cpp/rtps/participant/RTPSParticipantImpl.h
@@ -244,12 +244,40 @@ public:
         return mp_event_thr;
     }
 
+	/**
+	 * Send a message to several locations
+	 * @param msg Message to send.
+	 * @param destination_locators_begin Iterator at the first destination locator.
+	 * @param destination_locators_end Iterator at the end destination locator.
+	 * @param max_blocking_time_point execution time limit timepoint.
+	 * @return true if at least one locator has been sent.
+	 */
+	template<class LocatorIteratorT>
     bool sendSync(
         CDRMessage_t* msg,
-        LocatorsIterator& destination_locators_begin,
-        LocatorsIterator& destination_locators_end,
-        std::chrono::steady_clock::time_point& max_blocking_time_point);
-  
+		const LocatorIteratorT& destination_locators_begin,
+		const LocatorIteratorT& destination_locators_end,
+        std::chrono::steady_clock::time_point& max_blocking_time_point)
+	{
+		bool ret_code = false;
+		std::unique_lock<std::timed_mutex> lock(m_send_resources_mutex_, std::defer_lock);
+
+		if (lock.try_lock_until(max_blocking_time_point))
+		{
+			ret_code = true;
+
+			for (auto& send_resource : send_resource_list_)
+			{
+				LocatorIteratorT locators_begin = destination_locators_begin;
+				LocatorIteratorT locators_end = destination_locators_end;
+				send_resource->send(msg->buffer, msg->length, &locators_begin, &locators_end,
+					max_blocking_time_point);
+			}
+		}
+
+		return ret_code;
+	}
+
     //!Get the participant Mutex
     std::recursive_mutex* getParticipantMutex() const
     {

--- a/src/cpp/rtps/reader/StatefulReader.cpp
+++ b/src/cpp/rtps/reader/StatefulReader.cpp
@@ -1068,8 +1068,9 @@ void StatefulReader::send_acknack(
 
 bool StatefulReader::send_sync_nts(
         CDRMessage_t* message,
-        const Locator_t& locator,
+        LocatorsIterator& locators_begin,
+        LocatorsIterator& locators_end,
         std::chrono::steady_clock::time_point& max_blocking_time_point)
 {
-    return mp_RTPSParticipant->sendSync(message, locator, max_blocking_time_point);
+    return mp_RTPSParticipant->sendSync(message, locators_begin, locators_end, max_blocking_time_point);
 }

--- a/src/cpp/rtps/reader/StatefulReader.cpp
+++ b/src/cpp/rtps/reader/StatefulReader.cpp
@@ -1068,8 +1068,8 @@ void StatefulReader::send_acknack(
 
 bool StatefulReader::send_sync_nts(
         CDRMessage_t* message,
-        LocatorsIterator& locators_begin,
-        LocatorsIterator& locators_end,
+		const Locators& locators_begin,
+        const Locators& locators_end,
         std::chrono::steady_clock::time_point& max_blocking_time_point)
 {
     return mp_RTPSParticipant->sendSync(message, locators_begin, locators_end, max_blocking_time_point);

--- a/src/cpp/rtps/reader/StatefulReader.cpp
+++ b/src/cpp/rtps/reader/StatefulReader.cpp
@@ -1068,7 +1068,7 @@ void StatefulReader::send_acknack(
 
 bool StatefulReader::send_sync_nts(
         CDRMessage_t* message,
-		const Locators& locators_begin,
+        const Locators& locators_begin,
         const Locators& locators_end,
         std::chrono::steady_clock::time_point& max_blocking_time_point)
 {

--- a/src/cpp/rtps/reader/WriterProxy.cpp
+++ b/src/cpp/rtps/reader/WriterProxy.cpp
@@ -565,12 +565,10 @@ bool WriterProxy::send(
     }
 
     ResourceLimitedVector<Locator_t> remote_locators = remote_locators_shrinked();
-    Locators locators_begin(remote_locators.begin());
-    Locators locators_end(remote_locators.end());
-
+    
     return reader_->send_sync_nts(message,
-                   locators_begin,
-                   locators_end,
+                   Locators(remote_locators.begin()),
+                   Locators(remote_locators.end()),
                    max_blocking_time_point);
 }
 

--- a/src/cpp/rtps/reader/WriterProxy.cpp
+++ b/src/cpp/rtps/reader/WriterProxy.cpp
@@ -564,15 +564,14 @@ bool WriterProxy::send(
         return true;
     }
 
-    for (const Locator_t& locator : remote_locators_shrinked())
-    {
-        if (!reader_->send_sync_nts(message, locator, max_blocking_time_point))
-        {
-            return false;
-        }
-    }
+    ResourceLimitedVector<Locator_t> remote_locators = remote_locators_shrinked();
+    Locators locators_begin(remote_locators.begin());
+    Locators locators_end(remote_locators.end());
 
-    return true;
+    return reader_->send_sync_nts(message,
+                   locators_begin,
+                   locators_end,
+                   max_blocking_time_point);
 }
 
 #if !defined(NDEBUG) && defined(FASTRTPS_SOURCE) && defined(__linux__)

--- a/src/cpp/rtps/transport/TCPSenderResource.hpp
+++ b/src/cpp/rtps/transport/TCPSenderResource.hpp
@@ -28,26 +28,27 @@ class TCPSenderResource : public fastrtps::rtps::SenderResource
     public:
 
         TCPSenderResource(
-                TCPTransportInterface& transport,
-                std::shared_ptr<TCPChannelResource>& channel)
-            : fastrtps::rtps::SenderResource(transport.kind())
-            , channel_(channel)
-        {
-            // Implementation functions are bound to the right transport parameters
-            clean_up = [this, &transport]()
+        TCPTransportInterface& transport,
+        std::shared_ptr<TCPChannelResource>& channel)
+        : fastrtps::rtps::SenderResource(transport.kind())
+        , channel_(channel)
+    {
+        // Implementation functions are bound to the right transport parameters
+        clean_up = [this, &transport]()
                 {
                     transport.CloseOutputChannel(channel_);
                 };
 
-            send_lambda_ = [this, &transport] (
-                    const fastrtps::rtps::octet* data,
-                    uint32_t dataSize,
-                    const fastrtps::rtps::Locator_t& destination,
-                    const std::chrono::microseconds&)-> bool
+        send_lambda_ = [this, &transport] (
+            const fastrtps::rtps::octet* data,
+            uint32_t dataSize,
+            fastrtps::rtps::LocatorsIterator& destination_locators_begin,
+            fastrtps::rtps::LocatorsIterator& destination_locators_end,
+            const std::chrono::microseconds&) -> bool
                 {
-                    return transport.send(data, dataSize, channel_, destination);
+                    return transport.send(data, dataSize, channel_, destination_locators_begin, destination_locators_end);
                 };
-        }
+    }
 
         virtual ~TCPSenderResource()
         {

--- a/src/cpp/rtps/transport/TCPSenderResource.hpp
+++ b/src/cpp/rtps/transport/TCPSenderResource.hpp
@@ -44,7 +44,7 @@ class TCPSenderResource : public fastrtps::rtps::SenderResource
             uint32_t dataSize,
             fastrtps::rtps::LocatorsIterator& destination_locators_begin,
             fastrtps::rtps::LocatorsIterator& destination_locators_end,
-            const std::chrono::microseconds&) -> bool
+            const std::chrono::steady_clock::time_point&) -> bool
                 {
                     return transport.send(data, dataSize, channel_, destination_locators_begin, destination_locators_end);
                 };

--- a/src/cpp/rtps/transport/TCPSenderResource.hpp
+++ b/src/cpp/rtps/transport/TCPSenderResource.hpp
@@ -42,8 +42,8 @@ class TCPSenderResource : public fastrtps::rtps::SenderResource
         send_lambda_ = [this, &transport] (
             const fastrtps::rtps::octet* data,
             uint32_t dataSize,
-            fastrtps::rtps::LocatorsIterator& destination_locators_begin,
-            fastrtps::rtps::LocatorsIterator& destination_locators_end,
+            fastrtps::rtps::LocatorsIterator* destination_locators_begin,
+            fastrtps::rtps::LocatorsIterator* destination_locators_end,
             const std::chrono::steady_clock::time_point&) -> bool
                 {
                     return transport.send(data, dataSize, channel_, destination_locators_begin, destination_locators_end);

--- a/src/cpp/rtps/transport/TCPTransportInterface.cpp
+++ b/src/cpp/rtps/transport/TCPTransportInterface.cpp
@@ -989,14 +989,14 @@ bool TCPTransportInterface::send(
         const octet* send_buffer,
         uint32_t send_buffer_size,
         std::shared_ptr<TCPChannelResource>& channel,
-        fastrtps::rtps::LocatorsIterator& destination_locators_begin,
-        fastrtps::rtps::LocatorsIterator& destination_locators_end)
+        fastrtps::rtps::LocatorsIterator* destination_locators_begin,
+        fastrtps::rtps::LocatorsIterator* destination_locators_end)
 {
-    fastrtps::rtps::LocatorsIterator& it = destination_locators_begin;
+    fastrtps::rtps::LocatorsIterator& it = *destination_locators_begin;
 
     bool ret = true;
 
-    while (it != destination_locators_end)
+    while (it != *destination_locators_end)
     {
         ret &= send(send_buffer, send_buffer_size, channel,*it);
         ++it;

--- a/src/cpp/rtps/transport/TCPTransportInterface.cpp
+++ b/src/cpp/rtps/transport/TCPTransportInterface.cpp
@@ -989,8 +989,33 @@ bool TCPTransportInterface::send(
         const octet* send_buffer,
         uint32_t send_buffer_size,
         std::shared_ptr<TCPChannelResource>& channel,
+        fastrtps::rtps::LocatorsIterator& destination_locators_begin,
+        fastrtps::rtps::LocatorsIterator& destination_locators_end)
+{
+    fastrtps::rtps::LocatorsIterator& it = destination_locators_begin;
+
+    bool ret = true;
+
+    while (it != destination_locators_end)
+    {
+        ret &= send(send_buffer, send_buffer_size, channel,*it);
+        ++it;
+    }
+
+    return ret;
+}
+
+bool TCPTransportInterface::send(
+        const octet* send_buffer,
+        uint32_t send_buffer_size,
+        std::shared_ptr<TCPChannelResource>& channel,
         const Locator_t& remote_locator)
 {
+    if (!IsLocatorSupported(remote_locator))
+    {
+        return false;
+    }
+
     bool locator_mismatch = false;
 
     if (channel->locator() != IPLocator::toPhysicalLocator(remote_locator))

--- a/src/cpp/rtps/transport/UDPSenderResource.hpp
+++ b/src/cpp/rtps/transport/UDPSenderResource.hpp
@@ -43,8 +43,8 @@ class UDPSenderResource : public fastrtps::rtps::SenderResource
             send_lambda_ = [this, &transport] (
                 const fastrtps::rtps::octet* data,
                 uint32_t dataSize,
-                fastrtps::rtps::LocatorsIterator& destination_locators_begin,
-                fastrtps::rtps::LocatorsIterator& destination_locators_end,
+                fastrtps::rtps::LocatorsIterator* destination_locators_begin,
+                fastrtps::rtps::LocatorsIterator* destination_locators_end,
                 const std::chrono::steady_clock::time_point& max_blocking_time_point) -> bool
                     {
                         return transport.send(data, dataSize, socket_, destination_locators_begin,

--- a/src/cpp/rtps/transport/UDPSenderResource.hpp
+++ b/src/cpp/rtps/transport/UDPSenderResource.hpp
@@ -41,13 +41,15 @@ class UDPSenderResource : public fastrtps::rtps::SenderResource
                 };
 
             send_lambda_ = [this, &transport] (
-                    const fastrtps::rtps::octet* data,
-                    uint32_t dataSize,
-                    const fastrtps::rtps::Locator_t& destination,
-                    const std::chrono::microseconds& timeout)-> bool
-                {
-                    return transport.send(data, dataSize, socket_, destination, only_multicast_purpose_, timeout);
-                };
+                const fastrtps::rtps::octet* data,
+                uint32_t dataSize,
+                fastrtps::rtps::LocatorsIterator& destination_locators_begin,
+                fastrtps::rtps::LocatorsIterator& destination_locators_end,
+                const std::chrono::microseconds& timeout) -> bool
+                    {
+                        return transport.send(data, dataSize, socket_, destination_locators_begin,
+                                    destination_locators_end, only_multicast_purpose_, timeout);
+                    };
         }
 
         virtual ~UDPSenderResource()

--- a/src/cpp/rtps/transport/UDPSenderResource.hpp
+++ b/src/cpp/rtps/transport/UDPSenderResource.hpp
@@ -45,10 +45,10 @@ class UDPSenderResource : public fastrtps::rtps::SenderResource
                 uint32_t dataSize,
                 fastrtps::rtps::LocatorsIterator& destination_locators_begin,
                 fastrtps::rtps::LocatorsIterator& destination_locators_end,
-                const std::chrono::microseconds& timeout) -> bool
+                const std::chrono::steady_clock::time_point& max_blocking_time_point) -> bool
                     {
                         return transport.send(data, dataSize, socket_, destination_locators_begin,
-                                    destination_locators_end, only_multicast_purpose_, timeout);
+                                    destination_locators_end, only_multicast_purpose_, max_blocking_time_point);
                     };
         }
 

--- a/src/cpp/rtps/transport/UDPTransportInterface.cpp
+++ b/src/cpp/rtps/transport/UDPTransportInterface.cpp
@@ -442,16 +442,16 @@ bool UDPTransportInterface::send(
         const octet* send_buffer,
         uint32_t send_buffer_size,
         eProsimaUDPSocket& socket,
-        fastrtps::rtps::LocatorsIterator& destination_locators_begin,
-        fastrtps::rtps::LocatorsIterator& destination_locators_end,
+        fastrtps::rtps::LocatorsIterator* destination_locators_begin,
+        fastrtps::rtps::LocatorsIterator* destination_locators_end,
         bool only_multicast_purpose,
         const std::chrono::steady_clock::time_point& max_blocking_time_point)
 {
-    fastrtps::rtps::LocatorsIterator& it = destination_locators_begin;
+    fastrtps::rtps::LocatorsIterator& it = *destination_locators_begin;
 
     bool ret = true;
 
-    while (it != destination_locators_end)
+    while (it != *destination_locators_end)
     {
         auto now = std::chrono::steady_clock::now();
 
@@ -459,7 +459,8 @@ bool UDPTransportInterface::send(
         {
             ret &= send(send_buffer, 
                 send_buffer_size, 
-                socket,*it, 
+                socket,
+                *it, 
                 only_multicast_purpose, 
                 std::chrono::duration_cast<std::chrono::microseconds>(max_blocking_time_point - now));
 

--- a/src/cpp/rtps/transport/UDPTransportInterface.cpp
+++ b/src/cpp/rtps/transport/UDPTransportInterface.cpp
@@ -445,7 +445,7 @@ bool UDPTransportInterface::send(
         fastrtps::rtps::LocatorsIterator& destination_locators_begin,
         fastrtps::rtps::LocatorsIterator& destination_locators_end,
         bool only_multicast_purpose,
-        const std::chrono::microseconds& timeout)
+        const std::chrono::steady_clock::time_point& max_blocking_time_point)
 {
     fastrtps::rtps::LocatorsIterator& it = destination_locators_begin;
 
@@ -453,8 +453,23 @@ bool UDPTransportInterface::send(
 
     while (it != destination_locators_end)
     {
-        ret &= send(send_buffer, send_buffer_size, socket,*it, only_multicast_purpose, timeout);
-        ++it;
+        auto now = std::chrono::steady_clock::now();
+
+        if(now < max_blocking_time_point)
+        {
+            ret &= send(send_buffer, 
+                send_buffer_size, 
+                socket,*it, 
+                only_multicast_purpose, 
+                std::chrono::duration_cast<std::chrono::microseconds>(max_blocking_time_point - now));
+
+            ++it;
+        }
+        else // Time is out
+        {
+            ret = false;
+            break;
+        }
     }
 
     return ret;

--- a/src/cpp/rtps/transport/UDPTransportInterface.cpp
+++ b/src/cpp/rtps/transport/UDPTransportInterface.cpp
@@ -442,7 +442,29 @@ bool UDPTransportInterface::send(
         const octet* send_buffer,
         uint32_t send_buffer_size,
         eProsimaUDPSocket& socket,
-        const Locator_t& remote_locator,
+        fastrtps::rtps::LocatorsIterator& destination_locators_begin,
+        fastrtps::rtps::LocatorsIterator& destination_locators_end,
+        bool only_multicast_purpose,
+        const std::chrono::microseconds& timeout)
+{
+    fastrtps::rtps::LocatorsIterator& it = destination_locators_begin;
+
+    bool ret = true;
+
+    while (it != destination_locators_end)
+    {
+        ret &= send(send_buffer, send_buffer_size, socket,*it, only_multicast_purpose, timeout);
+        ++it;
+    }
+
+    return ret;
+}
+
+bool UDPTransportInterface::send(
+        const octet* send_buffer,
+        uint32_t send_buffer_size,
+        eProsimaUDPSocket& socket,
+        const fastrtps::rtps::Locator_t& remote_locator,
         bool only_multicast_purpose,
         const std::chrono::microseconds& timeout)
 {

--- a/src/cpp/rtps/transport/test_UDPv4Transport.cpp
+++ b/src/cpp/rtps/transport/test_UDPv4Transport.cpp
@@ -81,16 +81,16 @@ bool test_UDPv4Transport::send(
         const octet* send_buffer,
         uint32_t send_buffer_size,
         eProsimaUDPSocket& socket,
-        fastrtps::rtps::LocatorsIterator& destination_locators_begin,
-        fastrtps::rtps::LocatorsIterator& destination_locators_end,
+        fastrtps::rtps::LocatorsIterator* destination_locators_begin,
+        fastrtps::rtps::LocatorsIterator* destination_locators_end,
         bool only_multicast_purpose,
         const std::chrono::steady_clock::time_point& max_blocking_time_point)
 {
-    fastrtps::rtps::LocatorsIterator& it = destination_locators_begin;
+    fastrtps::rtps::LocatorsIterator& it = *destination_locators_begin;
 
     bool ret = true;
     
-    while (it != destination_locators_end)
+    while (it != *destination_locators_end)
     {
         auto now = std::chrono::steady_clock::now();
 
@@ -98,7 +98,8 @@ bool test_UDPv4Transport::send(
         {
             ret &= send(send_buffer, 
                 send_buffer_size, 
-                socket,*it, 
+                socket,
+                *it, 
                 only_multicast_purpose, 
                 std::chrono::duration_cast<std::chrono::microseconds>(now - max_blocking_time_point));
 

--- a/src/cpp/rtps/transport/test_UDPv4Transport.cpp
+++ b/src/cpp/rtps/transport/test_UDPv4Transport.cpp
@@ -81,6 +81,28 @@ bool test_UDPv4Transport::send(
         const octet* send_buffer,
         uint32_t send_buffer_size,
         eProsimaUDPSocket& socket,
+        fastrtps::rtps::LocatorsIterator& destination_locators_begin,
+        fastrtps::rtps::LocatorsIterator& destination_locators_end,
+        bool only_multicast_purpose,
+        const std::chrono::microseconds& timeout)
+{
+    fastrtps::rtps::LocatorsIterator& it = destination_locators_begin;
+
+    bool ret = true;
+
+    while (it != destination_locators_end)
+    {
+        ret &= !send(send_buffer, send_buffer_size, socket,*it, only_multicast_purpose, timeout);
+        ++it;
+    }
+
+    return ret;
+}
+
+bool test_UDPv4Transport::send(
+        const octet* send_buffer,
+        uint32_t send_buffer_size,
+        eProsimaUDPSocket& socket,
         const Locator_t& remote_locator,
         bool only_multicast_purpose,
         const std::chrono::microseconds& timeout)

--- a/src/cpp/rtps/writer/RTPSWriter.cpp
+++ b/src/cpp/rtps/writer/RTPSWriter.cpp
@@ -287,9 +287,7 @@ bool RTPSWriter::send(
 {
     RTPSParticipantImpl* participant = getRTPSParticipant();
 
-    LocatorSelector::iterator locators_begin = locator_selector_.begin();
-    LocatorSelector::iterator locators_end = locator_selector_.end();
-    return participant->sendSync(message, locators_begin, locators_end, max_blocking_time_point);
+    return participant->sendSync(message, locator_selector_.begin(), locator_selector_.end(), max_blocking_time_point);
 }
 
 const LivelinessQosPolicyKind& RTPSWriter::get_liveliness_kind() const

--- a/src/cpp/rtps/writer/RTPSWriter.cpp
+++ b/src/cpp/rtps/writer/RTPSWriter.cpp
@@ -285,19 +285,11 @@ bool RTPSWriter::send(
         CDRMessage_t* message,
         std::chrono::steady_clock::time_point& max_blocking_time_point) const
 {
-    bool ret_val = true;
-
     RTPSParticipantImpl* participant = getRTPSParticipant();
-    locator_selector_.for_each(
-        [participant, message, &max_blocking_time_point, &ret_val](const Locator_t& loc)
-                {
-                    if (ret_val)
-                    {
-                        ret_val = participant->sendSync(message, loc, max_blocking_time_point);
-                    }
-                });
 
-    return ret_val;
+    LocatorSelector::iterator locators_begin = locator_selector_.begin();
+    LocatorSelector::iterator locators_end = locator_selector_.end();
+    return participant->sendSync(message, locators_begin, locators_end, max_blocking_time_point);
 }
 
 const LivelinessQosPolicyKind& RTPSWriter::get_liveliness_kind() const

--- a/src/cpp/rtps/writer/ReaderLocator.cpp
+++ b/src/cpp/rtps/writer/ReaderLocator.cpp
@@ -132,23 +132,15 @@ bool ReaderLocator::send(
     {
         if (locator_info_.unicast.size() > 0)
         {
-            for (const Locator_t& locator : locator_info_.unicast)
-            {
-                if (!owner_->sendSync(message, locator, max_blocking_time_point))
-                {
-                    return false;
-                }
-            }
+            Locators locators_begin(locator_info_.unicast.begin());
+            Locators locators_end(locator_info_.unicast.end());
+            return owner_->sendSync(message, locators_begin, locators_end, max_blocking_time_point);
         }
         else
         {
-            for (const Locator_t& locator : locator_info_.multicast)
-            {
-                if (!owner_->sendSync(message, locator, max_blocking_time_point))
-                {
-                    return false;
-                }
-            }
+            Locators locators_begin = locator_info_.multicast.begin();
+            Locators locators_end = locator_info_.multicast.end();
+            return owner_->sendSync(message, locators_begin, locators_end, max_blocking_time_point);
         }
     }
 

--- a/src/cpp/rtps/writer/ReaderLocator.cpp
+++ b/src/cpp/rtps/writer/ReaderLocator.cpp
@@ -132,15 +132,11 @@ bool ReaderLocator::send(
     {
         if (locator_info_.unicast.size() > 0)
         {
-            Locators locators_begin(locator_info_.unicast.begin());
-            Locators locators_end(locator_info_.unicast.end());
-            return owner_->sendSync(message, locators_begin, locators_end, max_blocking_time_point);
+            return owner_->sendSync(message, Locators(locator_info_.unicast.begin()), Locators(locator_info_.unicast.end()), max_blocking_time_point);
         }
         else
         {
-            Locators locators_begin = locator_info_.multicast.begin();
-            Locators locators_end = locator_info_.multicast.end();
-            return owner_->sendSync(message, locators_begin, locators_end, max_blocking_time_point);
+            return owner_->sendSync(message, Locators(locator_info_.multicast.begin()), Locators(locator_info_.multicast.end()), max_blocking_time_point);
         }
     }
 

--- a/src/cpp/rtps/writer/StatelessWriter.cpp
+++ b/src/cpp/rtps/writer/StatelessWriter.cpp
@@ -706,10 +706,7 @@ bool StatelessWriter::send(
         return false;
     }
 
-    Locators locators_begin(fixed_locators_.begin());
-    Locators locators_end(fixed_locators_.end());
-
-    return mp_RTPSParticipant->sendSync(message, locators_begin, locators_end, max_blocking_time_point);
+    return mp_RTPSParticipant->sendSync(message, Locators(fixed_locators_.begin()), Locators(fixed_locators_.end()), max_blocking_time_point);
 }
 
 } /* namespace rtps */

--- a/src/cpp/rtps/writer/StatelessWriter.cpp
+++ b/src/cpp/rtps/writer/StatelessWriter.cpp
@@ -706,7 +706,9 @@ bool StatelessWriter::send(
         return false;
     }
 
-    return mp_RTPSParticipant->sendSync(message, Locators(fixed_locators_.begin()), Locators(fixed_locators_.end()), max_blocking_time_point);
+    return fixed_locators_.empty() ||
+       mp_RTPSParticipant->sendSync(message, Locators(fixed_locators_.begin()), Locators(
+                   fixed_locators_.end()), max_blocking_time_point);
 }
 
 } /* namespace rtps */

--- a/src/cpp/rtps/writer/StatelessWriter.cpp
+++ b/src/cpp/rtps/writer/StatelessWriter.cpp
@@ -706,15 +706,10 @@ bool StatelessWriter::send(
         return false;
     }
 
-    for (const Locator_t& locator : fixed_locators_)
-    {
-        if (!mp_RTPSParticipant->sendSync(message, locator, max_blocking_time_point))
-        {
-            return false;
-        }
-    }
+    Locators locators_begin(fixed_locators_.begin());
+    Locators locators_end(fixed_locators_.end());
 
-    return true;
+    return mp_RTPSParticipant->sendSync(message, locators_begin, locators_end, max_blocking_time_point);
 }
 
 } /* namespace rtps */

--- a/test/mock/rtps/StatefulReader/fastdds/rtps/reader/StatefulReader.h
+++ b/test/mock/rtps/StatefulReader/fastdds/rtps/reader/StatefulReader.h
@@ -73,8 +73,8 @@ class StatefulReader : public RTPSReader
 
         bool send_sync_nts(
                 CDRMessage_t* /*message*/,
-                LocatorsIterator& /*destination_locators_begin*/,
-                LocatorsIterator& /*destination_locators_end*/,
+                const LocatorsIterator& /*destination_locators_begin*/,
+                const LocatorsIterator& /*destination_locators_end*/,
                 std::chrono::steady_clock::time_point& /*max_blocking_time_point*/)
         {
             return true;

--- a/test/mock/rtps/StatefulReader/fastdds/rtps/reader/StatefulReader.h
+++ b/test/mock/rtps/StatefulReader/fastdds/rtps/reader/StatefulReader.h
@@ -73,7 +73,8 @@ class StatefulReader : public RTPSReader
 
         bool send_sync_nts(
                 CDRMessage_t* /*message*/,
-                const Locator_t& /*locator*/,
+                LocatorsIterator& /*destination_locators_begin*/,
+                LocatorsIterator& /*destination_locators_end*/,
                 std::chrono::steady_clock::time_point& /*max_blocking_time_point*/)
         {
             return true;

--- a/test/unittest/transport/TCPv4Tests.cpp
+++ b/test/unittest/transport/TCPv4Tests.cpp
@@ -221,7 +221,7 @@ TEST_F(TCPv4Tests, send_and_receive_between_ports)
         }
         EXPECT_TRUE(sent);
     };
-//std::this_thread::sleep_for(std::chrono::seconds(1));
+
     senderThread.reset(new std::thread(sendThreadFunction));
     std::this_thread::sleep_for(std::chrono::milliseconds(1));
     senderThread->join();
@@ -431,10 +431,10 @@ TEST_F(TCPv4Tests, send_and_receive_between_allowed_interfaces_ports)
                     bool sent = send_resource_list.at(0)->send(message, 5, &input_begin, &input_end, (std::chrono::steady_clock::now()+ std::chrono::microseconds(100)));
                     while (!bFinish && !sent)
                     {
-                        Locators input_begin(locator_list.begin());
-                        Locators input_end(locator_list.end());
+                        Locators input_begin2(locator_list.begin());
+                        Locators input_end2(locator_list.end());
 
-                        sent = send_resource_list.at(0)->send(message, 5, &input_begin, &input_end, (std::chrono::steady_clock::now()+ std::chrono::microseconds(100)));
+                        sent = send_resource_list.at(0)->send(message, 5, &input_begin2, &input_end2, (std::chrono::steady_clock::now()+ std::chrono::microseconds(100)));
                         std::this_thread::sleep_for(std::chrono::milliseconds(100));
                     }
                     EXPECT_TRUE(sent);
@@ -1182,10 +1182,10 @@ TEST_F(TCPv4Tests, send_and_receive_between_allowed_localhost_interfaces_ports)
             bool sent = send_resource_list.at(0)->send(message, 5, &input_begin, &input_end, (std::chrono::steady_clock::now()+ std::chrono::microseconds(100)));
             while (!bFinish && !sent)
             {
-                Locators input_begin(locator_list.begin());
-                Locators input_end(locator_list.end());
+                Locators input_begin2(locator_list.begin());
+                Locators input_end2(locator_list.end());
 
-                sent = send_resource_list.at(0)->send(message, 5, &input_begin, &input_end, (std::chrono::steady_clock::now()+ std::chrono::microseconds(100)));
+                sent = send_resource_list.at(0)->send(message, 5, &input_begin2, &input_end2, (std::chrono::steady_clock::now()+ std::chrono::microseconds(100)));
                 std::this_thread::sleep_for(std::chrono::milliseconds(100));
             }
             EXPECT_TRUE(sent);
@@ -1275,10 +1275,10 @@ TEST_F(TCPv4Tests, send_and_receive_between_blocked_interfaces_ports)
                     bool sent = send_resource_list.at(0)->send(message, 5, &input_begin, &input_end, (std::chrono::steady_clock::now()+ std::chrono::microseconds(100)));
                     while (!bFinished && !sent)
                     {
-                        Locators input_begin(locator_list.begin());
-                        Locators input_end(locator_list.end());
+                        Locators input_begin2(locator_list.begin());
+                        Locators input_end2(locator_list.end());
                         
-                        sent = send_resource_list.at(0)->send(message, 5, &input_begin, &input_end, (std::chrono::steady_clock::now()+ std::chrono::microseconds(100)));
+                        sent = send_resource_list.at(0)->send(message, 5, &input_begin2, &input_end2, (std::chrono::steady_clock::now()+ std::chrono::microseconds(100)));
                         std::this_thread::sleep_for(std::chrono::milliseconds(100));
                     }
                     EXPECT_FALSE(sent);

--- a/test/unittest/transport/TCPv4Tests.cpp
+++ b/test/unittest/transport/TCPv4Tests.cpp
@@ -212,10 +212,10 @@ TEST_F(TCPv4Tests, send_and_receive_between_ports)
 
     auto sendThreadFunction = [&]()
     {
-        bool sent = send_resource_list.at(0)->send(message, 5, input_begin, input_end, std::chrono::microseconds(100));
+        bool sent = send_resource_list.at(0)->send(message, 5, input_begin, input_end, (std::chrono::steady_clock::now()+ std::chrono::microseconds(100)));
         while (!sent)
         {
-            sent = send_resource_list.at(0)->send(message, 5, input_begin, input_end, std::chrono::microseconds(100));
+            sent = send_resource_list.at(0)->send(message, 5, input_begin, input_end, (std::chrono::steady_clock::now()+ std::chrono::microseconds(100)));
             std::this_thread::sleep_for(std::chrono::milliseconds(100));
         }
         EXPECT_TRUE(sent);
@@ -255,7 +255,7 @@ TEST_F(TCPv4Tests, send_is_rejected_if_buffer_size_is_bigger_to_size_specified_i
     // Then
     std::vector<octet> receiveBufferWrongSize(descriptor.sendBufferSize + 1);
     ASSERT_FALSE(send_resource_list.at(0)->send(receiveBufferWrongSize.data(), (uint32_t)receiveBufferWrongSize.size(),
-            destination_begin, destination_end, std::chrono::microseconds(100)));
+            destination_begin, destination_end, (std::chrono::steady_clock::now()+ std::chrono::microseconds(100))));
 }
 
 TEST_F(TCPv4Tests, RemoteToMainLocal_simply_strips_out_address_leaving_IP_ANY)
@@ -321,7 +321,7 @@ TEST_F(TCPv4Tests, send_to_wrong_interface)
 
     std::vector<octet> message = { 'H','e','l','l','o' };
     ASSERT_FALSE(send_resource_list.at(0)->send(message.data(), (uint32_t)message.size(), wrong_begin, wrong_end,
-                std::chrono::microseconds(100)));
+                (std::chrono::steady_clock::now()+ std::chrono::microseconds(100))));
 }
 
 TEST_F(TCPv4Tests, send_to_blocked_interface)
@@ -351,7 +351,7 @@ TEST_F(TCPv4Tests, send_to_blocked_interface)
 
     std::vector<octet> message = { 'H','e','l','l','o' };
     ASSERT_FALSE(send_resource_list.at(0)->send(message.data(), (uint32_t)message.size(), wrong_begin, wrong_end,
-                std::chrono::microseconds(100)));
+                (std::chrono::steady_clock::now()+ std::chrono::microseconds(100))));
 }
 
 #ifndef __APPLE__
@@ -426,10 +426,10 @@ TEST_F(TCPv4Tests, send_and_receive_between_allowed_interfaces_ports)
                 bool bFinish(false);
                 auto sendThreadFunction = [&]()
                 {
-                    bool sent = send_resource_list.at(0)->send(message, 5, input_begin, input_end, std::chrono::microseconds(100));
+                    bool sent = send_resource_list.at(0)->send(message, 5, input_begin, input_end, (std::chrono::steady_clock::now()+ std::chrono::microseconds(100)));
                     while (!bFinish && !sent)
                     {
-                        sent = send_resource_list.at(0)->send(message, 5, input_begin, input_end, std::chrono::microseconds(100));
+                        sent = send_resource_list.at(0)->send(message, 5, input_begin, input_end, (std::chrono::steady_clock::now()+ std::chrono::microseconds(100)));
                         std::this_thread::sleep_for(std::chrono::milliseconds(100));
                     }
                     EXPECT_TRUE(sent);
@@ -515,10 +515,10 @@ TEST_F(TCPv4Tests, send_and_receive_between_secure_ports_client_verifies)
 
         auto sendThreadFunction = [&]()
         {
-            bool sent = send_resource_list.at(0)->send(message, 5, input_begin, input_end, std::chrono::microseconds(100));
+            bool sent = send_resource_list.at(0)->send(message, 5, input_begin, input_end, (std::chrono::steady_clock::now()+ std::chrono::microseconds(100)));
             while (!sent)
             {
-                sent = send_resource_list.at(0)->send(message, 5, input_begin, input_end, std::chrono::microseconds(100));
+                sent = send_resource_list.at(0)->send(message, 5, input_begin, input_end, (std::chrono::steady_clock::now()+ std::chrono::microseconds(100)));
                 std::this_thread::sleep_for(std::chrono::milliseconds(100));
             }
             EXPECT_TRUE(sent);
@@ -607,10 +607,10 @@ TEST_F(TCPv4Tests, send_and_receive_between_secure_ports_server_verifies)
 
         auto sendThreadFunction = [&]()
         {
-            bool sent = send_resource_list.at(0)->send(message, 5, input_begin, input_end, std::chrono::microseconds(100));
+            bool sent = send_resource_list.at(0)->send(message, 5, input_begin, input_end, (std::chrono::steady_clock::now()+ std::chrono::microseconds(100)));
             while (!sent)
             {
-                sent = send_resource_list.at(0)->send(message, 5,  input_begin, input_end, std::chrono::microseconds(100));
+                sent = send_resource_list.at(0)->send(message, 5,  input_begin, input_end, (std::chrono::steady_clock::now()+ std::chrono::microseconds(100)));
                 std::this_thread::sleep_for(std::chrono::milliseconds(100));
             }
             EXPECT_TRUE(sent);
@@ -701,10 +701,10 @@ TEST_F(TCPv4Tests, send_and_receive_between_both_secure_ports)
 
         auto sendThreadFunction = [&]()
         {
-            bool sent = send_resource_list.at(0)->send(message, 5, input_begin, input_end, std::chrono::microseconds(100));
+            bool sent = send_resource_list.at(0)->send(message, 5, input_begin, input_end, (std::chrono::steady_clock::now()+ std::chrono::microseconds(100)));
             while (!sent)
             {
-                sent = send_resource_list.at(0)->send(message, 5, input_begin, input_end, std::chrono::microseconds(100));
+                sent = send_resource_list.at(0)->send(message, 5, input_begin, input_end, (std::chrono::steady_clock::now()+ std::chrono::microseconds(100)));
                 std::this_thread::sleep_for(std::chrono::milliseconds(100));
             }
             EXPECT_TRUE(sent);
@@ -796,11 +796,11 @@ TEST_F(TCPv4Tests, send_and_receive_between_both_secure_ports_untrusted)
 
         auto sendThreadFunction = [&]()
         {
-            bool sent = send_resource_list.at(0)->send(message, 5, input_begin, input_end,  std::chrono::microseconds(100));
+            bool sent = send_resource_list.at(0)->send(message, 5, input_begin, input_end, (std::chrono::steady_clock::now()+ std::chrono::microseconds(100)));
             int count = 0;
             while (!sent && count < 30)
             {
-                sent = send_resource_list.at(0)->send(message, 5, input_begin, input_end, std::chrono::microseconds(100));
+                sent = send_resource_list.at(0)->send(message, 5, input_begin, input_end, (std::chrono::steady_clock::now()+ std::chrono::microseconds(100)));
                 std::this_thread::sleep_for(std::chrono::milliseconds(100));
                 ++count;
             }
@@ -893,10 +893,10 @@ TEST_F(TCPv4Tests, send_and_receive_between_secure_clients_1)
 
         auto sendThreadFunction = [&]()
         {
-            bool sent = send_resource_list.at(0)->send(message, 5, input_begin, input_end, std::chrono::microseconds(100));
+            bool sent = send_resource_list.at(0)->send(message, 5, input_begin, input_end, (std::chrono::steady_clock::now()+ std::chrono::microseconds(100)));
             while (!sent)
             {
-                sent = send_resource_list.at(0)->send(message, 5, input_begin, input_end, std::chrono::microseconds(100));
+                sent = send_resource_list.at(0)->send(message, 5, input_begin, input_end, (std::chrono::steady_clock::now()+ std::chrono::microseconds(100)));
                 std::this_thread::sleep_for(std::chrono::milliseconds(100));
             }
             EXPECT_TRUE(sent);
@@ -1073,11 +1073,11 @@ TEST_F(TCPv4Tests, send_and_receive_between_secure_ports_untrusted_server)
 
         auto sendThreadFunction = [&]()
         {
-            bool sent = send_resource_list.at(0)->send(message, 5, input_begin, input_end, std::chrono::microseconds(100));
+            bool sent = send_resource_list.at(0)->send(message, 5, input_begin, input_end, (std::chrono::steady_clock::now()+ std::chrono::microseconds(100)));
             int count = 0;
             while (!sent && count < 30)
             {
-                sent = send_resource_list.at(0)->send(message, 5, input_begin, input_end, std::chrono::microseconds(100));
+                sent = send_resource_list.at(0)->send(message, 5, input_begin, input_end, (std::chrono::steady_clock::now()+ std::chrono::microseconds(100)));
                 std::this_thread::sleep_for(std::chrono::milliseconds(100));
                 ++count;
             }
@@ -1150,10 +1150,10 @@ TEST_F(TCPv4Tests, send_and_receive_between_allowed_localhost_interfaces_ports)
         bool bFinish(false);
         auto sendThreadFunction = [&]()
         {
-            bool sent = send_resource_list.at(0)->send(message, 5, input_begin, input_end, std::chrono::microseconds(100));
+            bool sent = send_resource_list.at(0)->send(message, 5, input_begin, input_end, (std::chrono::steady_clock::now()+ std::chrono::microseconds(100)));
             while (!bFinish && !sent)
             {
-                sent = send_resource_list.at(0)->send(message, 5, input_begin, input_end, std::chrono::microseconds(100));
+                sent = send_resource_list.at(0)->send(message, 5, input_begin, input_end, (std::chrono::steady_clock::now()+ std::chrono::microseconds(100)));
                 std::this_thread::sleep_for(std::chrono::milliseconds(100));
             }
             EXPECT_TRUE(sent);
@@ -1239,10 +1239,10 @@ TEST_F(TCPv4Tests, send_and_receive_between_blocked_interfaces_ports)
                 bool bFinished(false);
                 auto sendThreadFunction = [&]()
                 {
-                    bool sent = send_resource_list.at(0)->send(message, 5, input_begin, input_end, std::chrono::microseconds(100));
+                    bool sent = send_resource_list.at(0)->send(message, 5, input_begin, input_end, (std::chrono::steady_clock::now()+ std::chrono::microseconds(100)));
                     while (!bFinished && !sent)
                     {
-                        sent = send_resource_list.at(0)->send(message, 5, input_begin, input_end, std::chrono::microseconds(100));
+                        sent = send_resource_list.at(0)->send(message, 5, input_begin, input_end, (std::chrono::steady_clock::now()+ std::chrono::microseconds(100)));
                         std::this_thread::sleep_for(std::chrono::milliseconds(100));
                     }
                     EXPECT_FALSE(sent);

--- a/test/unittest/transport/TCPv4Tests.cpp
+++ b/test/unittest/transport/TCPv4Tests.cpp
@@ -181,6 +181,11 @@ TEST_F(TCPv4Tests, send_and_receive_between_ports)
     IPLocator::setIPv4(inputLocator, 127, 0, 0, 1);
     IPLocator::setLogicalPort(inputLocator, 7410);
 
+    LocatorList_t locator_list;
+    locator_list.push_back(inputLocator);
+    Locators input_begin(locator_list.begin());
+    Locators input_end(locator_list.end());
+
     Locator_t outputLocator;
     outputLocator.kind = LOCATOR_KIND_TCPv4;
     IPLocator::setIPv4(outputLocator, 127, 0, 0, 1);
@@ -207,10 +212,10 @@ TEST_F(TCPv4Tests, send_and_receive_between_ports)
 
     auto sendThreadFunction = [&]()
     {
-        bool sent = send_resource_list.at(0)->send(message, 5, inputLocator, std::chrono::microseconds(100));
+        bool sent = send_resource_list.at(0)->send(message, 5, input_begin, input_end, std::chrono::microseconds(100));
         while (!sent)
         {
-            sent = send_resource_list.at(0)->send(message, 5, inputLocator, std::chrono::microseconds(100));
+            sent = send_resource_list.at(0)->send(message, 5, input_begin, input_end, std::chrono::microseconds(100));
             std::this_thread::sleep_for(std::chrono::milliseconds(100));
         }
         EXPECT_TRUE(sent);
@@ -242,10 +247,15 @@ TEST_F(TCPv4Tests, send_is_rejected_if_buffer_size_is_bigger_to_size_specified_i
     destinationLocator.port = g_output_port + 1;
     IPLocator::setLogicalPort(destinationLocator, 7400);
 
+    LocatorList_t locator_list;
+    locator_list.push_back(destinationLocator);
+    Locators destination_begin(locator_list.begin());
+    Locators destination_end(locator_list.end());
+
     // Then
     std::vector<octet> receiveBufferWrongSize(descriptor.sendBufferSize + 1);
     ASSERT_FALSE(send_resource_list.at(0)->send(receiveBufferWrongSize.data(), (uint32_t)receiveBufferWrongSize.size(),
-            destinationLocator, std::chrono::microseconds(100)));
+            destination_begin, destination_end, std::chrono::microseconds(100)));
 }
 
 TEST_F(TCPv4Tests, RemoteToMainLocal_simply_strips_out_address_leaving_IP_ANY)
@@ -303,8 +313,14 @@ TEST_F(TCPv4Tests, send_to_wrong_interface)
     //Sending through a different IP will NOT work, except 0.0.0.0
     Locator_t wrongLocator(outputChannelLocator);
     IPLocator::setIPv4(wrongLocator, 111,111,111,111);
+
+    LocatorList_t locator_list;
+    locator_list.push_back(wrongLocator);
+    Locators wrong_begin(locator_list.begin());
+    Locators wrong_end(locator_list.end());
+
     std::vector<octet> message = { 'H','e','l','l','o' };
-    ASSERT_FALSE(send_resource_list.at(0)->send(message.data(), (uint32_t)message.size(), wrongLocator,
+    ASSERT_FALSE(send_resource_list.at(0)->send(message.data(), (uint32_t)message.size(), wrong_begin, wrong_end,
                 std::chrono::microseconds(100)));
 }
 
@@ -325,9 +341,16 @@ TEST_F(TCPv4Tests, send_to_blocked_interface)
 
     //Sending through a different IP will NOT work, except 0.0.0.0
     Locator_t wrongLocator(outputChannelLocator);
-    IPLocator::setIPv4(wrongLocator, 111, 111, 111, 111);
+    IPLocator::setIPv4(wrongLocator, 111, 111
+    , 111, 111);
+
+    LocatorList_t locator_list;
+    locator_list.push_back(wrongLocator);
+    Locators wrong_begin(locator_list.begin());
+    Locators wrong_end(locator_list.end());
+
     std::vector<octet> message = { 'H','e','l','l','o' };
-    ASSERT_FALSE(send_resource_list.at(0)->send(message.data(), (uint32_t)message.size(), wrongLocator,
+    ASSERT_FALSE(send_resource_list.at(0)->send(message.data(), (uint32_t)message.size(), wrong_begin, wrong_end,
                 std::chrono::microseconds(100)));
 }
 
@@ -371,6 +394,11 @@ TEST_F(TCPv4Tests, send_and_receive_between_allowed_interfaces_ports)
             inputLocator.set_address(locator);
             IPLocator::setLogicalPort(inputLocator, 7410);
 
+            LocatorList_t locator_list;
+            locator_list.push_back(inputLocator);
+            Locators input_begin(locator_list.begin());
+            Locators input_end(locator_list.end());
+
             Locator_t outputLocator;
             outputLocator.kind = LOCATOR_KIND_TCPv4;
             outputLocator.set_address(locator);
@@ -398,10 +426,10 @@ TEST_F(TCPv4Tests, send_and_receive_between_allowed_interfaces_ports)
                 bool bFinish(false);
                 auto sendThreadFunction = [&]()
                 {
-                    bool sent = send_resource_list.at(0)->send(message, 5, inputLocator, std::chrono::microseconds(100));
+                    bool sent = send_resource_list.at(0)->send(message, 5, input_begin, input_end, std::chrono::microseconds(100));
                     while (!bFinish && !sent)
                     {
-                        sent = send_resource_list.at(0)->send(message, 5, inputLocator, std::chrono::microseconds(100));
+                        sent = send_resource_list.at(0)->send(message, 5, input_begin, input_end, std::chrono::microseconds(100));
                         std::this_thread::sleep_for(std::chrono::milliseconds(100));
                     }
                     EXPECT_TRUE(sent);
@@ -455,6 +483,11 @@ TEST_F(TCPv4Tests, send_and_receive_between_secure_ports_client_verifies)
     IPLocator::setIPv4(inputLocator, 127, 0, 0, 1);
     IPLocator::setLogicalPort(inputLocator, 7410);
 
+    LocatorList_t locator_list;
+    locator_list.push_back(inputLocator);
+    Locators input_begin(locator_list.begin());
+    Locators input_end(locator_list.end());
+
     Locator_t outputLocator;
     outputLocator.kind = LOCATOR_KIND_TCPv4;
     IPLocator::setIPv4(outputLocator, 127, 0, 0, 1);
@@ -482,10 +515,10 @@ TEST_F(TCPv4Tests, send_and_receive_between_secure_ports_client_verifies)
 
         auto sendThreadFunction = [&]()
         {
-            bool sent = send_resource_list.at(0)->send(message, 5, inputLocator, std::chrono::microseconds(100));
+            bool sent = send_resource_list.at(0)->send(message, 5, input_begin, input_end, std::chrono::microseconds(100));
             while (!sent)
             {
-                sent = send_resource_list.at(0)->send(message, 5, inputLocator, std::chrono::microseconds(100));
+                sent = send_resource_list.at(0)->send(message, 5, input_begin, input_end, std::chrono::microseconds(100));
                 std::this_thread::sleep_for(std::chrono::milliseconds(100));
             }
             EXPECT_TRUE(sent);
@@ -542,6 +575,11 @@ TEST_F(TCPv4Tests, send_and_receive_between_secure_ports_server_verifies)
     IPLocator::setIPv4(inputLocator, 127, 0, 0, 1);
     IPLocator::setLogicalPort(inputLocator, 7410);
 
+    LocatorList_t locator_list;
+    locator_list.push_back(inputLocator);
+    Locators input_begin(locator_list.begin());
+    Locators input_end(locator_list.end());
+
     Locator_t outputLocator;
     outputLocator.kind = LOCATOR_KIND_TCPv4;
     IPLocator::setIPv4(outputLocator, 127, 0, 0, 1);
@@ -569,10 +607,10 @@ TEST_F(TCPv4Tests, send_and_receive_between_secure_ports_server_verifies)
 
         auto sendThreadFunction = [&]()
         {
-            bool sent = send_resource_list.at(0)->send(message, 5, inputLocator, std::chrono::microseconds(100));
+            bool sent = send_resource_list.at(0)->send(message, 5, input_begin, input_end, std::chrono::microseconds(100));
             while (!sent)
             {
-                sent = send_resource_list.at(0)->send(message, 5,  inputLocator, std::chrono::microseconds(100));
+                sent = send_resource_list.at(0)->send(message, 5,  input_begin, input_end, std::chrono::microseconds(100));
                 std::this_thread::sleep_for(std::chrono::milliseconds(100));
             }
             EXPECT_TRUE(sent);
@@ -631,6 +669,11 @@ TEST_F(TCPv4Tests, send_and_receive_between_both_secure_ports)
     IPLocator::setIPv4(inputLocator, 127, 0, 0, 1);
     IPLocator::setLogicalPort(inputLocator, 7410);
 
+    LocatorList_t locator_list;
+    locator_list.push_back(inputLocator);
+    Locators input_begin(locator_list.begin());
+    Locators input_end(locator_list.end());
+
     Locator_t outputLocator;
     outputLocator.kind = LOCATOR_KIND_TCPv4;
     IPLocator::setIPv4(outputLocator, 127, 0, 0, 1);
@@ -658,10 +701,10 @@ TEST_F(TCPv4Tests, send_and_receive_between_both_secure_ports)
 
         auto sendThreadFunction = [&]()
         {
-            bool sent = send_resource_list.at(0)->send(message, 5, inputLocator, std::chrono::microseconds(100));
+            bool sent = send_resource_list.at(0)->send(message, 5, input_begin, input_end, std::chrono::microseconds(100));
             while (!sent)
             {
-                sent = send_resource_list.at(0)->send(message, 5, inputLocator, std::chrono::microseconds(100));
+                sent = send_resource_list.at(0)->send(message, 5, input_begin, input_end, std::chrono::microseconds(100));
                 std::this_thread::sleep_for(std::chrono::milliseconds(100));
             }
             EXPECT_TRUE(sent);
@@ -720,6 +763,11 @@ TEST_F(TCPv4Tests, send_and_receive_between_both_secure_ports_untrusted)
     IPLocator::setIPv4(inputLocator, 127, 0, 0, 1);
     IPLocator::setLogicalPort(inputLocator, 7410);
 
+    LocatorList_t locator_list;
+    locator_list.push_back(inputLocator);
+    Locators input_begin(locator_list.begin());
+    Locators input_end(locator_list.end());
+
     Locator_t outputLocator;
     outputLocator.kind = LOCATOR_KIND_TCPv4;
     IPLocator::setIPv4(outputLocator, 127, 0, 0, 1);
@@ -748,11 +796,11 @@ TEST_F(TCPv4Tests, send_and_receive_between_both_secure_ports_untrusted)
 
         auto sendThreadFunction = [&]()
         {
-            bool sent = send_resource_list.at(0)->send(message, 5, inputLocator, std::chrono::microseconds(100));
+            bool sent = send_resource_list.at(0)->send(message, 5, input_begin, input_end,  std::chrono::microseconds(100));
             int count = 0;
             while (!sent && count < 30)
             {
-                sent = send_resource_list.at(0)->send(message, 5, inputLocator, std::chrono::microseconds(100));
+                sent = send_resource_list.at(0)->send(message, 5, input_begin, input_end, std::chrono::microseconds(100));
                 std::this_thread::sleep_for(std::chrono::milliseconds(100));
                 ++count;
             }
@@ -813,6 +861,11 @@ TEST_F(TCPv4Tests, send_and_receive_between_secure_clients_1)
     IPLocator::setIPv4(inputLocator, 127, 0, 0, 1);
     IPLocator::setLogicalPort(inputLocator, 7410);
 
+    LocatorList_t locator_list;
+    locator_list.push_back(inputLocator);
+    Locators input_begin(locator_list.begin());
+    Locators input_end(locator_list.end());
+
     Locator_t outputLocator;
     outputLocator.kind = LOCATOR_KIND_TCPv4;
     IPLocator::setIPv4(outputLocator, 127, 0, 0, 1);
@@ -840,10 +893,10 @@ TEST_F(TCPv4Tests, send_and_receive_between_secure_clients_1)
 
         auto sendThreadFunction = [&]()
         {
-            bool sent = send_resource_list.at(0)->send(message, 5, inputLocator, std::chrono::microseconds(100));
+            bool sent = send_resource_list.at(0)->send(message, 5, input_begin, input_end, std::chrono::microseconds(100));
             while (!sent)
             {
-                sent = send_resource_list.at(0)->send(message, 5, inputLocator, std::chrono::microseconds(100));
+                sent = send_resource_list.at(0)->send(message, 5, input_begin, input_end, std::chrono::microseconds(100));
                 std::this_thread::sleep_for(std::chrono::milliseconds(100));
             }
             EXPECT_TRUE(sent);
@@ -987,6 +1040,11 @@ TEST_F(TCPv4Tests, send_and_receive_between_secure_ports_untrusted_server)
     IPLocator::setIPv4(inputLocator, 127, 0, 0, 1);
     IPLocator::setLogicalPort(inputLocator, 7410);
 
+    LocatorList_t locator_list;
+    locator_list.push_back(inputLocator);
+    Locators input_begin(locator_list.begin());
+    Locators input_end(locator_list.end());
+
     Locator_t outputLocator;
     outputLocator.kind = LOCATOR_KIND_TCPv4;
     IPLocator::setIPv4(outputLocator, 127, 0, 0, 1);
@@ -1015,11 +1073,11 @@ TEST_F(TCPv4Tests, send_and_receive_between_secure_ports_untrusted_server)
 
         auto sendThreadFunction = [&]()
         {
-            bool sent = send_resource_list.at(0)->send(message, 5, inputLocator, std::chrono::microseconds(100));
+            bool sent = send_resource_list.at(0)->send(message, 5, input_begin, input_end, std::chrono::microseconds(100));
             int count = 0;
             while (!sent && count < 30)
             {
-                sent = send_resource_list.at(0)->send(message, 5, inputLocator, std::chrono::microseconds(100));
+                sent = send_resource_list.at(0)->send(message, 5, input_begin, input_end, std::chrono::microseconds(100));
                 std::this_thread::sleep_for(std::chrono::milliseconds(100));
                 ++count;
             }
@@ -1060,6 +1118,11 @@ TEST_F(TCPv4Tests, send_and_receive_between_allowed_localhost_interfaces_ports)
     IPLocator::setIPv4(inputLocator, 127, 0, 0, 1);
     IPLocator::setLogicalPort(inputLocator, 7410);
 
+    LocatorList_t locator_list;
+    locator_list.push_back(inputLocator);
+    Locators input_begin(locator_list.begin());
+    Locators input_end(locator_list.end());
+
     Locator_t outputLocator;
     outputLocator.kind = LOCATOR_KIND_TCPv4;
     IPLocator::setIPv4(outputLocator, 127, 0, 0, 1);
@@ -1087,10 +1150,10 @@ TEST_F(TCPv4Tests, send_and_receive_between_allowed_localhost_interfaces_ports)
         bool bFinish(false);
         auto sendThreadFunction = [&]()
         {
-            bool sent = send_resource_list.at(0)->send(message, 5, inputLocator, std::chrono::microseconds(100));
+            bool sent = send_resource_list.at(0)->send(message, 5, input_begin, input_end, std::chrono::microseconds(100));
             while (!bFinish && !sent)
             {
-                sent = send_resource_list.at(0)->send(message, 5, inputLocator, std::chrono::microseconds(100));
+                sent = send_resource_list.at(0)->send(message, 5, input_begin, input_end, std::chrono::microseconds(100));
                 std::this_thread::sleep_for(std::chrono::milliseconds(100));
             }
             EXPECT_TRUE(sent);
@@ -1144,6 +1207,11 @@ TEST_F(TCPv4Tests, send_and_receive_between_blocked_interfaces_ports)
             IPLocator::setIPv4(inputLocator, 127, 0, 0, 1);
             IPLocator::setLogicalPort(inputLocator, 7410);
 
+            LocatorList_t locator_list;
+            locator_list.push_back(inputLocator);
+            Locators input_begin(locator_list.begin());
+            Locators input_end(locator_list.end());
+
             Locator_t outputLocator;
             outputLocator.kind = LOCATOR_KIND_TCPv4;
             IPLocator::setIPv4(outputLocator, 127, 0, 0, 1);
@@ -1171,10 +1239,10 @@ TEST_F(TCPv4Tests, send_and_receive_between_blocked_interfaces_ports)
                 bool bFinished(false);
                 auto sendThreadFunction = [&]()
                 {
-                    bool sent = send_resource_list.at(0)->send(message, 5, inputLocator, std::chrono::microseconds(100));
+                    bool sent = send_resource_list.at(0)->send(message, 5, input_begin, input_end, std::chrono::microseconds(100));
                     while (!bFinished && !sent)
                     {
-                        sent = send_resource_list.at(0)->send(message, 5, inputLocator, std::chrono::microseconds(100));
+                        sent = send_resource_list.at(0)->send(message, 5, input_begin, input_end, std::chrono::microseconds(100));
                         std::this_thread::sleep_for(std::chrono::milliseconds(100));
                     }
                     EXPECT_FALSE(sent);

--- a/test/unittest/transport/UDPv4Tests.cpp
+++ b/test/unittest/transport/UDPv4Tests.cpp
@@ -167,10 +167,11 @@ TEST_F(UDPv4Tests, send_and_receive_between_ports)
     {
         LocatorList_t locator_list;
         locator_list.push_back(multicastLocator);
+
         Locators locators_begin(locator_list.begin());
         Locators locators_end(locator_list.end());
 
-        EXPECT_TRUE(send_resource_list.at(0)->send(message, 5, locators_begin, locators_end, 
+        EXPECT_TRUE(send_resource_list.at(0)->send(message, 5, &locators_begin, &locators_end, 
             (std::chrono::steady_clock::now()+ std::chrono::microseconds(100))));
     };
 
@@ -217,10 +218,11 @@ TEST_F(UDPv4Tests, send_to_loopback)
     {
         LocatorList_t locator_list;
         locator_list.push_back(multicastLocator);
+
         Locators locators_begin(locator_list.begin());
         Locators locators_end(locator_list.end());
 
-        EXPECT_TRUE(send_resource_list.at(0)->send(message, 5, locators_begin, locators_end, 
+        EXPECT_TRUE(send_resource_list.at(0)->send(message, 5, &locators_begin, &locators_end, 
             (std::chrono::steady_clock::now()+ std::chrono::microseconds(100))));
     };
 
@@ -256,7 +258,7 @@ TEST_F(UDPv4Tests, send_is_rejected_if_buffer_size_is_bigger_to_size_specified_i
     // Then
     std::vector<octet> receiveBufferWrongSize(descriptor.sendBufferSize + 1);
     ASSERT_FALSE(send_resource_list.at(0)->send(receiveBufferWrongSize.data(), (uint32_t)receiveBufferWrongSize.size(),
-                locators_begin, locators_end, (std::chrono::steady_clock::now()+ std::chrono::microseconds(100))));
+                &locators_begin, &locators_end, (std::chrono::steady_clock::now()+ std::chrono::microseconds(100))));
 }
 
 TEST_F(UDPv4Tests, RemoteToMainLocal_simply_strips_out_address_leaving_IP_ANY)
@@ -319,7 +321,7 @@ TEST_F(UDPv4Tests, send_to_wrong_interface)
     //Sending through a different IP will NOT work, except 0.0.0.0
     IPLocator::setIPv4(outputChannelLocator, 111, 111, 111, 111);
     std::vector<octet> message = { 'H','e','l','l','o' };
-    ASSERT_FALSE(send_resource_list.at(0)->send(message.data(), (uint32_t)message.size(), locators_begin, locators_end, 
+    ASSERT_FALSE(send_resource_list.at(0)->send(message.data(), (uint32_t)message.size(), &locators_begin, &locators_end, 
         (std::chrono::steady_clock::now()+ std::chrono::microseconds(100))));
 }
 
@@ -380,7 +382,7 @@ TEST_F(UDPv4Tests, send_to_allowed_interface)
             // Sending through a ALLOWED IP will work
             std::vector<octet> message = { 'H','e','l','l','o' };
             ASSERT_TRUE(send_resource_list.at(0)->send(message.data(), (uint32_t)message.size(),
-                        locators_begin, locators_end, (std::chrono::steady_clock::now()+ std::chrono::microseconds(100))));
+                        &locators_begin, &locators_end, (std::chrono::steady_clock::now()+ std::chrono::microseconds(100))));
         }
     }
 }
@@ -414,9 +416,7 @@ TEST_F(UDPv4Tests, send_and_receive_between_allowed_sockets_using_localhost)
 
     LocatorList_t locator_list;
     locator_list.push_back(unicastLocator);
-    Locators locators_begin(locator_list.begin());
-    Locators locators_end(locator_list.end());
-
+    
     Locator_t outputChannelLocator;
     outputChannelLocator.port = g_default_port + 1;
     outputChannelLocator.kind = LOCATOR_KIND_UDPv4;
@@ -442,7 +442,10 @@ TEST_F(UDPv4Tests, send_and_receive_between_allowed_sockets_using_localhost)
 
     auto sendThreadFunction = [&]()
     {
-        EXPECT_TRUE(send_resource_list.at(0)->send(message, 5, locators_begin, locators_end, 
+        Locators locators_begin(locator_list.begin());
+        Locators locators_end(locator_list.end());
+
+        EXPECT_TRUE(send_resource_list.at(0)->send(message, 5, &locators_begin, &locators_end, 
             (std::chrono::steady_clock::now()+ std::chrono::microseconds(100))));
     };
 
@@ -471,9 +474,7 @@ TEST_F(UDPv4Tests, send_and_receive_between_allowed_sockets_using_unicast)
 
     LocatorList_t locator_list;
     locator_list.push_back(unicastLocator);
-    Locators locators_begin(locator_list.begin());
-    Locators locators_end(locator_list.end());
-
+    
     Locator_t outputChannelLocator;
     outputChannelLocator.port = g_default_port + 1;
     outputChannelLocator.kind = LOCATOR_KIND_UDPv4;
@@ -499,7 +500,10 @@ TEST_F(UDPv4Tests, send_and_receive_between_allowed_sockets_using_unicast)
 
     auto sendThreadFunction = [&]()
     {
-        EXPECT_TRUE(send_resource_list.at(0)->send(message, 5, locators_begin, locators_end, 
+        Locators locators_begin(locator_list.begin());
+        Locators locators_end(locator_list.end());
+
+        EXPECT_TRUE(send_resource_list.at(0)->send(message, 5, &locators_begin, &locators_end, 
             (std::chrono::steady_clock::now()+ std::chrono::microseconds(100))));
     };
 
@@ -528,9 +532,7 @@ TEST_F(UDPv4Tests, send_and_receive_between_allowed_sockets_using_unicast_to_mul
 
     LocatorList_t locator_list;
     locator_list.push_back(unicastLocator);
-    Locators locators_begin(locator_list.begin());
-    Locators locators_end(locator_list.end());
-
+    
     Locator_t outputChannelLocator;
     outputChannelLocator.port = g_default_port + 1;
     outputChannelLocator.kind = LOCATOR_KIND_UDPv4;
@@ -556,7 +558,10 @@ TEST_F(UDPv4Tests, send_and_receive_between_allowed_sockets_using_unicast_to_mul
 
     auto sendThreadFunction = [&]()
     {
-        EXPECT_TRUE(send_resource_list.at(0)->send(message, 5, locators_begin, locators_end, 
+        Locators locators_begin(locator_list.begin());
+        Locators locators_end(locator_list.end());
+
+        EXPECT_TRUE(send_resource_list.at(0)->send(message, 5, &locators_begin, &locators_end, 
             (std::chrono::steady_clock::now()+ std::chrono::microseconds(100))));
     };
 

--- a/test/unittest/transport/UDPv4Tests.cpp
+++ b/test/unittest/transport/UDPv4Tests.cpp
@@ -165,7 +165,12 @@ TEST_F(UDPv4Tests, send_and_receive_between_ports)
 
     auto sendThreadFunction = [&]()
     {
-        EXPECT_TRUE(send_resource_list.at(0)->send(message, 5, multicastLocator, std::chrono::microseconds(100)));
+        LocatorList_t locator_list;
+        locator_list.push_back(multicastLocator);
+        Locators locators_begin(locator_list.begin());
+        Locators locators_end(locator_list.end());
+
+        EXPECT_TRUE(send_resource_list.at(0)->send(message, 5, locators_begin, locators_end, std::chrono::microseconds(100)));
     };
 
     senderThread.reset(new std::thread(sendThreadFunction));
@@ -209,7 +214,12 @@ TEST_F(UDPv4Tests, send_to_loopback)
 
     auto sendThreadFunction = [&]()
     {
-        EXPECT_TRUE(send_resource_list.at(0)->send(message, 5, multicastLocator, std::chrono::microseconds(100)));
+        LocatorList_t locator_list;
+        locator_list.push_back(multicastLocator);
+        Locators locators_begin(locator_list.begin());
+        Locators locators_end(locator_list.end());
+
+        EXPECT_TRUE(send_resource_list.at(0)->send(message, 5, locators_begin, locators_end, std::chrono::microseconds(100)));
     };
 
     senderThread.reset(new std::thread(sendThreadFunction));
@@ -236,10 +246,15 @@ TEST_F(UDPv4Tests, send_is_rejected_if_buffer_size_is_bigger_to_size_specified_i
     destinationLocator.kind = LOCATOR_KIND_UDPv4;
     destinationLocator.port = g_default_port + 1;
 
+    LocatorList_t locator_list;
+    locator_list.push_back(destinationLocator);
+    Locators locators_begin(locator_list.begin());
+    Locators locators_end(locator_list.end());
+
     // Then
     std::vector<octet> receiveBufferWrongSize(descriptor.sendBufferSize + 1);
     ASSERT_FALSE(send_resource_list.at(0)->send(receiveBufferWrongSize.data(), (uint32_t)receiveBufferWrongSize.size(),
-                destinationLocator, std::chrono::microseconds(100)));
+                locators_begin, locators_end, std::chrono::microseconds(100)));
 }
 
 TEST_F(UDPv4Tests, RemoteToMainLocal_simply_strips_out_address_leaving_IP_ANY)
@@ -294,10 +309,15 @@ TEST_F(UDPv4Tests, send_to_wrong_interface)
     ASSERT_TRUE(transportUnderTest.OpenOutputChannel(send_resource_list, outputChannelLocator));
     ASSERT_FALSE(send_resource_list.empty());
 
+    LocatorList_t locator_list;
+    locator_list.push_back(Locator_t());
+    Locators locators_begin(locator_list.begin());
+    Locators locators_end(locator_list.end());
+
     //Sending through a different IP will NOT work, except 0.0.0.0
     IPLocator::setIPv4(outputChannelLocator, 111, 111, 111, 111);
     std::vector<octet> message = { 'H','e','l','l','o' };
-    ASSERT_FALSE(send_resource_list.at(0)->send(message.data(), (uint32_t)message.size(), Locator_t(), std::chrono::microseconds(100)));
+    ASSERT_FALSE(send_resource_list.at(0)->send(message.data(), (uint32_t)message.size(), locators_begin, locators_end, std::chrono::microseconds(100)));
 }
 
 TEST_F(UDPv4Tests, send_to_blocked_interface)
@@ -349,10 +369,15 @@ TEST_F(UDPv4Tests, send_to_allowed_interface)
             remoteMulticastLocator.kind = LOCATOR_KIND_UDPv4;
             IPLocator::setIPv4(remoteMulticastLocator, 239, 255, 1, 4); // Loopback
 
+            LocatorList_t locator_list;
+            locator_list.push_back(remoteMulticastLocator);
+            Locators locators_begin(locator_list.begin());
+            Locators locators_end(locator_list.end());
+
             // Sending through a ALLOWED IP will work
             std::vector<octet> message = { 'H','e','l','l','o' };
             ASSERT_TRUE(send_resource_list.at(0)->send(message.data(), (uint32_t)message.size(),
-                        remoteMulticastLocator, std::chrono::microseconds(100)));
+                        locators_begin, locators_end, std::chrono::microseconds(100)));
         }
     }
 }
@@ -384,6 +409,11 @@ TEST_F(UDPv4Tests, send_and_receive_between_allowed_sockets_using_localhost)
     unicastLocator.kind = LOCATOR_KIND_UDPv4;
     IPLocator::setIPv4(unicastLocator, "127.0.0.1");
 
+    LocatorList_t locator_list;
+    locator_list.push_back(unicastLocator);
+    Locators locators_begin(locator_list.begin());
+    Locators locators_end(locator_list.end());
+
     Locator_t outputChannelLocator;
     outputChannelLocator.port = g_default_port + 1;
     outputChannelLocator.kind = LOCATOR_KIND_UDPv4;
@@ -409,7 +439,7 @@ TEST_F(UDPv4Tests, send_and_receive_between_allowed_sockets_using_localhost)
 
     auto sendThreadFunction = [&]()
     {
-        EXPECT_TRUE(send_resource_list.at(0)->send(message, 5, unicastLocator, std::chrono::microseconds(100)));
+        EXPECT_TRUE(send_resource_list.at(0)->send(message, 5, locators_begin, locators_end, std::chrono::microseconds(100)));
     };
 
     senderThread.reset(new std::thread(sendThreadFunction));
@@ -435,6 +465,11 @@ TEST_F(UDPv4Tests, send_and_receive_between_allowed_sockets_using_unicast)
     unicastLocator.kind = LOCATOR_KIND_UDPv4;
     IPLocator::setIPv4(unicastLocator, interfaces.at(0).name);
 
+    LocatorList_t locator_list;
+    locator_list.push_back(unicastLocator);
+    Locators locators_begin(locator_list.begin());
+    Locators locators_end(locator_list.end());
+
     Locator_t outputChannelLocator;
     outputChannelLocator.port = g_default_port + 1;
     outputChannelLocator.kind = LOCATOR_KIND_UDPv4;
@@ -460,7 +495,7 @@ TEST_F(UDPv4Tests, send_and_receive_between_allowed_sockets_using_unicast)
 
     auto sendThreadFunction = [&]()
     {
-        EXPECT_TRUE(send_resource_list.at(0)->send(message, 5, unicastLocator, std::chrono::microseconds(100)));
+        EXPECT_TRUE(send_resource_list.at(0)->send(message, 5, locators_begin, locators_end, std::chrono::microseconds(100)));
     };
 
     senderThread.reset(new std::thread(sendThreadFunction));
@@ -486,6 +521,11 @@ TEST_F(UDPv4Tests, send_and_receive_between_allowed_sockets_using_unicast_to_mul
     unicastLocator.kind = LOCATOR_KIND_UDPv4;
     IPLocator::setIPv4(unicastLocator, "239.255.1.4");
 
+    LocatorList_t locator_list;
+    locator_list.push_back(unicastLocator);
+    Locators locators_begin(locator_list.begin());
+    Locators locators_end(locator_list.end());
+
     Locator_t outputChannelLocator;
     outputChannelLocator.port = g_default_port + 1;
     outputChannelLocator.kind = LOCATOR_KIND_UDPv4;
@@ -511,7 +551,7 @@ TEST_F(UDPv4Tests, send_and_receive_between_allowed_sockets_using_unicast_to_mul
 
     auto sendThreadFunction = [&]()
     {
-        EXPECT_TRUE(send_resource_list.at(0)->send(message, 5, unicastLocator, std::chrono::microseconds(100)));
+        EXPECT_TRUE(send_resource_list.at(0)->send(message, 5, locators_begin, locators_end, std::chrono::microseconds(100)));
     };
 
     senderThread.reset(new std::thread(sendThreadFunction));

--- a/test/unittest/transport/UDPv4Tests.cpp
+++ b/test/unittest/transport/UDPv4Tests.cpp
@@ -170,7 +170,8 @@ TEST_F(UDPv4Tests, send_and_receive_between_ports)
         Locators locators_begin(locator_list.begin());
         Locators locators_end(locator_list.end());
 
-        EXPECT_TRUE(send_resource_list.at(0)->send(message, 5, locators_begin, locators_end, std::chrono::microseconds(100)));
+        EXPECT_TRUE(send_resource_list.at(0)->send(message, 5, locators_begin, locators_end, 
+            (std::chrono::steady_clock::now()+ std::chrono::microseconds(100))));
     };
 
     senderThread.reset(new std::thread(sendThreadFunction));
@@ -219,7 +220,8 @@ TEST_F(UDPv4Tests, send_to_loopback)
         Locators locators_begin(locator_list.begin());
         Locators locators_end(locator_list.end());
 
-        EXPECT_TRUE(send_resource_list.at(0)->send(message, 5, locators_begin, locators_end, std::chrono::microseconds(100)));
+        EXPECT_TRUE(send_resource_list.at(0)->send(message, 5, locators_begin, locators_end, 
+            (std::chrono::steady_clock::now()+ std::chrono::microseconds(100))));
     };
 
     senderThread.reset(new std::thread(sendThreadFunction));
@@ -254,7 +256,7 @@ TEST_F(UDPv4Tests, send_is_rejected_if_buffer_size_is_bigger_to_size_specified_i
     // Then
     std::vector<octet> receiveBufferWrongSize(descriptor.sendBufferSize + 1);
     ASSERT_FALSE(send_resource_list.at(0)->send(receiveBufferWrongSize.data(), (uint32_t)receiveBufferWrongSize.size(),
-                locators_begin, locators_end, std::chrono::microseconds(100)));
+                locators_begin, locators_end, (std::chrono::steady_clock::now()+ std::chrono::microseconds(100))));
 }
 
 TEST_F(UDPv4Tests, RemoteToMainLocal_simply_strips_out_address_leaving_IP_ANY)
@@ -317,7 +319,8 @@ TEST_F(UDPv4Tests, send_to_wrong_interface)
     //Sending through a different IP will NOT work, except 0.0.0.0
     IPLocator::setIPv4(outputChannelLocator, 111, 111, 111, 111);
     std::vector<octet> message = { 'H','e','l','l','o' };
-    ASSERT_FALSE(send_resource_list.at(0)->send(message.data(), (uint32_t)message.size(), locators_begin, locators_end, std::chrono::microseconds(100)));
+    ASSERT_FALSE(send_resource_list.at(0)->send(message.data(), (uint32_t)message.size(), locators_begin, locators_end, 
+        (std::chrono::steady_clock::now()+ std::chrono::microseconds(100))));
 }
 
 TEST_F(UDPv4Tests, send_to_blocked_interface)
@@ -377,7 +380,7 @@ TEST_F(UDPv4Tests, send_to_allowed_interface)
             // Sending through a ALLOWED IP will work
             std::vector<octet> message = { 'H','e','l','l','o' };
             ASSERT_TRUE(send_resource_list.at(0)->send(message.data(), (uint32_t)message.size(),
-                        locators_begin, locators_end, std::chrono::microseconds(100)));
+                        locators_begin, locators_end, (std::chrono::steady_clock::now()+ std::chrono::microseconds(100))));
         }
     }
 }
@@ -439,7 +442,8 @@ TEST_F(UDPv4Tests, send_and_receive_between_allowed_sockets_using_localhost)
 
     auto sendThreadFunction = [&]()
     {
-        EXPECT_TRUE(send_resource_list.at(0)->send(message, 5, locators_begin, locators_end, std::chrono::microseconds(100)));
+        EXPECT_TRUE(send_resource_list.at(0)->send(message, 5, locators_begin, locators_end, 
+            (std::chrono::steady_clock::now()+ std::chrono::microseconds(100))));
     };
 
     senderThread.reset(new std::thread(sendThreadFunction));
@@ -495,7 +499,8 @@ TEST_F(UDPv4Tests, send_and_receive_between_allowed_sockets_using_unicast)
 
     auto sendThreadFunction = [&]()
     {
-        EXPECT_TRUE(send_resource_list.at(0)->send(message, 5, locators_begin, locators_end, std::chrono::microseconds(100)));
+        EXPECT_TRUE(send_resource_list.at(0)->send(message, 5, locators_begin, locators_end, 
+            (std::chrono::steady_clock::now()+ std::chrono::microseconds(100))));
     };
 
     senderThread.reset(new std::thread(sendThreadFunction));
@@ -551,7 +556,8 @@ TEST_F(UDPv4Tests, send_and_receive_between_allowed_sockets_using_unicast_to_mul
 
     auto sendThreadFunction = [&]()
     {
-        EXPECT_TRUE(send_resource_list.at(0)->send(message, 5, locators_begin, locators_end, std::chrono::microseconds(100)));
+        EXPECT_TRUE(send_resource_list.at(0)->send(message, 5, locators_begin, locators_end, 
+            (std::chrono::steady_clock::now()+ std::chrono::microseconds(100))));
     };
 
     senderThread.reset(new std::thread(sendThreadFunction));


### PR DESCRIPTION
This is important for shared-memory-transport because only one copy has to be done, so instead calling send one time per destination locator only one call is made passing a LocatorsIterator reference.