### PR TITLE
[1.9.x] Not using std::set on ChangeForReader_t [7093]

### DIFF
--- a/include/fastrtps/rtps/common/CacheChange.h
+++ b/include/fastrtps/rtps/common/CacheChange.h
@@ -539,8 +539,16 @@ public:
             FragmentNumber_t base = unsent_fragments_.base();
             FragmentNumber_t max = unsent_fragments_.max();
             assert(!unsent_fragments_.is_set(base));
-            unsent_fragments_.base_update(base + 1);
-            unsent_fragments_.add(max + 1);
+
+            // Update base to first bit set
+            do
+            {
+                ++base;
+            } while (!unsent_fragments_.is_set(base));
+            unsent_fragments_.base_update(base);
+
+            // Add all possible fragments
+            unsent_fragments_.add_range(max + 1u, change_->getFragmentCount() + 1u);
         }
     }
 

--- a/include/fastrtps/rtps/common/CacheChange.h
+++ b/include/fastrtps/rtps/common/CacheChange.h
@@ -435,10 +435,8 @@ public:
     {
         if (change->getFragmentSize() != 0)
         {
-            for (uint32_t i = 1; i != change->getFragmentCount() + 1; i++)
-            {
-                unsent_fragments_.insert(i); // Indexed on 1
-            }
+            unsent_fragments_.base(1u);
+            unsent_fragments_.add_range(1u, change->getFragmentCount() + 1u);
         }
     }
 
@@ -519,35 +517,22 @@ public:
 
     FragmentNumberSet_t getUnsentFragments() const
     {
-        FragmentNumberSet_t rv;
-        auto min = unsent_fragments_.begin();
-        if (min != unsent_fragments_.end())
-        {
-            rv.base(*min);
-            for (FragmentNumber_t fn : unsent_fragments_)
-            {
-                rv.add(fn);
-            }
-        }
-
-        return rv;
+        return unsent_fragments_;
     }
 
     void markAllFragmentsAsUnsent()
     {
         if (change_ != nullptr && change_->getFragmentSize() != 0)
         {
-            for (uint32_t i = 1; i != change_->getFragmentCount() + 1; i++)
-            {
-                unsent_fragments_.insert(i); // Indexed on 1
-            }
+            unsent_fragments_.base(1u);
+            unsent_fragments_.add_range(1u, change_->getFragmentCount() + 1u);
         }
     }
 
     void markFragmentsAsSent(
             const FragmentNumber_t& sentFragment)
     {
-        unsent_fragments_.erase(sentFragment);
+        unsent_fragments_.remove(sentFragment);
     }
 
     void markFragmentsAsUnsent(
@@ -555,7 +540,7 @@ public:
     {
         unsentFragments.for_each([this](FragmentNumber_t element)
                     {
-                        unsent_fragments_.insert(element);
+                        unsent_fragments_.add(element);
                     });
     }
 
@@ -574,7 +559,7 @@ private:
     //const CacheChange_t* change_;
     CacheChange_t* change_;
 
-    std::set<FragmentNumber_t> unsent_fragments_;
+    FragmentNumberSet_t unsent_fragments_;
 };
 
 struct ChangeForReaderCmp

--- a/include/fastrtps/rtps/common/CacheChange.h
+++ b/include/fastrtps/rtps/common/CacheChange.h
@@ -533,10 +533,14 @@ public:
             const FragmentNumber_t& sentFragment)
     {
         unsent_fragments_.remove(sentFragment);
+
         if (!unsent_fragments_.empty() && unsent_fragments_.max() < change_->getFragmentCount())
         {
-            unsent_fragments_.base_update(unsent_fragments_.base() + 1);
-            unsent_fragments_.add(unsent_fragments_.max() + 1);
+            FragmentNumber_t base = unsent_fragments_.base();
+            FragmentNumber_t max = unsent_fragments_.max();
+            assert(!unsent_fragments_.is_set(base));
+            unsent_fragments_.base_update(base + 1);
+            unsent_fragments_.add(max + 1);
         }
     }
 

--- a/include/fastrtps/rtps/common/CacheChange.h
+++ b/include/fastrtps/rtps/common/CacheChange.h
@@ -533,15 +533,27 @@ public:
             const FragmentNumber_t& sentFragment)
     {
         unsent_fragments_.remove(sentFragment);
+        if (!unsent_fragments_.empty() && unsent_fragments_.max() < change_->getFragmentCount())
+        {
+            unsent_fragments_.base_update(unsent_fragments_.base() + 1);
+            unsent_fragments_.add(unsent_fragments_.max() + 1);
+        }
     }
 
     void markFragmentsAsUnsent(
             const FragmentNumberSet_t& unsentFragments)
     {
-        unsentFragments.for_each([this](FragmentNumber_t element)
-                    {
-                        unsent_fragments_.add(element);
-                    });
+        FragmentNumber_t other_base = unsentFragments.base();
+        if (other_base < unsent_fragments_.base())
+        {
+            unsent_fragments_.base_update(other_base);
+        }
+        unsentFragments.for_each(
+            [this](
+                    FragmentNumber_t element)
+            {
+                unsent_fragments_.add(element);
+            });
     }
 
 private:

--- a/include/fastrtps/utils/fixed_size_bitmap.hpp
+++ b/include/fastrtps/utils/fixed_size_bitmap.hpp
@@ -276,6 +276,33 @@ public:
     }
 
     /**
+     * Removes an element from the range.
+     * Removes an element from the bitmap.
+     *
+     * @param item   Value to be removed.
+     */
+    void remove(
+        const T& item) noexcept
+    {
+        // Check item is inside the allowed range.
+        T max_value = max();
+        if ((item >= base_) && (max_value >= item))
+        {
+            // Calc distance from base to item, and set the corresponding bit.
+            Diff d_func;
+            uint32_t diff = d_func(item, base_);
+            uint32_t pos = diff >> 5;
+            diff &= 31UL;
+            bitmap_[pos] &= ~(1UL << (31UL - diff));
+
+            if (item == max_value)
+            {
+                calc_maximum_bit_set(pos, 0);
+            }
+        }
+    }
+
+    /**
      * Gets the current value of the bitmap.
      * This method is designed to be used when performing serialization of a bitmap range.
      * 

--- a/test/blackbox/BlackboxTestsPubSubFragments.cpp
+++ b/test/blackbox/BlackboxTestsPubSubFragments.cpp
@@ -266,6 +266,7 @@ TEST(PubSubFragments, AsyncPubSubAsReliableData300kbInLossyConditionsSmallFragme
     // bultin transport, and instead use a lossy shim layer variant.
     auto testTransport = std::make_shared<test_UDPv4TransportDescriptor>();
     testTransport->sendBufferSize = 1024;
+    testTransport->maxMessageSize = 1024;
     testTransport->receiveBufferSize = 65536;
     // We drop 20% of all data frags
     testTransport->dropDataFragMessagesPercentage = 20;

--- a/test/blackbox/BlackboxTestsPubSubFragments.cpp
+++ b/test/blackbox/BlackboxTestsPubSubFragments.cpp
@@ -246,6 +246,60 @@ TEST(PubSubFragments, AsyncPubSubAsReliableData300kbInLossyConditions)
         testTransport->dropLogLength);
 }
 
+TEST(PubSubFragments, AsyncPubSubAsReliableData300kbInLossyConditionsSmallFragments)
+{
+    PubSubReader<Data1mbType> reader(TEST_TOPIC_NAME);
+    PubSubWriter<Data1mbType> writer(TEST_TOPIC_NAME);
+
+    reader.history_depth(5).
+        reliability(eprosima::fastrtps::RELIABLE_RELIABILITY_QOS).init();
+
+    ASSERT_TRUE(reader.isInitialized());
+
+    // When doing fragmentation, it is necessary to have some degree of
+    // flow control not to overrun the receive buffer.
+    uint32_t bytesPerPeriod = 300000;
+    uint32_t periodInMs = 200;
+    writer.add_throughput_controller_descriptor_to_pparams(bytesPerPeriod, periodInMs);
+
+    // To simulate lossy conditions, we are going to remove the default
+    // bultin transport, and instead use a lossy shim layer variant.
+    auto testTransport = std::make_shared<test_UDPv4TransportDescriptor>();
+    testTransport->sendBufferSize = 1024;
+    testTransport->receiveBufferSize = 65536;
+    // We drop 20% of all data frags
+    testTransport->dropDataFragMessagesPercentage = 20;
+    testTransport->dropLogLength = 1;
+    writer.disable_builtin_transport();
+    writer.add_user_transport_to_pparams(testTransport);
+
+    writer.history_depth(5).
+        asynchronously(eprosima::fastrtps::ASYNCHRONOUS_PUBLISH_MODE).init();
+
+    ASSERT_TRUE(writer.isInitialized());
+
+    // Because its volatile the durability
+    // Wait for discovery.
+    writer.wait_discovery();
+    reader.wait_discovery();
+
+    auto data = default_data300kb_data_generator(5);
+
+    reader.startReception(data);
+
+    // Send data
+    writer.send(data);
+    // In this test all data should be sent.
+    ASSERT_TRUE(data.empty());
+    // Block reader until reception finished or timeout.
+    reader.block_for_all();
+
+    // Sanity check. Make sure we have dropped a few packets
+    ASSERT_EQ(
+        eprosima::fastrtps::rtps::test_UDPv4Transport::test_UDPv4Transport_DropLog.size(),
+        testTransport->dropLogLength);
+}
+
 TEST(PubSubFragments, AsyncFragmentSizeTest)
 {
     // ThroghputController size large than maxMessageSize.

--- a/test/blackbox/BlackboxTestsPubSubFragments.cpp
+++ b/test/blackbox/BlackboxTestsPubSubFragments.cpp
@@ -268,8 +268,9 @@ TEST(PubSubFragments, AsyncPubSubAsReliableData300kbInLossyConditionsSmallFragme
     testTransport->sendBufferSize = 1024;
     testTransport->maxMessageSize = 1024;
     testTransport->receiveBufferSize = 65536;
-    // We drop 20% of all data frags
-    testTransport->dropDataFragMessagesPercentage = 20;
+    // We are sending around 300 fragments per sample.
+    // We drop 1% of all data frags
+    testTransport->dropDataFragMessagesPercentage = 1;
     testTransport->dropLogLength = 1;
     writer.disable_builtin_transport();
     writer.add_user_transport_to_pparams(testTransport);


### PR DESCRIPTION
This PR changes the std::set with the list of pending fragments with a FragmentNumberSet_t.