### PR TITLE
Ref. 7290 propagate errors on take_next_data [7292]

### DIFF
--- a/include/fastrtps/subscriber/SubscriberHistory.h
+++ b/include/fastrtps/subscriber/SubscriberHistory.h
@@ -191,7 +191,7 @@ class SubscriberHistory: public rtps::ReaderHistory
                 rtps::CacheChange_t* a_change,
                 std::vector<rtps::CacheChange_t*>& instance_changes);
 
-        void deserialize_change(
+        bool deserialize_change(
                 rtps::CacheChange_t* change,
                 uint32_t ownership_strength,
                 void* data,

--- a/src/cpp/subscriber/SubscriberHistory.cpp
+++ b/src/cpp/subscriber/SubscriberHistory.cpp
@@ -437,7 +437,7 @@ bool SubscriberHistory::remove_change_sub(
         }
         if (!found)
         {
-            logWarning(SUBSCRIBER, "Change not found, something is wrong");
+            logError(RTPS_HISTORY, "Change not found on this key, something is wrong");
         }
     }
 

--- a/src/cpp/subscriber/SubscriberHistory.cpp
+++ b/src/cpp/subscriber/SubscriberHistory.cpp
@@ -91,7 +91,7 @@ bool SubscriberHistory::received_change(
 {
     if (mp_reader == nullptr || mp_mutex == nullptr)
     {
-        logError(RTPS_HISTORY, "You need to create a Reader with this History before using it");
+        logError(SUBSCRIBER, "You need to create a Reader with this History before using it");
         return false;
     }
 
@@ -255,7 +255,7 @@ bool SubscriberHistory::find_key_for_change(
 {
     if (!a_change->instanceHandle.isDefined() && mp_subImpl->getType() != nullptr)
     {
-        logInfo(RTPS_HISTORY, "Getting Key of change with no Key transmitted")
+        logInfo(SUBSCRIBER, "Getting Key of change with no Key transmitted")
         mp_subImpl->getType()->deserialize(&a_change->serializedPayload, mp_getKeyObject);
         bool is_key_protected = false;
 #if HAVE_SECURITY
@@ -268,7 +268,7 @@ bool SubscriberHistory::find_key_for_change(
     }
     else if (!a_change->instanceHandle.isDefined())
     {
-        logWarning(RTPS_HISTORY, "NO KEY in topic: " << mp_subImpl->getAttributes().topic.topicName
+        logWarning(SUBSCRIBER, "NO KEY in topic: " << mp_subImpl->getAttributes().topic.topicName
             << " and no method to obtain it";);
         return false;
     }
@@ -286,7 +286,7 @@ bool SubscriberHistory::deserialize_change(
     {
         if (!mp_subImpl->getType()->deserialize(&change->serializedPayload, data))
         {
-            logError(RTPS_HISTORY, "Deserialization of data failed");
+            logError(SUBSCRIBER, "Deserialization of data failed");
             return false;
         }
     }
@@ -322,7 +322,7 @@ bool SubscriberHistory::readNextData(
 {
     if (mp_reader == nullptr || mp_mutex == nullptr)
     {
-        logError(RTPS_HISTORY, "You need to create a Reader with this History before using it");
+        logError(SUBSCRIBER, "You need to create a Reader with this History before using it");
         return false;
     }
 
@@ -351,7 +351,7 @@ bool SubscriberHistory::takeNextData(
 {
     if (mp_reader == nullptr || mp_mutex == nullptr)
     {
-        logError(RTPS_HISTORY, "You need to create a Reader with this History before using it");
+        logError(SUBSCRIBER, "You need to create a Reader with this History before using it");
         return false;
     }
 
@@ -414,7 +414,7 @@ bool SubscriberHistory::remove_change_sub(
 {
     if (mp_reader == nullptr || mp_mutex == nullptr)
     {
-        logError(RTPS_HISTORY, "You need to create a Reader with this History before using it");
+        logError(SUBSCRIBER, "You need to create a Reader with this History before using it");
         return false;
     }
 
@@ -437,7 +437,7 @@ bool SubscriberHistory::remove_change_sub(
         }
         if (!found)
         {
-            logError(RTPS_HISTORY, "Change not found on this key, something is wrong");
+            logError(SUBSCRIBER, "Change not found on this key, something is wrong");
         }
     }
 
@@ -456,7 +456,7 @@ bool SubscriberHistory::set_next_deadline(
 {
     if (mp_reader == nullptr || mp_mutex == nullptr)
     {
-        logError(RTPS_HISTORY, "You need to create a Reader with this History before using it");
+        logError(SUBSCRIBER, "You need to create a Reader with this History before using it");
         return false;
     }
     std::lock_guard<RecursiveTimedMutex> guard(*mp_mutex);
@@ -486,7 +486,7 @@ bool SubscriberHistory::get_next_deadline(
 {
     if (mp_reader == nullptr || mp_mutex == nullptr)
     {
-        logError(RTPS_HISTORY, "You need to create a Reader with this History before using it");
+        logError(SUBSCRIBER, "You need to create a Reader with this History before using it");
         return false;
     }
     std::lock_guard<RecursiveTimedMutex> guard(*mp_mutex);


### PR DESCRIPTION
SubscriberHistory::deserialize_change must return the result of the deserialization
and SubscriberHistory::takeNextData should propagate errors on deserialization and removal from history