### PR TITLE
Solve throughput test compiler warning in Windows <master>

### DIFF
--- a/test/performance/throughput/ThroughputPublisher.cpp
+++ b/test/performance/throughput/ThroughputPublisher.cpp
@@ -774,7 +774,7 @@ bool ThroughputPublisher::load_recoveries()
             iss >> input_recovery;
             if (input_recovery < 0)
             {
-                std::cout << "Recovery times must be positive. " << recovery << " found" << std::endl;
+                std::cout << "Recovery times must be positive. " << input_recovery << " found" << std::endl;
                 return false;
             }
             recovery = static_cast<uint32_t>(input_recovery);

--- a/test/performance/throughput/ThroughputPublisher.cpp
+++ b/test/performance/throughput/ThroughputPublisher.cpp
@@ -760,7 +760,7 @@ bool ThroughputPublisher::load_recoveries()
     std::string line;
     size_t start;
     size_t end;
-    int32_t recovery;
+    uint32_t recovery;
     bool more = true;
     while (std::getline(fi, line))
     {

--- a/test/performance/throughput/ThroughputPublisher.cpp
+++ b/test/performance/throughput/ThroughputPublisher.cpp
@@ -761,6 +761,7 @@ bool ThroughputPublisher::load_recoveries()
     size_t start;
     size_t end;
     uint32_t recovery;
+    int32_t input_recovery;
     bool more = true;
     while (std::getline(fi, line))
     {
@@ -770,12 +771,13 @@ bool ThroughputPublisher::load_recoveries()
         while (more)
         {
             std::istringstream iss(line.substr(start, end - start));
-            iss >> recovery;
-            if (recovery < 0)
+            iss >> input_recovery;
+            if (input_recovery < 0)
             {
                 std::cout << "Recovery times must be positive. " << recovery << " found" << std::endl;
                 return false;
             }
+            recovery = static_cast<uint32_t>(input_recovery);
             // Only add if it was not there already
             if (std::find(recovery_times_.begin(), recovery_times_.end(), recovery) == recovery_times_.end())
             {


### PR DESCRIPTION
From [Windows nightly 187](http://jenkins.eprosima.com:8080/job/FastRTPS%20Nightly%20Master%20Windows/label=windows-secure,platform=Win32,toolset=v141/187/consoleFull)
```
C:\Program Files (x86)\Microsoft Visual Studio\2017\BuildTools\VC\Tools\MSVC\14.16.27023\include\xutility(3520): warning C4389: '==': signed/unsigned mismatch (compiling source file C:\fastrtps-nightly\e0db3111\src\fastrtps\test\performance\throughput\ThroughputPublisher.cpp) [C:\fastrtps-nightly\e0db3111\build\fastrtps\test\performance\throughput\ThroughputTest.vcxproj]
  C:\Program Files (x86)\Microsoft Visual Studio\2017\BuildTools\VC\Tools\MSVC\14.16.27023\include\xutility(3533): note: see reference to function template instantiation '_InIt std::_Find_unchecked1<_InIt,_Ty>(_InIt,const _InIt,const _Ty &,std::false_type)' being compiled
          with
          [
              _InIt=unsigned int *,
              _Ty=int32_t
          ] (compiling source file C:\fastrtps-nightly\e0db3111\src\fastrtps\test\performance\throughput\ThroughputPublisher.cpp)
  C:\Program Files (x86)\Microsoft Visual Studio\2017\BuildTools\VC\Tools\MSVC\14.16.27023\include\xutility(3542): note: see reference to function template instantiation '_InIt std::_Find_unchecked<unsigned int*,_Ty>(const _InIt,const _InIt,const _Ty &)' being compiled
          with
          [
              _InIt=unsigned int *,
              _Ty=int32_t
          ] (compiling source file C:\fastrtps-nightly\e0db3111\src\fastrtps\test\performance\throughput\ThroughputPublisher.cpp)
  C:\fastrtps-nightly\e0db3111\src\fastrtps\test\performance\throughput\ThroughputPublisher.cpp(780): note: see reference to function template instantiation '_InIt std::find<std::_Vector_iterator<std::_Vector_val<std::_Simple_types<_Ty>>>,int32_t>(_InIt,const _InIt,const int &)' being compiled
          with
          [
              _InIt=std::_Vector_iterator<std::_Vector_val<std::_Simple_types<std::_Vbase>>>,
              _Ty=std::_Vbase
          ]
```