### PR TITLE
RTPSMessageGroup_t preallocation <1.9.x> [7165]

### DIFF
--- a/include/fastrtps/rtps/attributes/RTPSParticipantAllocationAttributes.hpp
+++ b/include/fastrtps/rtps/attributes/RTPSParticipantAllocationAttributes.hpp
@@ -50,6 +50,29 @@ struct RemoteLocatorsAllocationAttributes
 };
 
 /**
+ * @brief Holds limits for send buffers allocations.
+ */
+struct SendBuffersAllocationAttributes
+{
+    /** Initial number of send buffers to allocate.
+     *
+     * This attribute controls the initial number of send buffers to be allocated.
+     * The default value of 0 will perform an initial guess of the number of buffers
+     * required, based on the number of threads from which a send operation could be
+     * started.
+     */
+    size_t preallocated_number = 0u;
+
+    /** Whether the number of send buffers is allowed to grow.
+     *
+     * This attribute controls how the buffer manager behaves when a send buffer is not
+     * available. When true, a new buffer will be created. When false, it will wait for a
+     * buffer to be returned. This is a tradeoff between latency and dynamic allocations.
+     */
+    bool dynamic = false;
+};
+
+/**
  * @brief Holds allocation limits affecting collections managed by a participant.
  */
 struct RTPSParticipantAllocationAttributes
@@ -62,6 +85,8 @@ struct RTPSParticipantAllocationAttributes
     ResourceLimitedContainerConfig readers;
     //! Defines the allocation behaviour for collections dependent on the total number of writers per participant.
     ResourceLimitedContainerConfig writers;
+    //! Defines the allocation behaviour for the send buffer manager.
+    SendBuffersAllocationAttributes send_buffers;
 
     //! @return the allocation config for the total of readers in the system (participants * readers)
     ResourceLimitedContainerConfig total_readers() const

--- a/include/fastrtps/rtps/common/CDRMessage_t.h
+++ b/include/fastrtps/rtps/common/CDRMessage_t.h
@@ -164,6 +164,23 @@ struct RTPS_DllAPI CDRMessage_t{
         return *(this);
     }
 
+    void init(
+            octet* buffer_ptr,
+            uint32_t size)
+    {
+        wraps = true;
+        pos = 0;
+        length = 0;
+        buffer = buffer_ptr;
+        max_size = size;
+
+#if __BIG_ENDIAN__
+        msg_endian = BIGEND;
+#else
+        msg_endian = LITTLEEND;
+#endif
+    }
+
     void reserve(
             uint32_t size)
     {

--- a/include/fastrtps/rtps/common/CDRMessage_t.h
+++ b/include/fastrtps/rtps/common/CDRMessage_t.h
@@ -168,6 +168,7 @@ struct RTPS_DllAPI CDRMessage_t{
             octet* buffer_ptr,
             uint32_t size)
     {
+        assert(buffer == nullptr);
         wraps = true;
         pos = 0;
         length = 0;

--- a/include/fastrtps/rtps/messages/RTPSMessageGroup.h
+++ b/include/fastrtps/rtps/messages/RTPSMessageGroup.h
@@ -36,6 +36,7 @@ namespace rtps {
 
 class RTPSParticipantImpl;
 class Endpoint;
+class RTPSMessageGroup_t;
 
 /**
  * RTPSMessageGroup Class used to construct a RTPS message.
@@ -229,6 +230,7 @@ class Endpoint;
 
         std::chrono::steady_clock::time_point max_blocking_time_point_;
 
+        std::unique_ptr<RTPSMessageGroup_t> send_buffer_;
 };
 
 } /* namespace rtps */

--- a/include/fastrtps/xmlparser/XMLParser.h
+++ b/include/fastrtps/xmlparser/XMLParser.h
@@ -486,6 +486,11 @@ class XMLParser
         rtps::RemoteLocatorsAllocationAttributes& allocation,
         uint8_t ident);
 
+    RTPS_DllAPI static XMLP_ret getXMLSendBuffersAllocationAttributes(
+        tinyxml2::XMLElement* elem,
+        rtps::SendBuffersAllocationAttributes& allocation,
+        uint8_t ident);
+
     RTPS_DllAPI static XMLP_ret getXMLDiscoverySettings(
         tinyxml2::XMLElement* elem,
         rtps::DiscoverySettings& settings,

--- a/include/fastrtps/xmlparser/XMLParserCommon.h
+++ b/include/fastrtps/xmlparser/XMLParserCommon.h
@@ -115,6 +115,9 @@ extern const char* MAX_MULTICAST_LOCATORS;
 extern const char* TOTAL_PARTICIPANTS;
 extern const char* TOTAL_READERS;
 extern const char* TOTAL_WRITERS;
+extern const char* SEND_BUFFERS;
+extern const char* PREALLOCATED_NUMBER;
+extern const char* DYNAMIC_LC;
 
 /// Publisher-subscriber attributes
 extern const char* TOPIC;

--- a/resources/xsd/fastRTPS_profiles.xsd
+++ b/resources/xsd/fastRTPS_profiles.xsd
@@ -382,12 +382,20 @@
         </xs:all>
     </xs:complexType>
 
+    <xs:complexType name="sendBuffersAllocationConfigType">
+        <xs:all minOccurs="0">
+            <xs:element name="preallocated_number" type="uint32Type" minOccurs="0"/>
+            <xs:element name="dynamic" type="boolType" minOccurs="0"/>
+        </xs:all>
+    </xs:complexType>
+
     <xs:complexType name="rtpsParticipantAllocationAttributesType">
         <xs:all minOccurs="0">
             <xs:element name="remote_locators" type="remoteLocatorsAllocationConfigType" minOccurs="0"/>
             <xs:element name="total_participants" type="containerAllocationConfigType" minOccurs="0"/>
             <xs:element name="total_readers" type="containerAllocationConfigType" minOccurs="0"/>
             <xs:element name="total_writers" type="containerAllocationConfigType" minOccurs="0"/>
+            <xs:element name="send_buffers" type="sendBuffersAllocationConfigType" minOccurs="0"/>
         </xs:all>
     </xs:complexType>
 

--- a/src/cpp/CMakeLists.txt
+++ b/src/cpp/CMakeLists.txt
@@ -63,6 +63,7 @@ set(${PROJECT_NAME}_source_files
     rtps/messages/RTPSMessageCreator.cpp
     rtps/messages/RTPSMessageGroup.cpp
     rtps/messages/RTPSGapBuilder.cpp
+    rtps/messages/SendBuffersManager.cpp
     rtps/messages/MessageReceiver.cpp
     rtps/messages/submessages/AckNackMsg.hpp
     rtps/messages/submessages/DataMsg.hpp

--- a/src/cpp/rtps/RTPSDomain.cpp
+++ b/src/cpp/rtps/RTPSDomain.cpp
@@ -187,6 +187,14 @@ RTPSParticipant* RTPSDomain::createParticipant(
         pimpl = new RTPSParticipantImpl(PParam, guidP, p, listen);
     }
 
+    // Check there is at least one transport registered.
+    if (!pimpl->networkFactoryHasRegisteredTransports())
+    {
+        logError(RTPS_PARTICIPANT, "Cannot create participant, because there is any transport");
+        delete pimpl;
+        return nullptr;
+    }
+
 #if HAVE_SECURITY
     // Check security was correctly initialized
     if (!pimpl->is_security_initialized())
@@ -196,14 +204,6 @@ RTPSParticipant* RTPSDomain::createParticipant(
         return nullptr;
     }
 #endif
-
-    // Check there is at least one transport registered.
-    if (!pimpl->networkFactoryHasRegisteredTransports())
-    {
-        logError(RTPS_PARTICIPANT, "Cannot create participant, because there is any transport");
-        delete pimpl;
-        return nullptr;
-    }
 
     {
         std::lock_guard<std::mutex> guard(m_mutex);

--- a/src/cpp/rtps/messages/RTPSMessageGroup.cpp
+++ b/src/cpp/rtps/messages/RTPSMessageGroup.cpp
@@ -145,6 +145,8 @@ RTPSMessageGroup::~RTPSMessageGroup() noexcept(false)
         participant_->return_send_buffer(std::move(send_buffer_));
         throw;
     }
+    
+    participant_->return_send_buffer(std::move(send_buffer_));
 }
 
 void RTPSMessageGroup::reset_to_header()

--- a/src/cpp/rtps/messages/RTPSMessageGroup.cpp
+++ b/src/cpp/rtps/messages/RTPSMessageGroup.cpp
@@ -136,8 +136,15 @@ RTPSMessageGroup::RTPSMessageGroup(
 
 RTPSMessageGroup::~RTPSMessageGroup() noexcept(false)
 {
-    send();
-    participant_->return_send_buffer(std::move(send_buffer_));
+    try
+    {
+        send();
+    }
+    catch (...)
+    {
+        participant_->return_send_buffer(std::move(send_buffer_));
+        throw;
+    }
 }
 
 void RTPSMessageGroup::reset_to_header()

--- a/src/cpp/rtps/messages/RTPSMessageGroup.cpp
+++ b/src/cpp/rtps/messages/RTPSMessageGroup.cpp
@@ -23,6 +23,7 @@
 #include "../participant/RTPSParticipantImpl.h"
 #include "../flowcontrol/FlowController.h"
 #include "RTPSGapBuilder.hpp"
+#include "RTPSMessageGroup_t.hpp"
 
 #include <fastrtps/log/Log.h>
 
@@ -31,54 +32,6 @@
 namespace eprosima {
 namespace fastrtps {
 namespace rtps {
-
-/**
- * Class RTPSMessageGroup_t that contains the messages used to send multiples changes as one message.
- * @ingroup WRITER_MODULE
- */
-class RTPSMessageGroup_t
-{
-    public:
-
-        RTPSMessageGroup_t()
-            : rtpsmsg_submessage_(0u)
-            , rtpsmsg_fullmsg_(0u)
-#if HAVE_SECURITY
-            , rtpsmsg_encrypt_(0u)
-#endif
-        {
-        }
-
-        void init(
-#if HAVE_SECURITY
-                bool has_security,
-#endif
-                uint32_t payload,
-                const GuidPrefix_t& participant_guid)
-        {
-
-            rtpsmsg_fullmsg_.reserve(payload);
-            rtpsmsg_submessage_.reserve(payload);
-
-#if HAVE_SECURITY
-            if (has_security)
-            {
-                rtpsmsg_encrypt_.reserve(payload);
-            }
-#endif
-
-            CDRMessage::initCDRMsg(&rtpsmsg_fullmsg_);
-            RTPSMessageCreator::addHeader(&rtpsmsg_fullmsg_, participant_guid);
-        }
-
-        CDRMessage_t rtpsmsg_submessage_;
-
-        CDRMessage_t rtpsmsg_fullmsg_;
-
-#if HAVE_SECURITY
-        CDRMessage_t rtpsmsg_encrypt_;
-#endif
-};
 
 static thread_local std::unique_ptr<RTPSMessageGroup_t> tls_group;
 

--- a/src/cpp/rtps/messages/RTPSMessageGroup_t.hpp
+++ b/src/cpp/rtps/messages/RTPSMessageGroup_t.hpp
@@ -22,6 +22,7 @@
 #ifndef DOXYGEN_SHOULD_SKIP_THIS_PUBLIC
 
 #include <fastrtps/rtps/common/CDRMessage_t.h>
+#include <fastrtps/rtps/messages/CDRMessage.h>
 #include <fastrtps/rtps/messages/RTPSMessageCreator.h>
 
 namespace eprosima {
@@ -36,23 +37,18 @@ class RTPSMessageGroup_t
 {
 public:
 
-    RTPSMessageGroup_t()
+    RTPSMessageGroup_t(
+#if HAVE_SECURITY
+            bool has_security,
+#endif
+            uint32_t payload,
+            const GuidPrefix_t& participant_guid)
         : rtpsmsg_submessage_(0u)
         , rtpsmsg_fullmsg_(0u)
 #if HAVE_SECURITY
         , rtpsmsg_encrypt_(0u)
 #endif
     {
-    }
-
-    void init(
-#if HAVE_SECURITY
-        bool has_security,
-#endif
-        uint32_t payload,
-        const GuidPrefix_t& participant_guid)
-    {
-
         rtpsmsg_fullmsg_.reserve(payload);
         rtpsmsg_submessage_.reserve(payload);
 

--- a/src/cpp/rtps/messages/RTPSMessageGroup_t.hpp
+++ b/src/cpp/rtps/messages/RTPSMessageGroup_t.hpp
@@ -22,6 +22,7 @@
 #ifndef DOXYGEN_SHOULD_SKIP_THIS_PUBLIC
 
 #include <fastrtps/rtps/common/CDRMessage_t.h>
+#include <fastrtps/rtps/messages/RTPSMessageCreator.h>
 
 namespace eprosima {
 namespace fastrtps {

--- a/src/cpp/rtps/messages/RTPSMessageGroup_t.hpp
+++ b/src/cpp/rtps/messages/RTPSMessageGroup_t.hpp
@@ -1,0 +1,85 @@
+// Copyright 2019 Proyectos y Sistemas de Mantenimiento SL (eProsima).
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+/**
+ * @file RTPSMessageGroup_t.hpp
+ */
+
+ #ifndef RTPS_MESSAGES_RTPSMESSAGEGROUP_T_HPP
+ #define RTPS_MESSAGES_RTPSMESSAGEGROUP_T_HPP
+
+#ifndef DOXYGEN_SHOULD_SKIP_THIS_PUBLIC
+
+#include <fastrtps/rtps/common/CDRMessage_t.h>
+
+namespace eprosima {
+namespace fastrtps {
+namespace rtps {
+
+ /**
+ * Class RTPSMessageGroup_t that contains the messages used to send multiples changes as one message.
+ * @ingroup WRITER_MODULE
+ */
+class RTPSMessageGroup_t
+{
+public:
+
+    RTPSMessageGroup_t()
+        : rtpsmsg_submessage_(0u)
+        , rtpsmsg_fullmsg_(0u)
+#if HAVE_SECURITY
+        , rtpsmsg_encrypt_(0u)
+#endif
+    {
+    }
+
+    void init(
+#if HAVE_SECURITY
+        bool has_security,
+#endif
+        uint32_t payload,
+        const GuidPrefix_t& participant_guid)
+    {
+
+        rtpsmsg_fullmsg_.reserve(payload);
+        rtpsmsg_submessage_.reserve(payload);
+
+#if HAVE_SECURITY
+        if (has_security)
+        {
+            rtpsmsg_encrypt_.reserve(payload);
+        }
+#endif
+
+        CDRMessage::initCDRMsg(&rtpsmsg_fullmsg_);
+        RTPSMessageCreator::addHeader(&rtpsmsg_fullmsg_, participant_guid);
+    }
+
+    CDRMessage_t rtpsmsg_submessage_;
+
+    CDRMessage_t rtpsmsg_fullmsg_;
+
+#if HAVE_SECURITY
+    CDRMessage_t rtpsmsg_encrypt_;
+#endif
+};
+
+} // namespace rtps
+} // namespace fastrtps
+} // namespace eprosima
+
+#endif // DOXYGEN_SHOULD_SKIP_THIS_PUBLIC
+
+#endif // RTPS_MESSAGES_RTPSMESSAGEGROUP_T_HPP
+

--- a/src/cpp/rtps/messages/RTPSMessageGroup_t.hpp
+++ b/src/cpp/rtps/messages/RTPSMessageGroup_t.hpp
@@ -59,6 +59,40 @@ public:
         }
 #endif
 
+        init(participant_guid);
+    }
+
+    RTPSMessageGroup_t(
+            octet* buffer_ptr,
+#if HAVE_SECURITY
+            bool has_security,
+#endif
+            uint32_t payload,
+            const GuidPrefix_t& participant_guid)
+        : rtpsmsg_submessage_(0u)
+        , rtpsmsg_fullmsg_(0u)
+#if HAVE_SECURITY
+        , rtpsmsg_encrypt_(0u)
+#endif
+    {
+        rtpsmsg_fullmsg_.init(buffer_ptr, payload);
+        buffer_ptr += payload;
+        rtpsmsg_submessage_.init(buffer_ptr, payload);
+
+#if HAVE_SECURITY
+        if (has_security)
+        {
+            buffer_ptr += payload;
+            rtpsmsg_encrypt_.init(buffer_ptr, payload);
+        }
+#endif
+
+        init(participant_guid);
+    }
+
+    inline void init(
+            const GuidPrefix_t& participant_guid)
+    {
         CDRMessage::initCDRMsg(&rtpsmsg_fullmsg_);
         RTPSMessageCreator::addHeader(&rtpsmsg_fullmsg_, participant_guid);
     }

--- a/src/cpp/rtps/messages/SendBuffersManager.cpp
+++ b/src/cpp/rtps/messages/SendBuffersManager.cpp
@@ -43,7 +43,7 @@ void SendBuffersManager::init(
         // be aligned as if directly allocated.
         constexpr size_t align_size = sizeof(octet*) - 1;
         size_t payload_size = participant->getMaxMessageSize();
-        payload_size = (payload_size + align_size) & align_size;
+        payload_size = (payload_size + align_size) & ~align_size;
         size_t data_size = payload_size * (pool_.capacity() - n_created_);
         common_buffer_.assign(data_size, 0);
 

--- a/src/cpp/rtps/messages/SendBuffersManager.cpp
+++ b/src/cpp/rtps/messages/SendBuffersManager.cpp
@@ -44,7 +44,8 @@ void SendBuffersManager::init(
         // We align the payload size to the size of a pointer, so all buffers will
         // be aligned as if directly allocated.
         constexpr size_t align_size = sizeof(octet*) - 1;
-        size_t payload_size = participant->getMaxMessageSize();
+        uint32_t payload_size = participant->getMaxMessageSize();
+        assert(payload_size > 0u);
         payload_size = (payload_size + align_size) & ~align_size;
         size_t advance = payload_size;
 #if HAVE_SECURITY

--- a/src/cpp/rtps/messages/SendBuffersManager.cpp
+++ b/src/cpp/rtps/messages/SendBuffersManager.cpp
@@ -36,8 +36,39 @@ void SendBuffersManager::init(
 {
     std::lock_guard<std::mutex> guard(mutex_);
 
-    while (n_created_ < pool_.capacity())
+    if (n_created_ < pool_.capacity())
     {
+        // Single allocation for the data of all the buffers.
+        // We align the payload size to the size of a pointer, so all buffers will
+        // be aligned as if directly allocated.
+        constexpr size_t align_size = sizeof(octet*) - 1;
+        size_t payload_size = participant->getMaxMessageSize();
+        payload_size = (payload_size + align_size) & align_size;
+        size_t data_size = payload_size * (pool_.capacity() - n_created_);
+        common_buffer_.assign(data_size, 0);
+
+        const GuidPrefix_t& guid_prefix = participant->getGuid().guidPrefix;
+        size_t advance = payload_size;
+#if HAVE_SECURITY
+        bool secure = participant->is_secure();
+        advance *= secure ? 3 : 2;
+#else
+        advance *= 2;
+#endif
+
+        octet* raw_buffer = common_buffer_.data();
+        while(n_created_ < pool_.capacity())
+        {
+            pool_.emplace_back(new RTPSMessageGroup_t(
+                raw_buffer,
+#if HAVE_SECURITY
+                secure,
+#endif
+                payload_size, guid_prefix
+            ));
+            raw_buffer += advance;
+            ++n_created_;
+        }
         add_one_buffer(participant);
     }
 }

--- a/src/cpp/rtps/messages/SendBuffersManager.cpp
+++ b/src/cpp/rtps/messages/SendBuffersManager.cpp
@@ -1,0 +1,93 @@
+// Copyright 2019 Proyectos y Sistemas de Mantenimiento SL (eProsima).
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+/**
+ * @file SendBuffersManager.cpp
+ */
+
+#include "SendBuffersManager.hpp"
+#include "../participant/RTPSParticipantImpl.h"
+
+namespace eprosima {
+namespace fastrtps {
+namespace rtps {
+
+SendBuffersManager::SendBuffersManager(
+        size_t reserved_size,
+        bool allow_growing)
+    : allow_growing_(allow_growing)
+{
+    pool_.reserve(reserved_size);
+}
+
+void SendBuffersManager::init(
+        const RTPSParticipantImpl* participant)
+{
+    std::lock_guard<std::mutex> guard(mutex_);
+
+    while (n_created_ < pool_.capacity())
+    {
+        add_one_buffer(participant);
+    }
+}
+
+std::unique_ptr<RTPSMessageGroup_t> SendBuffersManager::get_buffer(
+        const RTPSParticipantImpl* participant)
+{
+    std::unique_lock<std::mutex> lock(mutex_);
+
+    std::unique_ptr<RTPSMessageGroup_t> ret_val;
+
+    if (pool_.empty())
+    {
+        if (allow_growing_ || n_created_ < pool_.capacity())
+        {
+            add_one_buffer(participant);
+        }
+        else
+        {
+            available_cv_.wait(lock);
+            assert(!pool_.empty());
+        }
+    }
+
+    ret_val = std::move(pool_.back());
+    pool_.pop_back();
+
+    return ret_val;
+}
+
+void SendBuffersManager::return_buffer(
+        std::unique_ptr <RTPSMessageGroup_t>&& buffer)
+{
+    std::lock_guard<std::mutex> guard(mutex_);
+    pool_.push_back(std::move(buffer));
+    available_cv_.notify_one();
+}
+
+void SendBuffersManager::add_one_buffer(
+        const RTPSParticipantImpl* participant)
+{
+    RTPSMessageGroup_t* new_item = new RTPSMessageGroup_t(
+#if HAVE_SECURITY
+        participant->is_secure(),
+#endif
+        participant->getMaxMessageSize(), participant->getGuid().guidPrefix);
+    pool_.emplace_back(new_item);
+    ++n_created_;
+}
+
+} /* namespace rtps */
+} /* namespace fastrtps */
+} /* namespace eprosima */

--- a/src/cpp/rtps/messages/SendBuffersManager.cpp
+++ b/src/cpp/rtps/messages/SendBuffersManager.cpp
@@ -38,16 +38,14 @@ void SendBuffersManager::init(
 
     if (n_created_ < pool_.capacity())
     {
+        const GuidPrefix_t& guid_prefix = participant->getGuid().guidPrefix;
+
         // Single allocation for the data of all the buffers.
         // We align the payload size to the size of a pointer, so all buffers will
         // be aligned as if directly allocated.
         constexpr size_t align_size = sizeof(octet*) - 1;
         size_t payload_size = participant->getMaxMessageSize();
         payload_size = (payload_size + align_size) & ~align_size;
-        size_t data_size = payload_size * (pool_.capacity() - n_created_);
-        common_buffer_.assign(data_size, 0);
-
-        const GuidPrefix_t& guid_prefix = participant->getGuid().guidPrefix;
         size_t advance = payload_size;
 #if HAVE_SECURITY
         bool secure = participant->is_secure();
@@ -55,6 +53,8 @@ void SendBuffersManager::init(
 #else
         advance *= 2;
 #endif
+        size_t data_size = advance * (pool_.capacity() - n_created_);
+        common_buffer_.assign(data_size, 0);
 
         octet* raw_buffer = common_buffer_.data();
         while(n_created_ < pool_.capacity())
@@ -69,7 +69,6 @@ void SendBuffersManager::init(
             raw_buffer += advance;
             ++n_created_;
         }
-        add_one_buffer(participant);
     }
 }
 

--- a/src/cpp/rtps/messages/SendBuffersManager.hpp
+++ b/src/cpp/rtps/messages/SendBuffersManager.hpp
@@ -87,6 +87,8 @@ private:
     std::mutex mutex_;
     //!Send buffers pool
     std::vector<std::unique_ptr<RTPSMessageGroup_t>> pool_;
+    //!Raw buffer shared by the buffers created inside init()
+    std::vector<octet> common_buffer_;
     //!Creation counter
     std::size_t n_created_ = 0;
     //!Whether we allow n_created_ to grow beyond the pool_ capacity.

--- a/src/cpp/rtps/messages/SendBuffersManager.hpp
+++ b/src/cpp/rtps/messages/SendBuffersManager.hpp
@@ -1,0 +1,104 @@
+// Copyright 2019 Proyectos y Sistemas de Mantenimiento SL (eProsima).
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+/**
+ * @file SendBuffersManager.hpp
+ */
+
+#ifndef RTPS_MESSAGES_SENDBUFFERSMANAGER_HPP
+#define RTPS_MESSAGES_SENDBUFFERSMANAGER_HPP
+#ifndef DOXYGEN_SHOULD_SKIP_THIS_PUBLIC
+
+#include "RTPSMessageGroup_t.hpp"
+#include <fastrtps/rtps/common/GuidPrefix_t.hpp>
+
+#include <vector>  // std::vector
+#include <memory>  // std::unique_ptr
+#include <mutex>   // std::mutex
+
+namespace eprosima {
+namespace fastrtps {
+namespace rtps {
+
+class RTPSParticipantImpl;
+
+/**
+ * Manages a pool of send buffers.
+ * @ingroup WRITER_MODULE
+ */
+class SendBuffersManager
+{
+public:
+
+    /**
+     * Construct a SendBuffersManager.
+     * @param reserved_size Initial size for the pool.
+     * @param allow_growing Whether we allow creation of more than reserved_size elements.
+     */
+    SendBuffersManager(
+            size_t reserved_size,
+            bool allow_growing);
+
+    ~SendBuffersManager()
+    {
+        assert(pool_.size() == n_created_);
+    }
+
+    /**
+     * Initialization of pool.
+     * Fills the pool to its reserved capacity.
+     * @param participant Pointer to the participant creating the pool.
+     */
+    void init(
+            const RTPSParticipantImpl* participant);
+
+    /**
+     * Get one buffer from the pool.
+     * @param participant Pointer to the participant asking for a buffer.
+     * @return unique pointer to a send buffer.
+     */
+    std::unique_ptr<RTPSMessageGroup_t> get_buffer(
+            const RTPSParticipantImpl* participant);
+
+    /**
+     * Return one buffer to the pool.
+     * @param buffer unique pointer to the buffer being returned.
+     */
+    void return_buffer(
+            std::unique_ptr <RTPSMessageGroup_t>&& buffer);
+
+private:
+
+    void add_one_buffer(
+            const RTPSParticipantImpl* participant);
+
+    //!Protects all data
+    std::mutex mutex_;
+    //!Send buffers pool
+    std::vector<std::unique_ptr<RTPSMessageGroup_t>> pool_;
+    //!Creation counter
+    std::size_t n_created_ = 0;
+    //!Whether we allow n_created_ to grow beyond the pool_ capacity.
+    bool allow_growing_ = true;
+    //!To wait for a buffer to be returned to the pool.
+    std::condition_variable available_cv_;
+};
+
+} /* namespace rtps */
+} /* namespace fastrtps */
+} /* namespace eprosima */
+
+#endif
+
+#endif // RTPS_MESSAGES_SENDBUFFERSMANAGER_HPP

--- a/src/cpp/rtps/participant/RTPSParticipantImpl.cpp
+++ b/src/cpp/rtps/participant/RTPSParticipantImpl.cpp
@@ -1239,12 +1239,12 @@ std::unique_ptr<RTPSMessageGroup_t> RTPSParticipantImpl::get_send_buffer()
     std::unique_ptr<RTPSMessageGroup_t> ret_val;
     if (send_buffers_pool_.empty())
     {
-        ret_val.reset(new RTPSMessageGroup_t());
+        ret_val.reset(
+            new RTPSMessageGroup_t(
 #if HAVE_SECURITY
-        ret_val->init(is_secure(), getMaxMessageSize(), m_guid.guidPrefix);
-#else
-        ret_val->init(getMaxMessageSize(), m_guid.guidPrefix);
+                is_secure(),
 #endif
+                getMaxMessageSize(), m_guid.guidPrefix));
     }
     else
     {

--- a/src/cpp/rtps/participant/RTPSParticipantImpl.cpp
+++ b/src/cpp/rtps/participant/RTPSParticipantImpl.cpp
@@ -248,6 +248,11 @@ RTPSParticipantImpl::RTPSParticipantImpl(
     // Start security
     // TODO(Ricardo) Get returned value in future.
     m_security_manager_initialized = m_security_manager.init(security_attributes_, PParam.properties, m_is_security_active);
+    if (!m_security_manager_initialized)
+    {
+        // Participant will be deleted, no need to allocate buffers or create builtin endpoints
+        return;
+    }
 #endif
 
     send_buffers_->init(this);
@@ -314,8 +319,6 @@ const std::vector<RTPSReader*>& RTPSParticipantImpl::getAllReaders() const
 RTPSParticipantImpl::~RTPSParticipantImpl()
 {
     disable();
-
-    delete mp_builtinProtocols;
 
 #if HAVE_SECURITY
     m_security_manager.destroy();

--- a/src/cpp/rtps/participant/RTPSParticipantImpl.cpp
+++ b/src/cpp/rtps/participant/RTPSParticipantImpl.cpp
@@ -237,12 +237,18 @@ RTPSParticipantImpl::RTPSParticipantImpl(
     createReceiverResources(m_att.defaultUnicastLocatorList, true);
     createReceiverResources(m_att.defaultMulticastLocatorList, true);
 
-    // Three buffers (user, events and async writer threads)
-    size_t num_send_buffers = 3;
-    // Add one buffer per reception thread
-    num_send_buffers += m_receiverResourcelist.size();
-    // Reserve buffer pool
-    send_buffers_.reset(new SendBuffersManager(num_send_buffers, true));
+    bool allow_growing_buffers = m_att.allocation.send_buffers.dynamic;
+    size_t num_send_buffers = m_att.allocation.send_buffers.preallocated_number;
+    if(num_send_buffers == 0)
+    {
+        // Three buffers (user, events and async writer threads)
+        num_send_buffers = 3;
+        // Add one buffer per reception thread
+        num_send_buffers += m_receiverResourcelist.size();
+    }
+
+    // Create buffer pool
+    send_buffers_.reset(new SendBuffersManager(num_send_buffers, allow_growing_buffers));
 
 #if HAVE_SECURITY
     // Start security
@@ -255,6 +261,7 @@ RTPSParticipantImpl::RTPSParticipantImpl(
     }
 #endif
 
+    // Allocate all pending send buffers
     send_buffers_->init(this);
 
     mp_builtinProtocols = new BuiltinProtocols();

--- a/src/cpp/rtps/participant/RTPSParticipantImpl.cpp
+++ b/src/cpp/rtps/participant/RTPSParticipantImpl.cpp
@@ -1236,6 +1236,7 @@ IPersistenceService* RTPSParticipantImpl::get_persistence_service(const Endpoint
 
 std::unique_ptr<RTPSMessageGroup_t> RTPSParticipantImpl::get_send_buffer()
 {
+    std::lock_guard<std::recursive_mutex> guard(*mp_mutex);
     std::unique_ptr<RTPSMessageGroup_t> ret_val;
     if (send_buffers_pool_.empty())
     {
@@ -1257,6 +1258,7 @@ std::unique_ptr<RTPSMessageGroup_t> RTPSParticipantImpl::get_send_buffer()
 
 void RTPSParticipantImpl::return_send_buffer(std::unique_ptr <RTPSMessageGroup_t>&& buffer)
 {
+    std::lock_guard<std::recursive_mutex> guard(*mp_mutex);
     send_buffers_pool_.push_back(std::move(buffer));
 }
 

--- a/src/cpp/rtps/participant/RTPSParticipantImpl.cpp
+++ b/src/cpp/rtps/participant/RTPSParticipantImpl.cpp
@@ -134,6 +134,11 @@ RTPSParticipantImpl::RTPSParticipantImpl(
     mp_userParticipant->mp_impl = this;
     mp_event_thr.init_thread();
 
+    if (!networkFactoryHasRegisteredTransports())
+    {
+        return;
+    }
+
     // Throughput controller, if the descriptor has valid values
     if (PParam.throughputController.bytesPerPeriod != UINT32_MAX && PParam.throughputController.periodMillisecs != 0)
     {

--- a/src/cpp/rtps/participant/RTPSParticipantImpl.cpp
+++ b/src/cpp/rtps/participant/RTPSParticipantImpl.cpp
@@ -1256,7 +1256,7 @@ IPersistenceService* RTPSParticipantImpl::get_persistence_service(const Endpoint
 
 std::unique_ptr<RTPSMessageGroup_t> RTPSParticipantImpl::get_send_buffer()
 {
-    std::lock_guard<std::recursive_mutex> guard(*mp_mutex);
+    std::lock_guard<std::mutex> guard(send_buffers_pool_mutex_);
     std::unique_ptr<RTPSMessageGroup_t> ret_val;
     if (send_buffers_pool_.empty())
     {
@@ -1278,7 +1278,7 @@ std::unique_ptr<RTPSMessageGroup_t> RTPSParticipantImpl::get_send_buffer()
 
 void RTPSParticipantImpl::return_send_buffer(std::unique_ptr <RTPSMessageGroup_t>&& buffer)
 {
-    std::lock_guard<std::recursive_mutex> guard(*mp_mutex);
+    std::lock_guard<std::mutex> guard(send_buffers_pool_mutex_);
     send_buffers_pool_.push_back(std::move(buffer));
 }
 

--- a/src/cpp/rtps/participant/RTPSParticipantImpl.h
+++ b/src/cpp/rtps/participant/RTPSParticipantImpl.h
@@ -46,6 +46,8 @@
 #include <fastrtps/rtps/resources/ResourceEvent.h>
 #include <fastrtps/rtps/resources/AsyncWriterThread.h>
 
+#include "../messages/RTPSMessageGroup_t.hpp"
+
 #if HAVE_SECURITY
 #include <fastrtps/rtps/Endpoint.h>
 #include <fastrtps/rtps/security/accesscontrol/ParticipantSecurityAttributes.h>
@@ -61,7 +63,9 @@ class TopicAttributes;
 class MessageReceiver;
 
 namespace rtps
-{ class RTPSParticipant;
+{
+
+class RTPSParticipant;
 class RTPSParticipantListener;
 class BuiltinProtocols;
 struct CDRMessage_t;
@@ -298,6 +302,9 @@ public:
     RTPSWriter* find_local_writer(
             const GUID_t& writer_guid);
 
+    std::unique_ptr<RTPSMessageGroup_t> get_send_buffer();
+    void return_send_buffer(std::unique_ptr <RTPSMessageGroup_t>&& buffer);
+
 private:
     //!Attributes of the RTPSParticipant
     RTPSParticipantAttributes m_att;
@@ -328,6 +335,8 @@ private:
     NetworkFactory m_network_Factory;
     //!Async writer thread
     AsyncWriterThread async_thread_;
+    //!Send buffers pool
+    std::vector<std::unique_ptr<RTPSMessageGroup_t>> send_buffers_pool_;
 
 #if HAVE_SECURITY
     // Security manager

--- a/src/cpp/rtps/participant/RTPSParticipantImpl.h
+++ b/src/cpp/rtps/participant/RTPSParticipantImpl.h
@@ -47,6 +47,7 @@
 #include <fastrtps/rtps/resources/AsyncWriterThread.h>
 
 #include "../messages/RTPSMessageGroup_t.hpp"
+#include "../messages/SendBuffersManager.hpp"
 
 #if HAVE_SECURITY
 #include <fastrtps/rtps/Endpoint.h>
@@ -335,10 +336,8 @@ private:
     NetworkFactory m_network_Factory;
     //!Async writer thread
     AsyncWriterThread async_thread_;
-    //!Protects access to send_buffers_pool_
-    std::mutex send_buffers_pool_mutex_;
-    //!Send buffers pool
-    std::vector<std::unique_ptr<RTPSMessageGroup_t>> send_buffers_pool_;
+    //!Pool of send buffers
+    std::unique_ptr<SendBuffersManager> send_buffers_;
 
 #if HAVE_SECURITY
     // Security manager

--- a/src/cpp/rtps/participant/RTPSParticipantImpl.h
+++ b/src/cpp/rtps/participant/RTPSParticipantImpl.h
@@ -335,6 +335,8 @@ private:
     NetworkFactory m_network_Factory;
     //!Async writer thread
     AsyncWriterThread async_thread_;
+    //!Protects access to send_buffers_pool_
+    std::mutex send_buffers_pool_mutex_;
     //!Send buffers pool
     std::vector<std::unique_ptr<RTPSMessageGroup_t>> send_buffers_pool_;
 

--- a/src/cpp/xmlparser/XMLElementParser.cpp
+++ b/src/cpp/xmlparser/XMLElementParser.cpp
@@ -37,6 +37,7 @@ XMLP_ret XMLParser::getXMLParticipantAllocationAttributes(
                 <xs:element name="total_participants" type="containerAllocationConfigType" minOccurs="0"/>
                 <xs:element name="total_readers" type="containerAllocationConfigType" minOccurs="0"/>
                 <xs:element name="total_writers" type="containerAllocationConfigType" minOccurs="0"/>
+                <xs:element name="send_buffers" type="sendBuffersAllocationConfigType" minOccurs="0"/>
             </xs:all>
         </xs:complexType>
     */
@@ -74,6 +75,14 @@ XMLP_ret XMLParser::getXMLParticipantAllocationAttributes(
         {
             // total_writers - containerAllocationConfigType
             if (XMLP_ret::XML_OK != getXMLContainerAllocationConfig(p_aux0, allocation.writers, ident))
+            {
+                return XMLP_ret::XML_ERROR;
+            }
+        }
+        else if (strcmp(name, SEND_BUFFERS) == 0)
+        {
+            // send_buffers - sendBuffersAllocationConfigType
+            if (XMLP_ret::XML_OK != getXMLSendBuffersAllocationAttributes(p_aux0, allocation.send_buffers, ident))
             {
                 return XMLP_ret::XML_ERROR;
             }
@@ -129,6 +138,55 @@ XMLP_ret XMLParser::getXMLRemoteLocatorsAllocationAttributes(
         else
         {
             logError(XMLPARSER, "Invalid element found into 'remoteLocatorsAllocationConfigType'. Name: " << name);
+            return XMLP_ret::XML_ERROR;
+        }
+    }
+
+    return XMLP_ret::XML_OK;
+}
+
+XMLP_ret XMLParser::getXMLSendBuffersAllocationAttributes(
+        tinyxml2::XMLElement* elem,
+        rtps::SendBuffersAllocationAttributes& allocation,
+        uint8_t ident)
+{
+    /*
+        <xs:complexType name="sendBuffersAllocationConfigType">
+            <xs:all minOccurs="0">
+                <xs:element name="preallocated_number" type="uint32Type" minOccurs="0"/>
+                <xs:element name="dynamic" type="boolType" minOccurs="0"/>
+            </xs:all>
+        </xs:complexType>
+    */
+
+    tinyxml2::XMLElement *p_aux0 = nullptr;
+    const char* name = nullptr;
+    uint32_t tmp;
+    for (p_aux0 = elem->FirstChildElement(); p_aux0 != NULL; p_aux0 = p_aux0->NextSiblingElement())
+    {
+        name = p_aux0->Name();
+        if (strcmp(name, PREALLOCATED_NUMBER) == 0)
+        {
+            // preallocated_number - uint32Type
+            if (XMLP_ret::XML_OK != getXMLUint(p_aux0, &tmp, ident))
+            {
+                return XMLP_ret::XML_ERROR;
+            }
+            allocation.preallocated_number = tmp;
+        }
+        else if (strcmp(name, DYNAMIC_LC) == 0)
+        {
+            // dynamic - boolType
+            bool tmp_bool = false;
+            if (XMLP_ret::XML_OK != getXMLBool(p_aux0, &tmp_bool, ident))
+            {
+                return XMLP_ret::XML_ERROR;
+            }
+            allocation.dynamic = tmp_bool;
+        }
+        else
+        {
+            logError(XMLPARSER, "Invalid element found into 'sendBuffersAllocationConfigType'. Name: " << name);
             return XMLP_ret::XML_ERROR;
         }
     }

--- a/src/cpp/xmlparser/XMLParserCommon.cpp
+++ b/src/cpp/xmlparser/XMLParserCommon.cpp
@@ -97,6 +97,9 @@ const char* MAX_MULTICAST_LOCATORS = "max_multicast_locators";
 const char* TOTAL_PARTICIPANTS = "total_participants";
 const char* TOTAL_READERS = "total_readers";
 const char* TOTAL_WRITERS = "total_writers";
+const char* SEND_BUFFERS = "send_buffers";
+const char* PREALLOCATED_NUMBER = "preallocated_number";
+const char* DYNAMIC_LC = "dynamic";
 
 /// Publisher-subscriber attributes
 const char* TOPIC = "topic";

--- a/test/unittest/xmlparser/XMLProfileParserTests.cpp
+++ b/test/unittest/xmlparser/XMLProfileParserTests.cpp
@@ -108,6 +108,20 @@ TEST_F(XMLProfileParserTests, XMLParserParcipant)
     LocatorListIterator loc_list_it;
     PortParameters &port = rtps_atts.port;
 
+    EXPECT_EQ(rtps_atts.allocation.locators.max_unicast_locators, 4u);
+    EXPECT_EQ(rtps_atts.allocation.locators.max_multicast_locators, 1u);
+    EXPECT_EQ(rtps_atts.allocation.participants.initial, 10u);
+    EXPECT_EQ(rtps_atts.allocation.participants.maximum, 20u);
+    EXPECT_EQ(rtps_atts.allocation.participants.increment, 2u);
+    EXPECT_EQ(rtps_atts.allocation.readers.initial, 10u);
+    EXPECT_EQ(rtps_atts.allocation.readers.maximum, 20u);
+    EXPECT_EQ(rtps_atts.allocation.readers.increment, 2u);
+    EXPECT_EQ(rtps_atts.allocation.writers.initial, 10u);
+    EXPECT_EQ(rtps_atts.allocation.writers.maximum, 20u);
+    EXPECT_EQ(rtps_atts.allocation.writers.increment, 2u);
+    EXPECT_EQ(rtps_atts.allocation.send_buffers.preallocated_number, 127u);
+    EXPECT_EQ(rtps_atts.allocation.send_buffers.dynamic, true);
+
     IPLocator::setIPv4(locator, 192, 168, 1 , 2);
     locator.port = 2019;
     EXPECT_EQ(*rtps_atts.defaultUnicastLocatorList.begin(), locator);

--- a/test/unittest/xmlparser/test_xml_profiles.xml
+++ b/test/unittest/xmlparser/test_xml_profiles.xml
@@ -26,6 +26,10 @@
                         <maximum>20</maximum>
                         <increment>2</increment>
                     </total_writers>
+                    <send_buffers>
+                        <preallocated_number>127</preallocated_number>
+                        <dynamic>true</dynamic>
+                    </send_buffers>
                 </allocation>
                 <defaultUnicastLocatorList>
                     <locator>


### PR DESCRIPTION
This PR:
* Adds a `SendBuffersManager` class, responsible of RTPSMessageGroup_t allocation
* Adds a `send_buffers` field to `RTPSParticipantAllocationAttributes` with the allocation options for the pool of `RTPSMessageGroup_t` instances
* Adds the corresponding XML parsing and test