### PR TITLE
[1.9.x] Fixing ResourceEvent vector management. [7172]

### DIFF
--- a/include/fastrtps/rtps/resources/ResourceEvent.h
+++ b/include/fastrtps/rtps/resources/ResourceEvent.h
@@ -140,7 +140,7 @@ private:
 
     void sort_timers();
     void update_current_time();
-    void activate_timer(
+    bool activate_timer(
             TimedEventImpl* event);
 
     void do_timer_actions();

--- a/include/fastrtps/rtps/resources/ResourceEvent.h
+++ b/include/fastrtps/rtps/resources/ResourceEvent.h
@@ -140,8 +140,6 @@ private:
 
     void sort_timers();
     void update_current_time();
-    bool activate_timer(
-            TimedEventImpl* event);
 
     void do_timer_actions();
 

--- a/src/cpp/rtps/resources/ResourceEvent.cpp
+++ b/src/cpp/rtps/resources/ResourceEvent.cpp
@@ -43,11 +43,14 @@ ResourceEvent::~ResourceEvent()
     assert(timers_count_ == 0);
 
     logInfo(RTPS_PARTICIPANT, "Removing event thread");
-    stop_.store(true);
-    cv_.notify_one();
-
     if (thread_.joinable())
     {
+        {
+            std::unique_lock<TimedMutex> lock(mutex_);
+            stop_.store(true);
+            cv_.notify_one();
+        }
+
         thread_.join();
     }
 }

--- a/src/cpp/rtps/resources/ResourceEvent.cpp
+++ b/src/cpp/rtps/resources/ResourceEvent.cpp
@@ -149,7 +149,7 @@ bool ResourceEvent::register_timer_nts(
     return false;
 }
 
-void ResourceEvent::activate_timer(
+bool ResourceEvent::activate_timer(
         TimedEventImpl* event)
 {
     std::vector<TimedEventImpl*>::iterator low_bound;
@@ -163,7 +163,10 @@ void ResourceEvent::activate_timer(
     {
         // ... add it on its place
         active_timers_.emplace(low_bound, event);
+        return true;
     }
+
+    return false;
 }
 
 void ResourceEvent::run_io_service()
@@ -219,7 +222,10 @@ void ResourceEvent::do_timer_actions()
             did_something = true;
             if (tp->update(current_time_, cancel_time))
             {
-                activate_timer(tp);
+                if (!activate_timer(tp))
+                {
+                    sort_timers();
+                }
             }
         }
         pending_timers_.clear();

--- a/src/cpp/rtps/resources/ResourceEvent.cpp
+++ b/src/cpp/rtps/resources/ResourceEvent.cpp
@@ -149,26 +149,6 @@ bool ResourceEvent::register_timer_nts(
     return false;
 }
 
-bool ResourceEvent::activate_timer(
-        TimedEventImpl* event)
-{
-    std::vector<TimedEventImpl*>::iterator low_bound;
-    std::vector<TimedEventImpl*>::iterator end_it = active_timers_.end();
-    
-    // Find insertion position
-    low_bound = std::lower_bound(active_timers_.begin(), end_it, event, event_compare);
-
-    // If event is not found from there onwards ...
-    if (std::find(low_bound, end_it, event) == end_it)
-    {
-        // ... add it on its place
-        active_timers_.emplace(low_bound, event);
-        return true;
-    }
-
-    return false;
-}
-
 void ResourceEvent::run_io_service()
 {
     while (!stop_.load())
@@ -219,13 +199,23 @@ void ResourceEvent::do_timer_actions()
         std::lock_guard<TimedMutex> lock(mutex_);
         for (TimedEventImpl* tp : pending_timers_)
         {
-            did_something = true;
+            // Remove item from active timers
+            auto current_pos = std::lower_bound(active_timers_.begin(), active_timers_.end(), tp, event_compare);
+            current_pos = std::find(current_pos, active_timers_.end(), tp);
+            if (current_pos != active_timers_.end())
+            {
+                active_timers_.erase(current_pos);
+            }
+
+            // Update timer info
             if (tp->update(current_time_, cancel_time))
             {
-                if (!activate_timer(tp))
-                {
-                    sort_timers();
-                }
+                // Timer has to be activated: add to active timers
+                std::vector<TimedEventImpl*>::iterator low_bound;
+
+                // Insert on correct position
+                low_bound = std::lower_bound(active_timers_.begin(), active_timers_.end(), tp, event_compare);
+                active_timers_.emplace(low_bound, tp);
             }
         }
         pending_timers_.clear();


### PR DESCRIPTION
Test `blackbox.LivelinessQos.ThreeWriters_ThreeReaders.Intraprocess` was failing frequently on MacOS with `libc++abi.dylib: terminating with uncaught exception of type std::__1::system_error: mutex lock failed: Invalid argument`.

Debugging showed that `active_timers_` on `ResourceEvent` had duplicates. This should not happen, as the mechanism is based on that array being ordered by `next triggering time` and without duplicates.

This PR changes the way in which pending requests are handled so that the array is kept in order after the processing of each request.