### PR TITLE
[1.9.x] Use cache change pool when DYNAMIC_RESERVE [7020]

### DIFF
--- a/include/fastrtps/rtps/history/CacheChangePool.h
+++ b/include/fastrtps/rtps/history/CacheChangePool.h
@@ -81,6 +81,9 @@ class CacheChangePool {
         //!Get the initial payload size associated with the Pool.
         inline uint32_t getInitialPayloadSize(){return m_initial_payload_size;};
     private:
+        //! Returns a CacheChange to the free caches pool
+        void return_cache_to_pool(CacheChange_t* ch);
+
         uint32_t m_initial_payload_size;
         uint32_t m_payload_size;
         uint32_t m_pool_size;

--- a/include/fastrtps/rtps/resources/ResourceManagement.h
+++ b/include/fastrtps/rtps/resources/ResourceManagement.h
@@ -30,9 +30,10 @@ namespace rtps{
  */
 
 typedef enum MemoryManagementPolicy{
-    PREALLOCATED_MEMORY_MODE, //!< Preallocated memory. Size set to the data type maximum. Largest memory footprint but smalles allocation count.
+    PREALLOCATED_MEMORY_MODE, //!< Preallocated memory. Size set to the data type maximum. Largest memory footprint but smallest allocation count.
     PREALLOCATED_WITH_REALLOC_MEMORY_MODE, //!< Default size preallocated, requires reallocation when a bigger message arrives. Smaller memory footprint at the cost of an increased allocation count.
-    DYNAMIC_RESERVE_MEMORY_MODE //< Dynamic allocation at the time of message arrival. Least memory footprint but highest allocation count.
+    DYNAMIC_RESERVE_MEMORY_MODE, //< Dynamic allocation at the time of message arrival. Least memory footprint but highest allocation count.
+    DYNAMIC_REUSABLE_MEMORY_MODE //< Like DYNAMIC_RESERVE_MEMORY_MODE but allocated memory is reused for future messages. Smaller allocation count at the cost of an increased memory footprint.
 }MemoryManagementPolicy_t;
 
 

--- a/include/fastrtps/xmlparser/XMLParserCommon.h
+++ b/include/fastrtps/xmlparser/XMLParserCommon.h
@@ -139,6 +139,7 @@ extern const char* PROPAGATE;
 extern const char* PREALLOCATED;
 extern const char* PREALLOCATED_WITH_REALLOC;
 extern const char* DYNAMIC;
+extern const char* DYNAMIC_REUSABLE;
 extern const char* LOCATOR;
 extern const char* UDPv4_LOCATOR;
 extern const char* UDPv6_LOCATOR;

--- a/resources/xsd/fastRTPS_profiles.xsd
+++ b/resources/xsd/fastRTPS_profiles.xsd
@@ -50,6 +50,7 @@
             <xs:enumeration value="PREALLOCATED"/>
             <xs:enumeration value="PREALLOCATED_WITH_REALLOC"/>
             <xs:enumeration value="DYNAMIC"/>
+            <xs:enumeration value="DYNAMIC_REUSABLE"/>
         </xs:restriction>
     </xs:simpleType>
 

--- a/src/cpp/rtps/history/CacheChangePool.cpp
+++ b/src/cpp/rtps/history/CacheChangePool.cpp
@@ -22,7 +22,7 @@
 #include <fastrtps/log/Log.h>
 
 #include <mutex>
-
+#include <cstring>
 #include <cassert>
 
 
@@ -213,8 +213,7 @@ void CacheChangePool::return_cache_to_pool(CacheChange_t* ch)
     ch->writerGUID = c_Guid_Unknown;
     ch->serializedPayload.length = 0;
     ch->serializedPayload.pos = 0;
-    for(uint8_t i=0;i<16;++i)
-        ch->instanceHandle.value[i] = 0;
+    memset(ch->instanceHandle.value, 0, 16);
     ch->isRead = 0;
     ch->sourceTimestamp.seconds(0);
     ch->sourceTimestamp.fraction(0);

--- a/src/cpp/rtps/history/CacheChangePool.cpp
+++ b/src/cpp/rtps/history/CacheChangePool.cpp
@@ -109,8 +109,7 @@ bool CacheChangePool::reserve_Cache(CacheChange_t** chan, uint32_t dataSize)
                     return false;
                 }
             }
-            *chan = m_freeCaches.back();
-            m_freeCaches.erase(m_freeCaches.end()-1);
+            *chan = m_freeCaches.pop_back();
             break;
 
         case PREALLOCATED_WITH_REALLOC_MEMORY_MODE:
@@ -121,8 +120,7 @@ bool CacheChangePool::reserve_Cache(CacheChange_t** chan, uint32_t dataSize)
                     return false;
                 }
             }
-            *chan = m_freeCaches.back();
-            m_freeCaches.erase(m_freeCaches.end()-1);
+            *chan = m_freeCaches.pop_back();
 
             // TODO(Ricardo) Improve reallocation.
             try
@@ -154,8 +152,7 @@ bool CacheChangePool::reserve_Cache(CacheChange_t** chan, uint32_t dataSize)
             }
             else
             {
-                *chan = m_freeCaches.back();
-                m_freeCaches.erase(m_freeCaches.end()-1);
+                *chan = m_freeCaches.pop_back();
                 // TODO(Ricardo) Improve reallocation.
                 try
                 {

--- a/src/cpp/rtps/history/CacheChangePool.cpp
+++ b/src/cpp/rtps/history/CacheChangePool.cpp
@@ -109,7 +109,8 @@ bool CacheChangePool::reserve_Cache(CacheChange_t** chan, uint32_t dataSize)
                     return false;
                 }
             }
-            *chan = m_freeCaches.pop_back();
+            *chan = m_freeCaches.back();
+            m_freeCaches.pop_back();
             break;
 
         case PREALLOCATED_WITH_REALLOC_MEMORY_MODE:
@@ -120,7 +121,8 @@ bool CacheChangePool::reserve_Cache(CacheChange_t** chan, uint32_t dataSize)
                     return false;
                 }
             }
-            *chan = m_freeCaches.pop_back();
+            *chan = m_freeCaches.back();
+            m_freeCaches.pop_back();
 
             // TODO(Ricardo) Improve reallocation.
             try
@@ -152,7 +154,8 @@ bool CacheChangePool::reserve_Cache(CacheChange_t** chan, uint32_t dataSize)
             }
             else
             {
-                *chan = m_freeCaches.pop_back();
+                *chan = m_freeCaches.back();
+                m_freeCaches.pop_back();
                 // TODO(Ricardo) Improve reallocation.
                 try
                 {

--- a/src/cpp/rtps/history/CacheChangePool.cpp
+++ b/src/cpp/rtps/history/CacheChangePool.cpp
@@ -70,11 +70,14 @@ CacheChangePool::CacheChangePool(int32_t pool_size, uint32_t payload_size, int32
             allocateGroup(pool_size);
             break;
         case PREALLOCATED_WITH_REALLOC_MEMORY_MODE:
-            logInfo(RTPS_UTILS,"Semi-Dynamic Mode is active, preallocating memory for pool_size. Size of the cachechanges can be increased");
+            logInfo(RTPS_UTILS,"Semi-Static Mode is active, preallocating memory for pool_size. Size of the cachechanges can be increased");
             allocateGroup(pool_size);
             break;
         case DYNAMIC_RESERVE_MEMORY_MODE:
             logInfo(RTPS_UTILS,"Dynamic Mode is active, CacheChanges are allocated on request");
+            break;
+        case DYNAMIC_REUSABLE_MEMORY_MODE:
+            logInfo(RTPS_UTILS,"Semi-Dynamic Mode is active, no preallocation but dynamically allocated CacheChanges are reused for future cachechanges");
             break;
     }
 }
@@ -133,12 +136,39 @@ bool CacheChangePool::reserve_Cache(CacheChange_t** chan, uint32_t dataSize)
                 *chan = nullptr;
                 return false;
             }
-
             break;
 
         case DYNAMIC_RESERVE_MEMORY_MODE:
             *chan = allocateSingle(dataSize); //Allocates a single, empty CacheChange. Allocated on Copy
             if(*chan == nullptr) return false;
+            break;
+
+        case DYNAMIC_REUSABLE_MEMORY_MODE:
+            if(m_freeCaches.empty())
+            {
+                *chan = allocateSingle(dataSize); //Allocates a single, empty CacheChange, only if none free
+                if(*chan == nullptr)
+                {
+                    return false;
+                }
+            }
+            else
+            {
+                *chan = m_freeCaches.back();
+                m_freeCaches.erase(m_freeCaches.end()-1);
+                // TODO(Ricardo) Improve reallocation.
+                try
+                {
+                    (*chan)->serializedPayload.reserve(dataSize);
+                }
+                catch(std::bad_alloc& ex)
+                {
+                    logError(RTPS_HISTORY, "Failed to allocate memory for the serializedPayload, exception caught: " << ex.what());
+                    delete(*chan);
+                    *chan = nullptr;
+                    return false;
+                }
+            }
             break;
     }
 
@@ -150,34 +180,13 @@ void CacheChangePool::release_Cache(CacheChange_t* ch)
     switch(memoryMode)
     {
         case PREALLOCATED_MEMORY_MODE:
-            ch->kind = ALIVE;
-            ch->sequenceNumber.high = 0;
-            ch->sequenceNumber.low = 0;
-            ch->writerGUID = c_Guid_Unknown;
-            ch->serializedPayload.length = 0;
-            ch->serializedPayload.pos = 0;
-            for(uint8_t i=0;i<16;++i)
-                ch->instanceHandle.value[i] = 0;
-            ch->isRead = 0;
-            ch->sourceTimestamp.seconds(0);
-            ch->sourceTimestamp.fraction(0);
-            ch->setFragmentSize(0);
-            m_freeCaches.push_back(ch);
+            return_cache_to_pool(ch);
             break;
         case PREALLOCATED_WITH_REALLOC_MEMORY_MODE:
-            ch->kind = ALIVE;
-            ch->sequenceNumber.high = 0;
-            ch->sequenceNumber.low = 0;
-            ch->writerGUID = c_Guid_Unknown;
-            ch->serializedPayload.length = 0;
-            ch->serializedPayload.pos = 0;
-            for(uint8_t i=0;i<16;++i)
-                ch->instanceHandle.value[i] = 0;
-            ch->isRead = 0;
-            ch->sourceTimestamp.seconds(0);
-            ch->sourceTimestamp.fraction(0);
-            ch->setFragmentSize(0);
-            m_freeCaches.push_back(ch);
+            return_cache_to_pool(ch);
+            break;
+        case DYNAMIC_REUSABLE_MEMORY_MODE:
+            return_cache_to_pool(ch);
             break;
         case DYNAMIC_RESERVE_MEMORY_MODE:
             // Find pointer in CacheChange vector, remove element, then delete it
@@ -193,14 +202,31 @@ void CacheChangePool::release_Cache(CacheChange_t* ch)
             delete(ch);
             --m_pool_size;
             break;
-
     }
+}
+
+void CacheChangePool::return_cache_to_pool(CacheChange_t* ch)
+{
+    ch->kind = ALIVE;
+    ch->sequenceNumber.high = 0;
+    ch->sequenceNumber.low = 0;
+    ch->writerGUID = c_Guid_Unknown;
+    ch->serializedPayload.length = 0;
+    ch->serializedPayload.pos = 0;
+    for(uint8_t i=0;i<16;++i)
+        ch->instanceHandle.value[i] = 0;
+    ch->isRead = 0;
+    ch->sourceTimestamp.seconds(0);
+    ch->sourceTimestamp.fraction(0);
+    ch->setFragmentSize(0);
+    m_freeCaches.push_back(ch);
 }
 
 bool CacheChangePool::allocateGroup(uint32_t group_size)
 {
-    // This method should only called from within PREALLOCATED_MEMORY_MODE
-    assert(memoryMode != DYNAMIC_RESERVE_MEMORY_MODE);
+    // This method should only called from within PREALLOCATED_MEMORY_MODE or PREALLOCATED_WITH_REALLOC_MEMORY_MODE
+    assert(memoryMode == PREALLOCATED_MEMORY_MODE ||
+            memoryMode == PREALLOCATED_WITH_REALLOC_MEMORY_MODE);
 
     logInfo(RTPS_UTILS,"Allocating group of cache changes of size: "<< group_size);
     bool added = false;
@@ -248,10 +274,11 @@ CacheChange_t* CacheChangePool::allocateSingle(uint32_t dataSize)
     bool added = false;
     CacheChange_t*ch = nullptr;
 
-    // This method should only be called from within DYNAMIC_RESERVE_MEMORY_MODE
-    assert(memoryMode == DYNAMIC_RESERVE_MEMORY_MODE);
+    // This method should only be called from within DYNAMIC_RESERVE_MEMORY_MODE or DYNAMIC_REUSABLE_MEMORY_MODE
+    assert(memoryMode == DYNAMIC_RESERVE_MEMORY_MODE ||
+            memoryMode == DYNAMIC_REUSABLE_MEMORY_MODE);
 
-    if((m_max_pool_size == 0) | (m_pool_size < m_max_pool_size)) { //If no limit or curren changes < max changes
+    if((m_max_pool_size == 0) | (m_pool_size < m_max_pool_size)) { //If no limit or current changes < max changes
         ++m_pool_size;
         ch = new CacheChange_t(dataSize);
         m_allCaches.push_back(ch);

--- a/src/cpp/rtps/history/CacheChangePool.cpp
+++ b/src/cpp/rtps/history/CacheChangePool.cpp
@@ -27,69 +27,86 @@
 
 
 namespace eprosima {
-namespace fastrtps{
+namespace fastrtps {
 namespace rtps {
 
 
 CacheChangePool::~CacheChangePool()
 {
-    logInfo(RTPS_UTILS,"ChangePool destructor");
+    logInfo(RTPS_UTILS, "ChangePool destructor");
     //Deletion process does not depend on the memory management policy
-    for(std::vector<CacheChange_t*>::iterator it = m_allCaches.begin();it!=m_allCaches.end();++it)
+    for (std::vector<CacheChange_t*>::iterator it = m_allCaches.begin(); it != m_allCaches.end(); ++it)
     {
         delete(*it);
     }
 }
 
-CacheChangePool::CacheChangePool(int32_t pool_size, uint32_t payload_size, int32_t max_pool_size, MemoryManagementPolicy_t memoryPolicy) :
-    memoryMode(memoryPolicy)
+CacheChangePool::CacheChangePool(
+        int32_t pool_size,
+        uint32_t payload_size,
+        int32_t max_pool_size,
+        MemoryManagementPolicy_t memoryPolicy)
+    : memoryMode(memoryPolicy)
 {
     //Common for all modes: Set the payload size (maximum allowed), size and size limit
     ++pool_size;
-    logInfo(RTPS_UTILS,"Creating CacheChangePool of size: "<< pool_size << " with payload of size: " << payload_size);
+    logInfo(RTPS_UTILS, 
+            "Creating CacheChangePool of size: " << pool_size << " with payload of size: " << payload_size);
 
     m_payload_size = payload_size;
     m_initial_payload_size = payload_size;
     m_pool_size = 0;
-    if(max_pool_size > 0)
+    if (max_pool_size > 0)
     {
         if (pool_size > max_pool_size)
         {
             m_max_pool_size = (uint32_t)abs(pool_size);
         }
         else
+        {
             m_max_pool_size = (uint32_t)abs(max_pool_size + 1);
+        }
     }
     else
+    {
         m_max_pool_size = 0;
+    }
 
-    switch(memoryMode)
+    switch (memoryMode)
     {
         case PREALLOCATED_MEMORY_MODE:
-            logInfo(RTPS_UTILS,"Static Mode is active, preallocating memory for pool_size elements");
+            logInfo(RTPS_UTILS, "Static Mode is active, preallocating memory for pool_size elements");
             allocateGroup(pool_size);
             break;
         case PREALLOCATED_WITH_REALLOC_MEMORY_MODE:
-            logInfo(RTPS_UTILS,"Semi-Static Mode is active, preallocating memory for pool_size. Size of the cachechanges can be increased");
+            logInfo(RTPS_UTILS,
+                    "Semi-Static Mode is active, preallocating memory for pool_size. "
+                    "Size of the cachechanges can be increased");
             allocateGroup(pool_size);
             break;
         case DYNAMIC_RESERVE_MEMORY_MODE:
-            logInfo(RTPS_UTILS,"Dynamic Mode is active, CacheChanges are allocated on request");
+            logInfo(RTPS_UTILS, "Dynamic Mode is active, CacheChanges are allocated on request");
             break;
         case DYNAMIC_REUSABLE_MEMORY_MODE:
-            logInfo(RTPS_UTILS,"Semi-Dynamic Mode is active, no preallocation but dynamically allocated CacheChanges are reused for future cachechanges");
+            logInfo(RTPS_UTILS,
+                    "Semi-Dynamic Mode is active, no preallocation but dynamically allocated CacheChanges "
+                    "are reused for future cachechanges");
             break;
     }
 }
 
-bool CacheChangePool::reserve_Cache(CacheChange_t** chan, const std::function<uint32_t()>& calculateSizeFunc)
+bool CacheChangePool::reserve_Cache(
+        CacheChange_t** chan,
+        const std::function<uint32_t()>& calculateSizeFunc)
 {
     uint32_t dataSize = 0;
 
-    if(memoryMode != PREALLOCATED_MEMORY_MODE)
+    if (memoryMode != PREALLOCATED_MEMORY_MODE)
+    {
         dataSize = calculateSizeFunc();
+    }
 
-    if(reserve_Cache(chan, dataSize))
+    if (reserve_Cache(chan, dataSize))
     {
         return true;
     }
@@ -97,12 +114,14 @@ bool CacheChangePool::reserve_Cache(CacheChange_t** chan, const std::function<ui
     return false;
 }
 
-bool CacheChangePool::reserve_Cache(CacheChange_t** chan, uint32_t dataSize)
+bool CacheChangePool::reserve_Cache(
+        CacheChange_t** chan,
+        uint32_t dataSize)
 {
-    switch(memoryMode)
+    switch (memoryMode)
     {
         case PREALLOCATED_MEMORY_MODE:
-            if(m_freeCaches.empty())
+            if (m_freeCaches.empty())
             {
                 if (!allocateGroup((uint16_t)(ceil((float)m_pool_size / 10) + 10)))
                 {
@@ -114,7 +133,7 @@ bool CacheChangePool::reserve_Cache(CacheChange_t** chan, uint32_t dataSize)
             break;
 
         case PREALLOCATED_WITH_REALLOC_MEMORY_MODE:
-            if(m_freeCaches.empty())
+            if (m_freeCaches.empty())
             {
                 if (!allocateGroup((uint16_t)(ceil((float)m_pool_size / 10) + 10)))
                 {
@@ -129,9 +148,10 @@ bool CacheChangePool::reserve_Cache(CacheChange_t** chan, uint32_t dataSize)
             {
                 (*chan)->serializedPayload.reserve(dataSize);
             }
-            catch(std::bad_alloc& ex)
+            catch (std::bad_alloc& ex)
             {
-                logError(RTPS_HISTORY, "Failed to allocate memory for the serializedPayload, exception caught: " << ex.what());
+                logError(RTPS_HISTORY,
+                        "Failed to allocate memory for the serializedPayload, exception caught: " << ex.what());
                 delete(*chan);
                 *chan = nullptr;
                 return false;
@@ -140,14 +160,17 @@ bool CacheChangePool::reserve_Cache(CacheChange_t** chan, uint32_t dataSize)
 
         case DYNAMIC_RESERVE_MEMORY_MODE:
             *chan = allocateSingle(dataSize); //Allocates a single, empty CacheChange. Allocated on Copy
-            if(*chan == nullptr) return false;
+            if (*chan == nullptr)
+            {
+                return false;
+            }
             break;
 
         case DYNAMIC_REUSABLE_MEMORY_MODE:
-            if(m_freeCaches.empty())
+            if (m_freeCaches.empty())
             {
                 *chan = allocateSingle(dataSize); //Allocates a single, empty CacheChange, only if none free
-                if(*chan == nullptr)
+                if (*chan == nullptr)
                 {
                     return false;
                 }
@@ -161,9 +184,11 @@ bool CacheChangePool::reserve_Cache(CacheChange_t** chan, uint32_t dataSize)
                 {
                     (*chan)->serializedPayload.reserve(dataSize);
                 }
-                catch(std::bad_alloc& ex)
+                catch (std::bad_alloc& ex)
                 {
-                    logError(RTPS_HISTORY, "Failed to allocate memory for the serializedPayload, exception caught: " << ex.what());
+                    logError(RTPS_HISTORY,
+                            "Failed to allocate memory for the serializedPayload, exception caught: " <<
+                            ex.what());
                     delete(*chan);
                     *chan = nullptr;
                     return false;
@@ -175,9 +200,10 @@ bool CacheChangePool::reserve_Cache(CacheChange_t** chan, uint32_t dataSize)
     return true;
 }
 
-void CacheChangePool::release_Cache(CacheChange_t* ch)
+void CacheChangePool::release_Cache(
+        CacheChange_t* ch)
 {
-    switch(memoryMode)
+    switch (memoryMode)
     {
         case PREALLOCATED_MEMORY_MODE:
             return_cache_to_pool(ch);
@@ -191,12 +217,14 @@ void CacheChangePool::release_Cache(CacheChange_t* ch)
         case DYNAMIC_RESERVE_MEMORY_MODE:
             // Find pointer in CacheChange vector, remove element, then delete it
             std::vector<CacheChange_t*>::iterator target = m_allCaches.begin();
-            target = find(m_allCaches.begin(),m_allCaches.end(), ch);
-            if(target != m_allCaches.end())
+            target = find(m_allCaches.begin(), m_allCaches.end(), ch);
+            if (target != m_allCaches.end())
             {
                 m_allCaches.erase(target);
-            }else{
-                logInfo(RTPS_UTILS,"Tried to release a CacheChange that is not logged in the Pool");
+            }
+            else
+            {
+                logInfo(RTPS_UTILS, "Tried to release a CacheChange that is not logged in the Pool");
                 break;
             }
             delete(ch);
@@ -205,7 +233,8 @@ void CacheChangePool::release_Cache(CacheChange_t* ch)
     }
 }
 
-void CacheChangePool::return_cache_to_pool(CacheChange_t* ch)
+void CacheChangePool::return_cache_to_pool(
+        CacheChange_t* ch)
 {
     ch->kind = ALIVE;
     ch->sequenceNumber.high = 0;
@@ -221,17 +250,20 @@ void CacheChangePool::return_cache_to_pool(CacheChange_t* ch)
     m_freeCaches.push_back(ch);
 }
 
-bool CacheChangePool::allocateGroup(uint32_t group_size)
+bool CacheChangePool::allocateGroup(
+        uint32_t group_size)
 {
     // This method should only called from within PREALLOCATED_MEMORY_MODE or PREALLOCATED_WITH_REALLOC_MEMORY_MODE
     assert(memoryMode == PREALLOCATED_MEMORY_MODE ||
             memoryMode == PREALLOCATED_WITH_REALLOC_MEMORY_MODE);
 
-    logInfo(RTPS_UTILS,"Allocating group of cache changes of size: "<< group_size);
+    logInfo(RTPS_UTILS, "Allocating group of cache changes of size: " << group_size);
     bool added = false;
     uint32_t reserved = 0;
     if (m_max_pool_size == 0)
+    {
         reserved = group_size;
+    }
     else
     {
         if (m_pool_size + group_size > m_max_pool_size)
@@ -243,7 +275,7 @@ bool CacheChangePool::allocateGroup(uint32_t group_size)
             reserved = group_size;
         }
     }
-    for(uint32_t i = 0; i < reserved; ++i)
+    for (uint32_t i = 0; i < reserved; ++i)
     {
         CacheChange_t* ch = new CacheChange_t(m_payload_size);
         m_allCaches.push_back(ch);
@@ -252,12 +284,15 @@ bool CacheChangePool::allocateGroup(uint32_t group_size)
         added = true;
     }
     if (!added)
+    {
         logWarning(RTPS_HISTORY, "Maximum number of allowed reserved caches reached");
+    }
     //logInfo(RTPS_UTILS,"Finish allocating CacheChange_t");
     return added;
 }
 
-CacheChange_t* CacheChangePool::allocateSingle(uint32_t dataSize)
+CacheChange_t* CacheChangePool::allocateSingle(
+        uint32_t dataSize)
 {
     /*
      *   In Dynamic Memory Mode CacheChanges are only allocated when they are needed.
@@ -271,20 +306,21 @@ CacheChange_t* CacheChangePool::allocateSingle(uint32_t dataSize)
      *
      */
     bool added = false;
-    CacheChange_t*ch = nullptr;
+    CacheChange_t* ch = nullptr;
 
     // This method should only be called from within DYNAMIC_RESERVE_MEMORY_MODE or DYNAMIC_REUSABLE_MEMORY_MODE
     assert(memoryMode == DYNAMIC_RESERVE_MEMORY_MODE ||
             memoryMode == DYNAMIC_REUSABLE_MEMORY_MODE);
 
-    if((m_max_pool_size == 0) | (m_pool_size < m_max_pool_size)) { //If no limit or current changes < max changes
+    if ((m_max_pool_size == 0) | (m_pool_size < m_max_pool_size))  //If no limit or current changes < max changes
+    {
         ++m_pool_size;
         ch = new CacheChange_t(dataSize);
         m_allCaches.push_back(ch);
         added = true;
     }
 
-    if(!added)
+    if (!added)
     {
         logWarning(RTPS_HISTORY, "Maximum number of allowed reserved caches reached");
         return NULL;
@@ -293,6 +329,6 @@ CacheChange_t* CacheChangePool::allocateSingle(uint32_t dataSize)
     return ch;
 }
 
-}
 } /* namespace rtps */
+} /* namespace fastrtps */
 } /* namespace eprosima */

--- a/src/cpp/rtps/writer/RTPSWriter.cpp
+++ b/src/cpp/rtps/writer/RTPSWriter.cpp
@@ -221,8 +221,7 @@ bool RTPSWriter::encrypt_cachechange(
                 // In future v2 changepool is in writer, and writer set this value to cachechagepool.
                 +20 /*SecureDataHeader*/ + 4 + ((2 * 16) /*EVP_MAX_IV_LENGTH max block size*/ - 1) /* SecureDataBodey*/
                 + 16 + 4 /*SecureDataTag*/ &&
-                (mp_history->m_att.memoryPolicy == MemoryManagementPolicy_t::PREALLOCATED_WITH_REALLOC_MEMORY_MODE ||
-                mp_history->m_att.memoryPolicy == MemoryManagementPolicy_t::DYNAMIC_RESERVE_MEMORY_MODE))
+                (mp_history->m_att.memoryPolicy != MemoryManagementPolicy_t::PREALLOCATED_MEMORY_MODE))
         {
             encrypt_payload_.data = (octet*)realloc(encrypt_payload_.data, change->serializedPayload.length +
                             // In future v2 changepool is in writer, and writer set this value to cachechagepool.

--- a/src/cpp/xmlparser/XMLElementParser.cpp
+++ b/src/cpp/xmlparser/XMLElementParser.cpp
@@ -2320,6 +2320,8 @@ XMLP_ret XMLParser::getXMLHistoryMemoryPolicy(tinyxml2::XMLElement *elem,
         historyMemoryPolicy = MemoryManagementPolicy::PREALLOCATED_WITH_REALLOC_MEMORY_MODE;
     else if (strcmp(text, DYNAMIC) == 0)
         historyMemoryPolicy = MemoryManagementPolicy::DYNAMIC_RESERVE_MEMORY_MODE;
+    else if (strcmp(text, DYNAMIC_REUSABLE) == 0)
+        historyMemoryPolicy = MemoryManagementPolicy::DYNAMIC_REUSABLE_MEMORY_MODE;
     else
     {
         logError(XMLPARSER, "Node '" << KIND << "' bad content");

--- a/src/cpp/xmlparser/XMLParserCommon.cpp
+++ b/src/cpp/xmlparser/XMLParserCommon.cpp
@@ -121,6 +121,7 @@ const char* PROPAGATE = "propagate";
 const char* PREALLOCATED = "PREALLOCATED";
 const char* PREALLOCATED_WITH_REALLOC = "PREALLOCATED_WITH_REALLOC";
 const char* DYNAMIC = "DYNAMIC";
+const char* DYNAMIC_REUSABLE = "DYNAMIC_REUSABLE";
 const char* LOCATOR = "locator";
 const char* UDPv4_LOCATOR = "udpv4";
 const char* UDPv6_LOCATOR = "udpv6";

--- a/test/unittest/rtps/history/CacheChangePoolTests.cpp
+++ b/test/unittest/rtps/history/CacheChangePoolTests.cpp
@@ -175,7 +175,7 @@ TEST_P(CacheChangePoolTests, release_cache)
             ASSERT_EQ(pool->get_allCachesSize(), 0U);
             ASSERT_EQ(pool->get_freeCachesSize(), 0U);
         }
-        if (memory_policy == MemoryManagementPolicy_t::DYNAMIC_REUSABLE_MEMORY_MODE)
+        else if (memory_policy == MemoryManagementPolicy_t::DYNAMIC_REUSABLE_MEMORY_MODE)
         {
             ASSERT_EQ(pool->get_allCachesSize(), 1U);
             ASSERT_EQ(pool->get_freeCachesSize(), 1U);
@@ -254,8 +254,8 @@ INSTANTIATE_TEST_CASE_P(
             Values(0, 10, 20, 30),
             Values(128, 256, 512, 1024),
             Values(MemoryManagementPolicy_t::PREALLOCATED_MEMORY_MODE,
-                    MemoryManagementPolicy_t::PREALLOCATED_WITH_REALLOC_MEMORY_MODE,
-                    MemoryManagementPolicy_t::DYNAMIC_RESERVE_MEMORY_MODE,
+                   MemoryManagementPolicy_t::PREALLOCATED_WITH_REALLOC_MEMORY_MODE,
+                   MemoryManagementPolicy_t::DYNAMIC_RESERVE_MEMORY_MODE,
                    MemoryManagementPolicy_t::DYNAMIC_REUSABLE_MEMORY_MODE)), );
 
 int main(int argc, char **argv)

--- a/test/unittest/rtps/history/CacheChangePoolTests.cpp
+++ b/test/unittest/rtps/history/CacheChangePoolTests.cpp
@@ -68,7 +68,8 @@ TEST_P(CacheChangePoolTests, init_pool)
     ASSERT_EQ(pool->getInitialPayloadSize(), payload_size);
 
     size_t expected_size;
-    if (memory_policy == MemoryManagementPolicy_t::DYNAMIC_RESERVE_MEMORY_MODE)
+    if (memory_policy == MemoryManagementPolicy_t::DYNAMIC_RESERVE_MEMORY_MODE ||
+            memory_policy == MemoryManagementPolicy_t::DYNAMIC_REUSABLE_MEMORY_MODE)
     {
         expected_size = 0;
     }
@@ -121,6 +122,9 @@ TEST_P(CacheChangePoolTests, reserve_cache)
             case MemoryManagementPolicy_t::DYNAMIC_RESERVE_MEMORY_MODE:
                 ASSERT_EQ(ch->serializedPayload.max_size, data_size);
                 break;
+            case MemoryManagementPolicy_t::DYNAMIC_REUSABLE_MEMORY_MODE:
+                ASSERT_EQ(ch->serializedPayload.max_size, data_size);
+                break;
         }
 
         if (max_size > 0)
@@ -152,9 +156,10 @@ TEST_P(CacheChangePoolTests, release_cache)
 
         pool->reserve_Cache(&ch, [data_size]() -> uint32_t {return data_size;});
 
-        if (memory_policy == MemoryManagementPolicy_t::DYNAMIC_RESERVE_MEMORY_MODE)
+        if (memory_policy == MemoryManagementPolicy_t::DYNAMIC_RESERVE_MEMORY_MODE ||
+                memory_policy == MemoryManagementPolicy_t::DYNAMIC_REUSABLE_MEMORY_MODE)
         {
-            ASSERT_EQ(pool->get_allCachesSize(), all_caches_size + 1U);
+            ASSERT_EQ(pool->get_allCachesSize(), 1U);
             ASSERT_EQ(pool->get_freeCachesSize(), 0U);
         }
         else
@@ -167,8 +172,13 @@ TEST_P(CacheChangePoolTests, release_cache)
 
         if (memory_policy == MemoryManagementPolicy_t::DYNAMIC_RESERVE_MEMORY_MODE)
         {
-            ASSERT_EQ(pool->get_allCachesSize(), all_caches_size);
+            ASSERT_EQ(pool->get_allCachesSize(), 0U);
             ASSERT_EQ(pool->get_freeCachesSize(), 0U);
+        }
+        if (memory_policy == MemoryManagementPolicy_t::DYNAMIC_REUSABLE_MEMORY_MODE)
+        {
+            ASSERT_EQ(pool->get_allCachesSize(), 1U);
+            ASSERT_EQ(pool->get_freeCachesSize(), 1U);
         }
         else
         {
@@ -244,8 +254,9 @@ INSTANTIATE_TEST_CASE_P(
             Values(0, 10, 20, 30),
             Values(128, 256, 512, 1024),
             Values(MemoryManagementPolicy_t::PREALLOCATED_MEMORY_MODE,
-                   MemoryManagementPolicy_t::PREALLOCATED_WITH_REALLOC_MEMORY_MODE,
-                   MemoryManagementPolicy_t::DYNAMIC_RESERVE_MEMORY_MODE)), );
+                    MemoryManagementPolicy_t::PREALLOCATED_WITH_REALLOC_MEMORY_MODE,
+                    MemoryManagementPolicy_t::DYNAMIC_RESERVE_MEMORY_MODE,
+                   MemoryManagementPolicy_t::DYNAMIC_REUSABLE_MEMORY_MODE)), );
 
 int main(int argc, char **argv)
 {


### PR DESCRIPTION
Adds a DYNAMIC_REUSABLE memory mode

This memory mode starts with an empty pool (much like DYNAMIC),
but the allocated slots for CacheChange are not freed, they are
added to the pool of free changes for future reuse insted.