### PR TITLE
TCP transport: using asio::write to send data. <master> [7224]

### DIFF
--- a/include/fastdds/rtps/transport/TCPChannelResource.h
+++ b/include/fastdds/rtps/transport/TCPChannelResource.h
@@ -23,9 +23,9 @@
 
 #include <asio.hpp>
 
-namespace eprosima{
-namespace fastdds{
-namespace rtps{
+namespace eprosima {
+namespace fastdds {
+namespace rtps {
 
 class TCPConnector;
 class TCPTransportInterface;
@@ -71,7 +71,6 @@ protected:
     std::vector<uint16_t> pending_logical_output_ports_; // Must be accessed after lock pending_logical_mutex_
     std::vector<uint16_t> logical_output_ports_;
     std::mutex read_mutex_;
-    std::mutex write_mutex_;
     std::recursive_mutex pending_logical_mutex_;
     std::atomic<eConnectionStatus> connection_status_;
 
@@ -81,15 +80,19 @@ public:
             uint16_t port,
             RTCPMessageManager* rtcp_manager);
 
-    void set_logical_port_pending(uint16_t port);
+    void set_logical_port_pending(
+            uint16_t port);
 
-    bool remove_logical_port(uint16_t port);
+    bool remove_logical_port(
+            uint16_t port);
 
     virtual void disable() override;
 
-    bool is_logical_port_opened(uint16_t port);
+    bool is_logical_port_opened(
+            uint16_t port);
 
-    bool is_logical_port_added(uint16_t port);
+    bool is_logical_port_added(
+            uint16_t port);
 
     bool connection_established()
     {
@@ -106,7 +109,8 @@ public:
         return locator_;
     }
 
-    ResponseCode process_bind_request(const fastrtps::rtps::Locator_t& locator);
+    ResponseCode process_bind_request(
+            const fastrtps::rtps::Locator_t& locator);
 
     // Socket related methods
     virtual void connect(
@@ -115,45 +119,52 @@ public:
     virtual void disconnect() = 0;
 
     virtual uint32_t read(
-        fastrtps::rtps::octet* buffer,
-        std::size_t size,
-        asio::error_code& ec) = 0;
+            fastrtps::rtps::octet* buffer,
+            std::size_t size,
+            asio::error_code& ec) = 0;
 
     virtual size_t send(
-        const fastrtps::rtps::octet* header,
-        size_t header_size,
-        const fastrtps::rtps::octet* buffer,
-        size_t size,
-        asio::error_code& ec) = 0;
+            const fastrtps::rtps::octet* header,
+            size_t header_size,
+            const fastrtps::rtps::octet* buffer,
+            size_t size,
+            asio::error_code& ec) = 0;
 
     virtual asio::ip::tcp::endpoint remote_endpoint() const = 0;
 
     virtual asio::ip::tcp::endpoint local_endpoint() const = 0;
 
-    virtual void set_options(const TCPTransportDescriptor* options) = 0;
+    virtual void set_options(
+            const TCPTransportDescriptor* options) = 0;
 
     virtual void cancel() = 0;
 
     virtual void close() = 0;
 
-    virtual void shutdown(asio::socket_base::shutdown_type what) = 0;
+    virtual void shutdown(
+            asio::socket_base::shutdown_type what) = 0;
 
-    TCPConnectionType tcp_connection_type() const { return tcp_connection_type_; }
+    TCPConnectionType tcp_connection_type() const
+    {
+        return tcp_connection_type_;
+    }
 
 protected:
 
     // Constructor called when trying to connect to a remote server
     TCPChannelResource(
-        TCPTransportInterface* parent,
-        const fastrtps::rtps::Locator_t& locator,
-        uint32_t maxMsgSize);
+            TCPTransportInterface* parent,
+            const fastrtps::rtps::Locator_t& locator,
+            uint32_t maxMsgSize);
 
     // Constructor called when local server accepted connection
     TCPChannelResource(
-        TCPTransportInterface* parent,
-        uint32_t maxMsgSize);
+            TCPTransportInterface* parent,
+            uint32_t maxMsgSize);
 
-    inline eConnectionStatus change_status(eConnectionStatus s, RTCPMessageManager* rtcp_manager = nullptr)
+    inline eConnectionStatus change_status(
+            eConnectionStatus s,
+            RTCPMessageManager* rtcp_manager = nullptr)
     {
         eConnectionStatus old = connection_status_.exchange(s);
 
@@ -169,11 +180,14 @@ protected:
         return old;
     }
 
-    void add_logical_port_response(const TCPTransactionId &id, bool success, RTCPMessageManager* rtcp_manager);
+    void add_logical_port_response(
+            const TCPTransactionId& id,
+            bool success,
+            RTCPMessageManager* rtcp_manager);
 
     void process_check_logical_ports_response(
-            const TCPTransactionId &transactionId,
-            const std::vector<uint16_t> &availablePorts,
+            const TCPTransactionId& transactionId,
+            const std::vector<uint16_t>& availablePorts,
             RTCPMessageManager* rtcp_manager);
 
     TCPConnectionType tcp_connection_type_;
@@ -187,13 +201,16 @@ private:
             uint16_t closedPort,
             RTCPMessageManager* rtcp_manager);
 
-    void send_pending_open_logical_ports(RTCPMessageManager* rtcp_manager);
+    void send_pending_open_logical_ports(
+            RTCPMessageManager* rtcp_manager);
 
     void set_all_ports_pending();
 
-    TCPChannelResource(const TCPChannelResource&) = delete;
+    TCPChannelResource(
+            const TCPChannelResource&) = delete;
 
-    TCPChannelResource& operator=(const TCPChannelResource&) = delete;
+    TCPChannelResource& operator =(
+            const TCPChannelResource&) = delete;
 };
 
 

--- a/src/cpp/rtps/transport/TCPChannelResourceBasic.cpp
+++ b/src/cpp/rtps/transport/TCPChannelResourceBasic.cpp
@@ -155,13 +155,17 @@ size_t TCPChannelResourceBasic::send(
 
     if (eConnecting < connection_status_)
     {
-        std::vector<asio::const_buffer> buffers;
         if (header_size > 0)
         {
-            buffers.push_back(asio::buffer(header, header_size));
+            std::array<asio::const_buffer, 2> buffers;
+            buffers[0] = asio::buffer(header, header_size);
+            buffers[1] = asio::buffer(data, size);
+            bytes_sent = asio::write(*socket_.get(), buffers, ec);
         }
-        buffers.push_back(asio::buffer(data, size));
-        bytes_sent = asio::write(*socket_.get(), buffers, ec);
+        else
+        {
+            bytes_sent = asio::write(*socket_.get(), asio::buffer(data, size), ec);
+        }
     }
 
     return bytes_sent;

--- a/src/cpp/rtps/transport/TCPChannelResourceBasic.cpp
+++ b/src/cpp/rtps/transport/TCPChannelResourceBasic.cpp
@@ -18,7 +18,7 @@
 #include <fastrtps/utils/IPLocator.h>
 
 #include <future>
-#include <vector>
+#include <array>
 
 using namespace asio;
 


### PR DESCRIPTION
`asio::write()` ensures all data is sent. This function avoids an error using `asio::basic_stream_socket::send()` with large fragments.

Fixed #941.