### PR TITLE
Bugfix: UDPTransportInterface::select_locators <1.9.x> [7231]

### DIFF
--- a/src/cpp/transport/UDPTransportInterface.cpp
+++ b/src/cpp/transport/UDPTransportInterface.cpp
@@ -565,7 +565,7 @@ void UDPTransportInterface::select_locators(LocatorSelector& selector) const
             {
                 for (size_t j = 0; j < entry->unicast.size(); ++j)
                 {
-                    if (IsLocatorSupported(entry->unicast[j].kind) && !selector.is_selected(entry->unicast[j]))
+                    if (IsLocatorSupported(entry->unicast[j]) && !selector.is_selected(entry->unicast[j]))
                     {
                         entry->state.unicast.push_back(j);
                         selected = true;


### PR DESCRIPTION
In UDPTransportInterface::select_locators, IsLocatorSupported() is called with unicast[j].kind instead of unicast[j]. This is an error because IsLocatorSupported() receives a Locator_t as parameter, so when passing unicast[i].kind an instance of a Locator_t with kind UDP and port_number (unicast[i].kind) is created and passed to IsLocatorSupported().

This bug can cause problems when a Participant registers a Transport UDP and an additional transport like, for example, TCP. In that case UDPTransportInterface::IsLocatorSupported over TCP locators will return true because TCP locators will be converted to Locator_t (kind = UDP, port = TCP.Kind) in the call to IsLocatorSupported.