### PR TITLE
Ref. 7288 Change removed when not on instance [7289]

### DIFF
--- a/src/cpp/subscriber/SubscriberHistory.cpp
+++ b/src/cpp/subscriber/SubscriberHistory.cpp
@@ -415,22 +415,20 @@ bool SubscriberHistory::remove_change_sub(
     }
 
     std::lock_guard<RecursiveTimedMutex> guard(*mp_mutex);
-    if (mp_subImpl->getAttributes().topic.getTopicKind() != NO_KEY)
+    if (mp_subImpl->getAttributes().topic.getTopicKind() == WITH_KEY)
     {
-        t_m_Inst_Caches::iterator vit;
-        if (!find_key(change, &vit))
-        {
-            return false;
-        }
-
         bool found = false;
-        for (auto chit = vit->second.cache_changes.begin(); chit != vit->second.cache_changes.end(); ++chit)
+        t_m_Inst_Caches::iterator vit;
+        if (find_key(change, &vit))
         {
-            if ((*chit)->sequenceNumber == change->sequenceNumber && (*chit)->writerGUID == change->writerGUID)
+            for (auto chit = vit->second.cache_changes.begin(); chit != vit->second.cache_changes.end(); ++chit)
             {
-                vit->second.cache_changes.erase(chit);
-                found = true;
-                break;
+                if ((*chit)->sequenceNumber == change->sequenceNumber && (*chit)->writerGUID == change->writerGUID)
+                {
+                    vit->second.cache_changes.erase(chit);
+                    found = true;
+                    break;
+                }
             }
         }
         if (!found)
@@ -438,11 +436,13 @@ bool SubscriberHistory::remove_change_sub(
             logWarning(SUBSCRIBER, "Change not found, something is wrong");
         }
     }
+
     if (remove_change(change))
     {
         m_isHistoryFull = false;
         return true;
     }
+
     return false;
 }
 

--- a/test/blackbox/BlackboxTests.hpp
+++ b/test/blackbox/BlackboxTests.hpp
@@ -60,6 +60,9 @@ template<>
 void default_receive_print(const FixedSized& hello);
 
 template<>
+void default_receive_print(const KeyedHelloWorld& str);
+
+template<>
 void default_receive_print(const String& str);
 
 template<>
@@ -82,6 +85,9 @@ void default_send_print(const HelloWorld& hello);
 
 template<>
 void default_send_print(const FixedSized& hello);
+
+template<>
+void default_send_print(const KeyedHelloWorld& str);
 
 template<>
 void default_send_print(const String& str);

--- a/test/blackbox/PubSubReader.hpp
+++ b/test/blackbox/PubSubReader.hpp
@@ -546,6 +546,18 @@ public:
         return *this;
     }
 
+    PubSubReader& resource_limits_max_instances(const int32_t max)
+    {
+        subscriber_attr_.topic.resourceLimitsQos.max_instances = max;
+        return *this;
+    }
+
+    PubSubReader& resource_limits_max_samples_per_instance(const int32_t max)
+    {
+        subscriber_attr_.topic.resourceLimitsQos.max_samples_per_instance = max;
+        return *this;
+    }
+
     PubSubReader& matched_writers_allocation(size_t initial, size_t maximum)
     {
         subscriber_attr_.matched_publisher_allocation.initial = initial;

--- a/test/blackbox/PubSubWriter.hpp
+++ b/test/blackbox/PubSubWriter.hpp
@@ -576,6 +576,18 @@ class PubSubWriter
         return *this;
     }
 
+    PubSubWriter& resource_limits_max_instances(const int32_t max)
+    {
+        publisher_attr_.topic.resourceLimitsQos.max_instances = max;
+        return *this;
+    }
+
+    PubSubWriter& resource_limits_max_samples_per_instance(const int32_t max)
+    {
+        publisher_attr_.topic.resourceLimitsQos.max_samples_per_instance = max;
+        return *this;
+    }
+
     PubSubWriter& matched_readers_allocation(size_t initial, size_t maximum)
     {
         publisher_attr_.matched_subscriber_allocation.initial = initial;

--- a/test/blackbox/types/KeyedHelloWorld.cpp
+++ b/test/blackbox/types/KeyedHelloWorld.cpp
@@ -35,8 +35,8 @@ using namespace eprosima::fastcdr::exception;
 
 KeyedHelloWorld::KeyedHelloWorld()
 {
+    m_index = 0;
     m_key = 0;
-
 }
 
 KeyedHelloWorld::~KeyedHelloWorld()
@@ -45,18 +45,21 @@ KeyedHelloWorld::~KeyedHelloWorld()
 
 KeyedHelloWorld::KeyedHelloWorld(const KeyedHelloWorld &x)
 {
+    m_index = x.m_index;
     m_key = x.m_key;
     m_message = x.m_message;
 }
 
 KeyedHelloWorld::KeyedHelloWorld(KeyedHelloWorld &&x)
 {
+    m_index = x.m_index;
     m_key = x.m_key;
     m_message = std::move(x.m_message);
 }
 
 KeyedHelloWorld& KeyedHelloWorld::operator=(const KeyedHelloWorld &x)
 {
+    m_index = x.m_index;
     m_key = x.m_key;
     m_message = x.m_message;
     
@@ -65,6 +68,7 @@ KeyedHelloWorld& KeyedHelloWorld::operator=(const KeyedHelloWorld &x)
 
 KeyedHelloWorld& KeyedHelloWorld::operator=(KeyedHelloWorld &&x)
 {
+    m_index = x.m_index;
     m_key = x.m_key;
     m_message = std::move(x.m_message);
     
@@ -73,7 +77,8 @@ KeyedHelloWorld& KeyedHelloWorld::operator=(KeyedHelloWorld &&x)
 
 bool KeyedHelloWorld::operator==(const KeyedHelloWorld &x) const
 {
-    if(m_message == x.m_message &&
+    if(m_index == x.m_index &&
+            m_message == x.m_message &&
             m_key == x.m_key)
         return true;
 
@@ -99,6 +104,7 @@ size_t KeyedHelloWorld::getCdrSerializedSize(const KeyedHelloWorld& data, size_t
 void KeyedHelloWorld::serialize(eprosima::fastcdr::Cdr &scdr) const
 {
     scdr << m_key;
+    scdr << m_index;
 
     if(m_message.length() <= 256)
     {
@@ -113,6 +119,7 @@ void KeyedHelloWorld::serialize(eprosima::fastcdr::Cdr &scdr) const
 void KeyedHelloWorld::deserialize(eprosima::fastcdr::Cdr &dcdr)
 {
     dcdr >> m_key;
+    dcdr >> m_index;
     dcdr >> m_message;
 }
 

--- a/test/blackbox/types/KeyedHelloWorld.h
+++ b/test/blackbox/types/KeyedHelloWorld.h
@@ -114,6 +114,33 @@ public:
     {
         return m_key;
     }
+
+    /*
+     * @brief This function sets a value in member index
+     * @param _index New value for member index
+     */
+   inline eProsima_user_DllExport void index(uint16_t _index)
+   {
+       m_index = _index;
+   }
+
+   /*!
+    * @brief This function returns the value of member index
+    * @return Value of member index
+    */
+   inline eProsima_user_DllExport uint16_t index() const
+   {
+       return m_index;
+   }
+
+   /*!
+    * @brief This function returns a reference to member index
+    * @return Reference to member index
+    */
+   inline eProsima_user_DllExport uint16_t& index()
+   {
+       return m_index;
+   }
     /*!
      * @brief This function copies the value in member message
      * @param _message New value to be copied in member message
@@ -201,6 +228,7 @@ public:
     eProsima_user_DllExport void serializeKey(eprosima::fastcdr::Cdr &cdr) const;
     
 private:
+    uint16_t m_index;
     uint16_t m_key;
     std::string m_message;
 };

--- a/test/blackbox/utils/data_generators.cpp
+++ b/test/blackbox/utils/data_generators.cpp
@@ -60,6 +60,7 @@ std::list<KeyedHelloWorld> default_keyedhelloworld_data_generator(size_t max)
     std::generate(returnedValue.begin(), returnedValue.end(), [&index]
     {
         KeyedHelloWorld hello;
+        hello.index(index);
         hello.key(index % 2);
         std::stringstream ss;
         ss << "HelloWorld " << index;

--- a/test/blackbox/utils/print_functions.cpp
+++ b/test/blackbox/utils/print_functions.cpp
@@ -21,6 +21,12 @@ void default_receive_print(const HelloWorld& hello)
 }
 
 template<>
+void default_receive_print(const KeyedHelloWorld& hello)
+{
+    std::cout << "Received HelloWorld " << hello.index() << " with key " << hello.key() << std::endl;
+}
+
+template<>
 void default_receive_print(const FixedSized& hello)
 {
     std::cout << "Received FixedSized " << hello.index() << std::endl;
@@ -55,6 +61,12 @@ template<>
 void default_send_print(const HelloWorld& hello)
 {
     std::cout << "Sent HelloWorld " << hello.index() << std::endl;
+}
+
+template<>
+void default_send_print(const KeyedHelloWorld& hello)
+{
+    std::cout << "Sent HelloWorld " << hello.index() << " with key " << hello.key() << std::endl;
 }
 
 template<>


### PR DESCRIPTION
SubscriberHistory::remove_change_sub should remove from
the general RTPS history even though it didn't find
the change in the instance's history.

Failing to do so will result on the same change returned
once and again every time a new change is added
to the subscriber's history