### PR TITLE
Include What You Use BlackboxTests.hpp

### DIFF
--- a/test/blackbox/BlackboxTests.cpp
+++ b/test/blackbox/BlackboxTests.cpp
@@ -26,6 +26,8 @@
 #include "PubSubWriter.hpp"
 #include "PubSubWriterReader.hpp"
 
+#include <gtest/gtest.h>
+
 #include <fastrtps/rtps/RTPSDomain.h>
 #include <fastrtps/log/Log.h>
 

--- a/test/blackbox/BlackboxTests.hpp
+++ b/test/blackbox/BlackboxTests.hpp
@@ -33,6 +33,7 @@
 #include "types/Data64kbType.h"
 #include "types/Data1mbType.h"
 
+#include <algorithm>
 #include <list>
 #include <functional>
 #include <gtest/gtest.h>

--- a/test/blackbox/BlackboxTests.hpp
+++ b/test/blackbox/BlackboxTests.hpp
@@ -34,9 +34,10 @@
 #include "types/Data1mbType.h"
 
 #include <algorithm>
+#include <cstddef>
+#include <iostream>
 #include <list>
 #include <functional>
-#include <gtest/gtest.h>
 
 #if HAVE_SECURITY
 extern void blackbox_security_init();

--- a/test/blackbox/BlackboxTestsAcknackQos.cpp
+++ b/test/blackbox/BlackboxTestsAcknackQos.cpp
@@ -19,6 +19,8 @@
 #include "ReqRepAsReliableHelloWorldRequester.hpp"
 #include "ReqRepAsReliableHelloWorldReplier.hpp"
 
+#include <gtest/gtest.h>
+
 #include <fastrtps/utils/TimeConversion.h>
 #include <fastrtps/transport/test_UDPv4Transport.h>
 

--- a/test/blackbox/BlackboxTestsDeadlineQos.cpp
+++ b/test/blackbox/BlackboxTestsDeadlineQos.cpp
@@ -19,6 +19,8 @@
 #include "ReqRepAsReliableHelloWorldRequester.hpp"
 #include "ReqRepAsReliableHelloWorldReplier.hpp"
 
+#include <gtest/gtest.h>
+
 #include <fastrtps/utils/TimeConversion.h>
 
 using namespace eprosima::fastrtps;

--- a/test/blackbox/BlackboxTestsDiscovery.cpp
+++ b/test/blackbox/BlackboxTestsDiscovery.cpp
@@ -18,6 +18,8 @@
 #include "PubSubReader.hpp"
 #include "PubSubWriter.hpp"
 
+#include <gtest/gtest.h>
+
 #include <fastrtps/transport/test_UDPv4Transport.h>
 
 using namespace eprosima::fastrtps;

--- a/test/blackbox/BlackboxTestsLatencyBudgetQos.cpp
+++ b/test/blackbox/BlackboxTestsLatencyBudgetQos.cpp
@@ -16,6 +16,8 @@
 
 #include "ReqRepHelloWorldRequester.hpp"
 
+#include <gtest/gtest.h>
+
 using namespace eprosima::fastrtps;
 using namespace eprosima::fastrtps::rtps;
 

--- a/test/blackbox/BlackboxTestsLifespanQoS.cpp
+++ b/test/blackbox/BlackboxTestsLifespanQoS.cpp
@@ -19,6 +19,8 @@
 #include "ReqRepAsReliableHelloWorldRequester.hpp"
 #include "ReqRepAsReliableHelloWorldReplier.hpp"
 
+#include <gtest/gtest.h>
+
 #include <fastrtps/utils/TimeConversion.h>
 
 using namespace eprosima::fastrtps;

--- a/test/blackbox/BlackboxTestsLivelinessQos.cpp
+++ b/test/blackbox/BlackboxTestsLivelinessQos.cpp
@@ -20,6 +20,8 @@
 #include "ReqRepAsReliableHelloWorldRequester.hpp"
 #include "ReqRepAsReliableHelloWorldReplier.hpp"
 
+#include <gtest/gtest.h>
+
 using namespace eprosima::fastrtps;
 using namespace eprosima::fastrtps::rtps;
 

--- a/test/blackbox/BlackboxTestsNetworkConf.cpp
+++ b/test/blackbox/BlackboxTestsNetworkConf.cpp
@@ -20,6 +20,8 @@
 #include <fastrtps/transport/UDPv4Transport.h>
 #include <fastrtps/utils/IPFinder.h>
 
+#include <gtest/gtest.h>
+
 #include <memory>
 
 using namespace eprosima::fastrtps;

--- a/test/blackbox/BlackboxTestsPersistence.cpp
+++ b/test/blackbox/BlackboxTestsPersistence.cpp
@@ -20,6 +20,9 @@
 #include "RTPSAsSocketWriter.hpp"
 #include "RTPSWithRegistrationReader.hpp"
 #include "RTPSWithRegistrationWriter.hpp"
+
+#include <gtest/gtest.h>
+
 #include <thread>
 
 using namespace eprosima::fastrtps;

--- a/test/blackbox/BlackboxTestsPubSubBasic.cpp
+++ b/test/blackbox/BlackboxTestsPubSubBasic.cpp
@@ -19,6 +19,8 @@
 #include "ReqRepAsReliableHelloWorldRequester.hpp"
 #include "ReqRepAsReliableHelloWorldReplier.hpp"
 
+#include <gtest/gtest.h>
+
 using namespace eprosima::fastrtps;
 using namespace eprosima::fastrtps::rtps;
 

--- a/test/blackbox/BlackboxTestsPubSubFlowControllers.cpp
+++ b/test/blackbox/BlackboxTestsPubSubFlowControllers.cpp
@@ -17,6 +17,8 @@
 #include "PubSubReader.hpp"
 #include "PubSubWriter.hpp"
 
+#include <gtest/gtest.h>
+
 using namespace eprosima::fastrtps;
 using namespace eprosima::fastrtps::rtps;
 

--- a/test/blackbox/BlackboxTestsPubSubFragments.cpp
+++ b/test/blackbox/BlackboxTestsPubSubFragments.cpp
@@ -17,6 +17,8 @@
 #include "PubSubReader.hpp"
 #include "PubSubWriter.hpp"
 
+#include <gtest/gtest.h>
+
 #include <fastrtps/log/Log.h>
 #include <fastrtps/transport/test_UDPv4Transport.h>
 

--- a/test/blackbox/BlackboxTestsPubSubHistory.cpp
+++ b/test/blackbox/BlackboxTestsPubSubHistory.cpp
@@ -17,6 +17,8 @@
 #include "PubSubReader.hpp"
 #include "PubSubWriter.hpp"
 
+#include <gtest/gtest.h>
+
 using namespace eprosima::fastrtps;
 using namespace eprosima::fastrtps::rtps;
 

--- a/test/blackbox/BlackboxTestsRTPS.cpp
+++ b/test/blackbox/BlackboxTestsRTPS.cpp
@@ -18,7 +18,8 @@
 #include "RTPSAsSocketWriter.hpp"
 #include "RTPSWithRegistrationReader.hpp"
 #include "RTPSWithRegistrationWriter.hpp"
-#include <thread>
+
+#include <gtest/gtest.h>
 
 #include <thread>
 

--- a/test/blackbox/BlackboxTestsRealtimeAllocations.cpp
+++ b/test/blackbox/BlackboxTestsRealtimeAllocations.cpp
@@ -17,6 +17,8 @@
 #include "PubSubReader.hpp"
 #include "PubSubWriter.hpp"
 
+#include <gtest/gtest.h>
+
 using namespace eprosima::fastrtps;
 using namespace eprosima::fastrtps::rtps;
 

--- a/test/blackbox/BlackboxTestsSecurity.cpp
+++ b/test/blackbox/BlackboxTestsSecurity.cpp
@@ -20,6 +20,8 @@
 #include "PubSubWriter.hpp"
 #include "PubSubWriterReader.hpp"
 
+#include <gtest/gtest.h>
+
 #include <fastrtps/transport/test_UDPv4Transport.h>
 
 using namespace eprosima::fastrtps;

--- a/test/blackbox/BlackboxTestsTransportTCP.cpp
+++ b/test/blackbox/BlackboxTestsTransportTCP.cpp
@@ -17,6 +17,8 @@
 #include "TCPReqRepHelloWorldRequester.hpp"
 #include "TCPReqRepHelloWorldReplier.hpp"
 
+#include <gtest/gtest.h>
+
 using namespace eprosima::fastrtps;
 using namespace eprosima::fastrtps::rtps;
 

--- a/test/blackbox/BlackboxTestsTransportUDP.cpp
+++ b/test/blackbox/BlackboxTestsTransportUDP.cpp
@@ -17,6 +17,8 @@
 #include "PubSubReader.hpp"
 #include "PubSubWriter.hpp"
 
+#include <gtest/gtest.h>
+
 #include <fastrtps/transport/UDPv4Transport.h>
 
 using namespace eprosima::fastrtps;

--- a/test/blackbox/BlackboxTestsVolatile.cpp
+++ b/test/blackbox/BlackboxTestsVolatile.cpp
@@ -21,6 +21,8 @@
 #include "ReqRepAsReliableHelloWorldRequester.hpp"
 #include "ReqRepAsReliableHelloWorldReplier.hpp"
 
+#include <gtest/gtest.h>
+
 // Test created to check bug #3020 (Github ros2/demos #238)
 TEST(BlackBox, PubSubAsReliableVolatilePubRemoveWithoutSubs)
 {

--- a/test/blackbox/utils/data_generators.cpp
+++ b/test/blackbox/utils/data_generators.cpp
@@ -14,6 +14,12 @@
 
 #include "../BlackboxTests.hpp"
 
+#include <cstddef>
+#include <cstdint>
+#include <iomanip>
+#include <list>
+#include <sstream>
+
 std::list<HelloWorld> default_helloworld_data_generator(size_t max)
 {
     uint16_t index = 1;

--- a/test/blackbox/utils/lambda_functions.cpp
+++ b/test/blackbox/utils/lambda_functions.cpp
@@ -14,6 +14,9 @@
 
 #include "../BlackboxTests.hpp"
 
+#include <functional>
+#include <iostream>
+
 const std::function<void(const HelloWorld&)>  default_helloworld_print = [](const HelloWorld& hello)
 {
     std::cout << hello.index() << " ";

--- a/test/blackbox/utils/print_functions.cpp
+++ b/test/blackbox/utils/print_functions.cpp
@@ -14,6 +14,8 @@
 
 #include "../BlackboxTests.hpp"
 
+#include <iostream>
+
 template<>
 void default_receive_print(const HelloWorld& hello)
 {

--- a/test/unittest/rtps/history/CacheChangePoolTests.cpp
+++ b/test/unittest/rtps/history/CacheChangePoolTests.cpp
@@ -237,7 +237,7 @@ TEST_P(CacheChangePoolTests, chage_change)
     }
 }
 
-INSTANTIATE_TEST_CASE_P(
+INSTANTIATE_TEST_SUITE_P(
     instance_1,
     CacheChangePoolTests,
     Combine(Values(0, 10, 20, 30),
@@ -245,7 +245,7 @@ INSTANTIATE_TEST_CASE_P(
             Values(128, 256, 512, 1024),
             Values(MemoryManagementPolicy_t::PREALLOCATED_MEMORY_MODE,
                    MemoryManagementPolicy_t::PREALLOCATED_WITH_REALLOC_MEMORY_MODE,
-                   MemoryManagementPolicy_t::DYNAMIC_RESERVE_MEMORY_MODE)), );
+                   MemoryManagementPolicy_t::DYNAMIC_RESERVE_MEMORY_MODE)));
 
 int main(int argc, char **argv)
 {

--- a/test/unittest/rtps/history/CacheChangePoolTests.cpp
+++ b/test/unittest/rtps/history/CacheChangePoolTests.cpp
@@ -237,7 +237,7 @@ TEST_P(CacheChangePoolTests, chage_change)
     }
 }
 
-INSTANTIATE_TEST_SUITE_P(
+INSTANTIATE_TEST_CASE_P(
     instance_1,
     CacheChangePoolTests,
     Combine(Values(0, 10, 20, 30),

--- a/test/unittest/rtps/history/CacheChangePoolTests.cpp
+++ b/test/unittest/rtps/history/CacheChangePoolTests.cpp
@@ -245,7 +245,7 @@ INSTANTIATE_TEST_CASE_P(
             Values(128, 256, 512, 1024),
             Values(MemoryManagementPolicy_t::PREALLOCATED_MEMORY_MODE,
                    MemoryManagementPolicy_t::PREALLOCATED_WITH_REALLOC_MEMORY_MODE,
-                   MemoryManagementPolicy_t::DYNAMIC_RESERVE_MEMORY_MODE)));
+                   MemoryManagementPolicy_t::DYNAMIC_RESERVE_MEMORY_MODE)), );
 
 int main(int argc, char **argv)
 {


### PR DESCRIPTION
There was a missing include in one header file for `std::for_each`. Also, `INSTANTIATE_TEST_CASE_P` is deprecated in favor `INSTANTIATE_TEST_SUITE_P`. I'm not sure why the last coma in the macro was necessary.