### PR TITLE
TCP transport: using asio::write to send data. <1.9.x>

### DIFF
--- a/include/fastrtps/transport/TCPChannelResource.h
+++ b/include/fastrtps/transport/TCPChannelResource.h
@@ -23,9 +23,9 @@
 
 #include <asio.hpp>
 
-namespace eprosima{
-namespace fastrtps{
-namespace rtps{
+namespace eprosima {
+namespace fastrtps {
+namespace rtps {
 
 class TCPConnector;
 class TCPTransportInterface;
@@ -71,7 +71,6 @@ protected:
     std::vector<uint16_t> pending_logical_output_ports_; // Must be accessed after lock pending_logical_mutex_
     std::vector<uint16_t> logical_output_ports_;
     std::mutex read_mutex_;
-    std::mutex write_mutex_;
     std::recursive_mutex pending_logical_mutex_;
     std::atomic<eConnectionStatus> connection_status_;
 
@@ -81,15 +80,19 @@ public:
             uint16_t port,
             RTCPMessageManager* rtcp_manager);
 
-    void set_logical_port_pending(uint16_t port);
+    void set_logical_port_pending(
+            uint16_t port);
 
-    bool remove_logical_port(uint16_t port);
+    bool remove_logical_port(
+            uint16_t port);
 
     virtual void disable() override;
 
-    bool is_logical_port_opened(uint16_t port);
+    bool is_logical_port_opened(
+            uint16_t port);
 
-    bool is_logical_port_added(uint16_t port);
+    bool is_logical_port_added(
+            uint16_t port);
 
     bool connection_established()
     {
@@ -106,7 +109,8 @@ public:
         return locator_;
     }
 
-    ResponseCode process_bind_request(const Locator_t& locator);
+    ResponseCode process_bind_request(
+            const Locator_t& locator);
 
     // Socket related methods
     virtual void connect(
@@ -115,45 +119,52 @@ public:
     virtual void disconnect() = 0;
 
     virtual uint32_t read(
-        octet* buffer,
-        std::size_t size,
-        asio::error_code& ec) = 0;
+            octet* buffer,
+            std::size_t size,
+            asio::error_code& ec) = 0;
 
     virtual size_t send(
-        const octet* header,
-        size_t header_size,
-        const octet* buffer,
-        size_t size,
-        asio::error_code& ec) = 0;
+            const octet* header,
+            size_t header_size,
+            const octet* buffer,
+            size_t size,
+            asio::error_code& ec) = 0;
 
     virtual asio::ip::tcp::endpoint remote_endpoint() const = 0;
 
     virtual asio::ip::tcp::endpoint local_endpoint() const = 0;
 
-    virtual void set_options(const TCPTransportDescriptor* options) = 0;
+    virtual void set_options(
+            const TCPTransportDescriptor* options) = 0;
 
     virtual void cancel() = 0;
 
     virtual void close() = 0;
 
-    virtual void shutdown(asio::socket_base::shutdown_type what) = 0;
+    virtual void shutdown(
+            asio::socket_base::shutdown_type what) = 0;
 
-    TCPConnectionType tcp_connection_type() const { return tcp_connection_type_; }
+    TCPConnectionType tcp_connection_type() const
+    {
+        return tcp_connection_type_;
+    }
 
 protected:
 
     // Constructor called when trying to connect to a remote server
     TCPChannelResource(
-        TCPTransportInterface* parent,
-        const Locator_t& locator,
-        uint32_t maxMsgSize);
+            TCPTransportInterface* parent,
+            const Locator_t& locator,
+            uint32_t maxMsgSize);
 
     // Constructor called when local server accepted connection
     TCPChannelResource(
-        TCPTransportInterface* parent,
-        uint32_t maxMsgSize);
+            TCPTransportInterface* parent,
+            uint32_t maxMsgSize);
 
-    inline eConnectionStatus change_status(eConnectionStatus s, RTCPMessageManager* rtcp_manager = nullptr)
+    inline eConnectionStatus change_status(
+            eConnectionStatus s,
+            RTCPMessageManager* rtcp_manager = nullptr)
     {
         eConnectionStatus old = connection_status_.exchange(s);
 
@@ -169,11 +180,14 @@ protected:
         return old;
     }
 
-    void add_logical_port_response(const TCPTransactionId &id, bool success, RTCPMessageManager* rtcp_manager);
+    void add_logical_port_response(
+            const TCPTransactionId& id,
+            bool success,
+            RTCPMessageManager* rtcp_manager);
 
     void process_check_logical_ports_response(
-            const TCPTransactionId &transactionId,
-            const std::vector<uint16_t> &availablePorts,
+            const TCPTransactionId& transactionId,
+            const std::vector<uint16_t>& availablePorts,
             RTCPMessageManager* rtcp_manager);
 
     TCPConnectionType tcp_connection_type_;
@@ -187,13 +201,16 @@ private:
             uint16_t closedPort,
             RTCPMessageManager* rtcp_manager);
 
-    void send_pending_open_logical_ports(RTCPMessageManager* rtcp_manager);
+    void send_pending_open_logical_ports(
+            RTCPMessageManager* rtcp_manager);
 
     void set_all_ports_pending();
 
-    TCPChannelResource(const TCPChannelResource&) = delete;
+    TCPChannelResource(
+            const TCPChannelResource&) = delete;
 
-    TCPChannelResource& operator=(const TCPChannelResource&) = delete;
+    TCPChannelResource& operator =(
+            const TCPChannelResource&) = delete;
 };
 
 

--- a/src/cpp/transport/TCPChannelResourceBasic.cpp
+++ b/src/cpp/transport/TCPChannelResourceBasic.cpp
@@ -150,13 +150,17 @@ size_t TCPChannelResourceBasic::send(
 
     if (eConnecting < connection_status_)
     {
-        std::vector<asio::const_buffer> buffers;
         if (header_size > 0)
         {
-            buffers.push_back(asio::buffer(header, header_size));
+            std::array<asio::const_buffer, 2> buffers;
+            buffers[0] = asio::buffer(header, header_size);
+            buffers[1] = asio::buffer(data, size);
+            bytes_sent = asio::write(*socket_.get(), buffers, ec);
         }
-        buffers.push_back(asio::buffer(data, size));
-        bytes_sent = asio::write(*socket_.get(), buffers, ec);
+        else
+        {
+            bytes_sent = asio::write(*socket_.get(), asio::buffer(data, size), ec);
+        }
     }
 
     return bytes_sent;

--- a/src/cpp/transport/TCPChannelResourceBasic.cpp
+++ b/src/cpp/transport/TCPChannelResourceBasic.cpp
@@ -18,6 +18,7 @@
 #include <fastrtps/utils/IPLocator.h>
 
 #include <future>
+#include <vector>
 
 using namespace asio;
 
@@ -51,7 +52,7 @@ TCPChannelResourceBasic::~TCPChannelResourceBasic()
 }
 
 void TCPChannelResourceBasic::connect(
-            const std::shared_ptr<TCPChannelResource>& myself)
+        const std::shared_ptr<TCPChannelResource>& myself)
 {
     assert(TCPConnectionType::TCP_CONNECT_TYPE == tcp_connection_type_);
     eConnectionStatus expected = eConnectionStatus::eDisconnected;
@@ -63,8 +64,9 @@ void TCPChannelResourceBasic::connect(
             ip::tcp::resolver resolver(service_);
 
             auto endpoints = resolver.resolve({
-                IPLocator::hasWan(locator_) ? IPLocator::toWanstring(locator_) : IPLocator::ip_to_string(locator_),
-                std::to_string(IPLocator::getPhysicalPort(locator_))});
+                            IPLocator::hasWan(locator_) ? IPLocator::toWanstring(locator_) : IPLocator::ip_to_string(
+                                locator_),
+                            std::to_string(IPLocator::getPhysicalPort(locator_))});
 
             socket_ = std::make_shared<asio::ip::tcp::socket>(service_);
             std::weak_ptr<TCPChannelResource> channel_weak_ptr = myself;
@@ -74,20 +76,20 @@ void TCPChannelResourceBasic::connect(
                 endpoints,
                 [this, channel_weak_ptr](std::error_code ec
 #if ASIO_VERSION >= 101200
-                        , ip::tcp::endpoint
+                , ip::tcp::endpoint
 #else
-                        , ip::tcp::resolver::iterator
+                , ip::tcp::resolver::iterator
 #endif
-                        )
-                {
-                    if (!channel_weak_ptr.expired())
-                    {
-                        parent_->SocketConnected(channel_weak_ptr, ec);
-                    }
-                }
-            );
+                )
+                        {
+                            if (!channel_weak_ptr.expired())
+                            {
+                                parent_->SocketConnected(channel_weak_ptr, ec);
+                            }
+                        }
+                );
         }
-        catch(const std::system_error &error)
+        catch (const std::system_error& error)
         {
             logError(RTCP, "Openning socket " << error.what());
         }
@@ -101,23 +103,23 @@ void TCPChannelResourceBasic::disconnect()
         auto socket = socket_;
 
         service_.post([&, socket]()
-                {
-                    try
                     {
-                        std::error_code ec;
-                        socket->shutdown(asio::ip::tcp::socket::shutdown_both, ec);
-                        socket->cancel();
+                        try
+                        {
+                            std::error_code ec;
+                            socket->shutdown(asio::ip::tcp::socket::shutdown_both, ec);
+                            socket->cancel();
 
-                    // This method was added on the version 1.12.0
+                            // This method was added on the version 1.12.0
 #if ASIO_VERSION >= 101200 && (!defined(_WIN32_WINNT) || _WIN32_WINNT >= 0x0603)
-                        socket->release();
+                            socket->release();
 #endif
-                        socket->close();
-                    }
-                    catch(std::exception&)
-                    {
-                    }
-                });
+                            socket->close();
+                        }
+                        catch (std::exception&)
+                        {
+                        }
+                    });
 
     }
 }
@@ -148,21 +150,16 @@ size_t TCPChannelResourceBasic::send(
 
     if (eConnecting < connection_status_)
     {
-        std::unique_lock<std::mutex> write_lock(write_mutex_);
-
-
+        std::vector<asio::const_buffer> buffers;
         if (header_size > 0)
         {
-            bytes_sent = socket_->send(asio::buffer(header, header_size), 0, ec);
+            buffers.push_back(asio::buffer(header, header_size));
         }
-
-        if (!ec)
-        {
-            bytes_sent += socket_->send(asio::buffer(data, size), 0, ec);
-        }
+        buffers.push_back(asio::buffer(data, size));
+        bytes_sent = asio::write(*socket_.get(), buffers, ec);
     }
 
-    return  bytes_sent;
+    return bytes_sent;
 }
 
 asio::ip::tcp::endpoint TCPChannelResourceBasic::remote_endpoint() const
@@ -176,7 +173,8 @@ asio::ip::tcp::endpoint TCPChannelResourceBasic::local_endpoint() const
     return socket_->local_endpoint(ec);
 }
 
-void TCPChannelResourceBasic::set_options(const TCPTransportDescriptor* options)
+void TCPChannelResourceBasic::set_options(
+        const TCPTransportDescriptor* options)
 {
     socket_->set_option(socket_base::receive_buffer_size(options->receiveBufferSize));
     socket_->set_option(socket_base::send_buffer_size(options->sendBufferSize));
@@ -193,7 +191,8 @@ void TCPChannelResourceBasic::close()
     socket_->close();
 }
 
-void TCPChannelResourceBasic::shutdown(asio::socket_base::shutdown_type what)
+void TCPChannelResourceBasic::shutdown(
+        asio::socket_base::shutdown_type what)
 {
     socket_->shutdown(what);
 }

--- a/src/cpp/transport/TCPChannelResourceBasic.cpp
+++ b/src/cpp/transport/TCPChannelResourceBasic.cpp
@@ -18,7 +18,7 @@
 #include <fastrtps/utils/IPLocator.h>
 
 #include <future>
-#include <vector>
+#include <array>
 
 using namespace asio;
 


### PR DESCRIPTION
`asio::write()` ensures all data is sent. This function avoids an error using `asio::basic_stream_socket::send()` with large fragments.

Fixed #941.