### PR TITLE
[1.9.x] Correct clang warnings due to overwritten methods [7263]

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -308,7 +308,7 @@ if(BUILD_DOCUMENTATION)
     elseif(WIN32)
         set(DOXYFILE_MAKE make.bat)
     endif()
-    
+
     if(NOT CHECK_DOCUMENTATION)
         find_program(WGET_EXE wget)
         if(WGET_EXE)

--- a/test/performance/latency/LatencyTestTypes.hpp
+++ b/test/performance/latency/LatencyTestTypes.hpp
@@ -61,11 +61,11 @@ class LatencyDataType : public eprosima::fastrtps::TopicDataType
             m_isGetKeyDefined = false;
         };
         ~LatencyDataType(){};
-        bool serialize(void*data, eprosima::fastrtps::rtps::SerializedPayload_t* payload);
-        bool deserialize(eprosima::fastrtps::rtps::SerializedPayload_t* payload,void * data);
-        std::function<uint32_t()> getSerializedSizeProvider(void* data);
-        void* createData();
-        void deleteData(void* data);
+        bool serialize(void*data, eprosima::fastrtps::rtps::SerializedPayload_t* payload) override;
+        bool deserialize(eprosima::fastrtps::rtps::SerializedPayload_t* payload,void * data) override;
+        std::function<uint32_t()> getSerializedSizeProvider(void* data) override;
+        void* createData() override;
+        void deleteData(void* data) override;
         bool getKey(void* /*data*/, eprosima::fastrtps::rtps::InstanceHandle_t* /*ihandle*/, bool force_md5 = false) override {
             (void)force_md5;
             return false;
@@ -99,11 +99,11 @@ class TestCommandDataType : public eprosima::fastrtps::TopicDataType
             m_isGetKeyDefined = false;
         };
         ~TestCommandDataType(){};
-        bool serialize(void*data,eprosima::fastrtps::rtps::SerializedPayload_t* payload);
-        bool deserialize(eprosima::fastrtps::rtps::SerializedPayload_t* payload,void * data);
-        std::function<uint32_t()> getSerializedSizeProvider(void* data);
-        void* createData();
-        void deleteData(void* data);
+        bool serialize(void*data,eprosima::fastrtps::rtps::SerializedPayload_t* payload) override;
+        bool deserialize(eprosima::fastrtps::rtps::SerializedPayload_t* payload,void * data) override;
+        std::function<uint32_t()> getSerializedSizeProvider(void* data) override;
+        void* createData() override;
+        void deleteData(void* data) override;
         bool getKey(void* /*data*/, eprosima::fastrtps::rtps::InstanceHandle_t* /*ihandle*/, bool force_md5 = false) override {
             (void)force_md5;
             return false;

--- a/test/performance/latency/main_LatencyTest.cpp
+++ b/test/performance/latency/main_LatencyTest.cpp
@@ -36,12 +36,6 @@
 using namespace eprosima::fastrtps;
 using namespace eprosima::fastrtps::rtps;
 
-#if defined(__LITTLE_ENDIAN__)
-const Endianness_t DEFAULT_ENDIAN = LITTLEEND;
-#elif defined (__BIG_ENDIAN__)
-const Endianness_t DEFAULT_ENDIAN = BIGEND;
-#endif
-
 #if defined(_WIN32)
 #define COPYSTR strcpy_s
 #else

--- a/test/performance/throughput/ThroughputTypes.hpp
+++ b/test/performance/throughput/ThroughputTypes.hpp
@@ -131,19 +131,19 @@ class ThroughputDataType: public eprosima::fastrtps::TopicDataType
 
         bool serialize(
                 void*data,
-                eprosima::fastrtps::rtps::SerializedPayload_t* payload);
+                eprosima::fastrtps::rtps::SerializedPayload_t* payload) override;
 
         bool deserialize(
                 eprosima::fastrtps::rtps::SerializedPayload_t* payload,
-                void * data);
+                void * data) override;
 
         std::function<uint32_t()> getSerializedSizeProvider(
-                void* data);
+                void* data) override;
 
-        void* createData();
+        void* createData() override;
 
         void deleteData(
-                void* data);
+                void* data) override;
 
         bool getKey(
                 void* /*data*/,
@@ -230,19 +230,19 @@ class ThroughputCommandDataType : public eprosima::fastrtps::TopicDataType
 
         bool serialize(
                 void*data,
-                eprosima::fastrtps::rtps::SerializedPayload_t* payload);
+                eprosima::fastrtps::rtps::SerializedPayload_t* payload) override;
 
         bool deserialize(
                 eprosima::fastrtps::rtps::SerializedPayload_t* payload,
-                void * data);
+                void * data) override;
 
         std::function<uint32_t()> getSerializedSizeProvider(
-                void* data);
+                void* data) override;
 
-        void* createData();
+        void* createData() override;
 
         void deleteData(
-                void* data);
+                void* data) override;
 
         bool getKey(
                 void* /*data*/,

--- a/test/performance/throughput/main_ThroughputTest.cpp
+++ b/test/performance/throughput/main_ThroughputTest.cpp
@@ -37,13 +37,6 @@
 using namespace eprosima::fastrtps;
 using namespace eprosima::fastrtps::rtps;
 
-
-#if defined(__LITTLE_ENDIAN__)
-const Endianness_t DEFAULT_ENDIAN = LITTLEEND;
-#elif defined (__BIG_ENDIAN__)
-const Endianness_t DEFAULT_ENDIAN = BIGEND;
-#endif
-
 #if defined(_WIN32)
 #define COPYSTR strcpy_s
 #else

--- a/test/performance/video/VideoTestTypes.hpp
+++ b/test/performance/video/VideoTestTypes.hpp
@@ -72,11 +72,11 @@ class VideoDataType : public eprosima::fastrtps::TopicDataType
             m_isGetKeyDefined = false;
         };
         ~VideoDataType(){};
-        bool serialize(void*data, eprosima::fastrtps::rtps::SerializedPayload_t* payload);
-        bool deserialize(eprosima::fastrtps::rtps::SerializedPayload_t* payload,void * data);
-        std::function<uint32_t()> getSerializedSizeProvider(void* data);
-        void* createData();
-        void deleteData(void* data);
+        bool serialize(void*data, eprosima::fastrtps::rtps::SerializedPayload_t* payload) override;
+        bool deserialize(eprosima::fastrtps::rtps::SerializedPayload_t* payload,void * data) override;
+        std::function<uint32_t()> getSerializedSizeProvider(void* data) override;
+        void* createData() override;
+        void deleteData(void* data) override;
         bool getKey(void* /*data*/, eprosima::fastrtps::rtps::InstanceHandle_t* /*ihandle*/, bool force_md5 = false) override {
             (void)force_md5;
             return false;
@@ -110,11 +110,11 @@ class TestCommandDataType : public eprosima::fastrtps::TopicDataType
             m_isGetKeyDefined = false;
         };
         ~TestCommandDataType(){};
-        bool serialize(void*data,eprosima::fastrtps::rtps::SerializedPayload_t* payload);
-        bool deserialize(eprosima::fastrtps::rtps::SerializedPayload_t* payload,void * data);
-        std::function<uint32_t()> getSerializedSizeProvider(void* data);
-        void* createData();
-        void deleteData(void* data);
+        bool serialize(void*data,eprosima::fastrtps::rtps::SerializedPayload_t* payload) override;
+        bool deserialize(eprosima::fastrtps::rtps::SerializedPayload_t* payload,void * data) override;
+        std::function<uint32_t()> getSerializedSizeProvider(void* data) override;
+        void* createData() override;
+        void deleteData(void* data) override;
         bool getKey(void* /*data*/, eprosima::fastrtps::rtps::InstanceHandle_t* /*ihandle*/, bool force_md5 = false) override {
             (void)force_md5;
             return false;

--- a/test/performance/video/main_VideoTest.cpp
+++ b/test/performance/video/main_VideoTest.cpp
@@ -38,12 +38,6 @@
 using namespace eprosima::fastrtps;
 using namespace eprosima::fastrtps::rtps;
 
-#if defined(__LITTLE_ENDIAN__)
-const Endianness_t DEFAULT_ENDIAN = LITTLEEND;
-#elif defined (__BIG_ENDIAN__)
-const Endianness_t DEFAULT_ENDIAN = BIGEND;
-#endif
-
 #if defined(_WIN32)
 #define COPYSTR strcpy_s
 #else


### PR DESCRIPTION
Backport of #954 to 1.9.x