### PR TITLE
[7138] Bugfix/discovery server localhost

### DIFF
--- a/include/fastrtps/rtps/builtin/BuiltinProtocols.h
+++ b/include/fastrtps/rtps/builtin/BuiltinProtocols.h
@@ -24,7 +24,7 @@
 #include <list>
 
 #include "../attributes/RTPSParticipantAttributes.h"
-
+#include "../network/NetworkFactory.h"
 
 namespace eprosima {
 
@@ -70,6 +70,13 @@ class BuiltinProtocols
      * @return True on success
      */
     bool updateMetatrafficLocators(LocatorList_t& loclist);
+
+    /**
+     * Traverses the list of discover servers translating from remote to local locators
+     * if possible
+     * @param nf NetworkFactory used to make the translation
+     */
+    void transform_server_remote_locators(NetworkFactory & nf);
 
     //!BuiltinAttributes of the builtin protocols.
     BuiltinAttributes m_att;

--- a/include/fastrtps/rtps/builtin/BuiltinProtocols.h
+++ b/include/fastrtps/rtps/builtin/BuiltinProtocols.h
@@ -69,14 +69,16 @@ class BuiltinProtocols
      * @param loclist LocatorList to update
      * @return True on success
      */
-    bool updateMetatrafficLocators(LocatorList_t& loclist);
+    bool updateMetatrafficLocators(
+        LocatorList_t& loclist);
 
     /**
      * Traverses the list of discover servers translating from remote to local locators
      * if possible
      * @param nf NetworkFactory used to make the translation
      */
-    void transform_server_remote_locators(NetworkFactory & nf);
+    void transform_server_remote_locators(
+        NetworkFactory & nf);
 
     //!BuiltinAttributes of the builtin protocols.
     BuiltinAttributes m_att;

--- a/include/fastrtps/rtps/builtin/BuiltinProtocols.h
+++ b/include/fastrtps/rtps/builtin/BuiltinProtocols.h
@@ -78,7 +78,7 @@ class BuiltinProtocols
      * @param nf NetworkFactory used to make the translation
      */
     void transform_server_remote_locators(
-        NetworkFactory & nf);
+            NetworkFactory & nf);
 
     //!BuiltinAttributes of the builtin protocols.
     BuiltinAttributes m_att;

--- a/include/fastrtps/rtps/builtin/BuiltinProtocols.h
+++ b/include/fastrtps/rtps/builtin/BuiltinProtocols.h
@@ -80,13 +80,6 @@ class BuiltinProtocols
     void transform_server_remote_locators(
         NetworkFactory & nf);
 
-    /**
-     * Traverses the list of discover servers translating from remote to local locators
-     * if possible
-     * @param nf NetworkFactory used to make the translation
-     */
-    void transform_server_remote_locators(NetworkFactory & nf);
-
     //!BuiltinAttributes of the builtin protocols.
     BuiltinAttributes m_att;
     //!Pointer to the RTPSParticipantImpl.

--- a/include/fastrtps/rtps/builtin/BuiltinProtocols.h
+++ b/include/fastrtps/rtps/builtin/BuiltinProtocols.h
@@ -70,7 +70,7 @@ class BuiltinProtocols
      * @return True on success
      */
     bool updateMetatrafficLocators(
-        LocatorList_t& loclist);
+            LocatorList_t& loclist);
 
     /**
      * Traverses the list of discover servers translating from remote to local locators

--- a/include/fastrtps/rtps/builtin/BuiltinProtocols.h
+++ b/include/fastrtps/rtps/builtin/BuiltinProtocols.h
@@ -80,6 +80,13 @@ class BuiltinProtocols
     void transform_server_remote_locators(
         NetworkFactory & nf);
 
+    /**
+     * Traverses the list of discover servers translating from remote to local locators
+     * if possible
+     * @param nf NetworkFactory used to make the translation
+     */
+    void transform_server_remote_locators(NetworkFactory & nf);
+
     //!BuiltinAttributes of the builtin protocols.
     BuiltinAttributes m_att;
     //!Pointer to the RTPSParticipantImpl.

--- a/src/cpp/rtps/builtin/BuiltinProtocols.cpp
+++ b/src/cpp/rtps/builtin/BuiltinProtocols.cpp
@@ -140,14 +140,14 @@ bool BuiltinProtocols::initBuiltinProtocols(
 }
 
 bool BuiltinProtocols::updateMetatrafficLocators(
-    LocatorList_t& loclist)
+        LocatorList_t& loclist)
 {
     m_metatrafficUnicastLocatorList = loclist;
     return true;
 }
 
 void BuiltinProtocols::transform_server_remote_locators(
-    NetworkFactory & nf)
+        NetworkFactory & nf)
 {
     for(RemoteServerAttributes & rs : m_DiscoveryServers)
     {

--- a/src/cpp/rtps/builtin/BuiltinProtocols.cpp
+++ b/src/cpp/rtps/builtin/BuiltinProtocols.cpp
@@ -139,13 +139,15 @@ bool BuiltinProtocols::initBuiltinProtocols(
     return true;
 }
 
-bool BuiltinProtocols::updateMetatrafficLocators(LocatorList_t& loclist)
+bool BuiltinProtocols::updateMetatrafficLocators(
+    LocatorList_t& loclist)
 {
     m_metatrafficUnicastLocatorList = loclist;
     return true;
 }
 
-void BuiltinProtocols::transform_server_remote_locators(NetworkFactory & nf)
+void BuiltinProtocols::transform_server_remote_locators(
+    NetworkFactory & nf)
 {
     for(RemoteServerAttributes & rs : m_DiscoveryServers)
     {

--- a/src/cpp/rtps/builtin/BuiltinProtocols.cpp
+++ b/src/cpp/rtps/builtin/BuiltinProtocols.cpp
@@ -79,6 +79,8 @@ bool BuiltinProtocols::initBuiltinProtocols(
     m_initialPeersList = m_att.initialPeersList;
     m_DiscoveryServers = m_att.discovery_config.m_DiscoveryServers;
 
+    transform_server_remote_locators(p_part->network_factory());
+
     const RTPSParticipantAllocationAttributes& allocation = p_part->getRTPSParticipantAttributes().allocation;
 
     // PDP
@@ -141,6 +143,21 @@ bool BuiltinProtocols::updateMetatrafficLocators(LocatorList_t& loclist)
 {
     m_metatrafficUnicastLocatorList = loclist;
     return true;
+}
+
+void BuiltinProtocols::transform_server_remote_locators(NetworkFactory & nf)
+{
+    for(RemoteServerAttributes & rs : m_DiscoveryServers)
+    {
+        for(Locator_t & loc : rs.metatrafficUnicastLocatorList)
+        {
+            Locator_t localized;
+            if(nf.transform_remote_locator(loc, localized))
+            {
+                loc = localized;
+            }
+        }
+    }
 }
 
 bool BuiltinProtocols::addLocalWriter(

--- a/src/cpp/rtps/builtin/data/ParticipantProxyData.cpp
+++ b/src/cpp/rtps/builtin/data/ParticipantProxyData.cpp
@@ -17,6 +17,7 @@
  *
  */
 
+#include <fastrtps/rtps/network/NetworkFactory.h>
 #include <fastrtps/rtps/builtin/data/ParticipantProxyData.h>
 #include <fastrtps/rtps/builtin/data/WriterProxyData.h>
 #include <fastrtps/rtps/builtin/data/ReaderProxyData.h>

--- a/src/cpp/rtps/builtin/discovery/participant/PDPServer.cpp
+++ b/src/cpp/rtps/builtin/discovery/participant/PDPServer.cpp
@@ -708,6 +708,8 @@ bool PDPServer::match_servers_EDP_endpoints()
 
 void PDPServer::announceParticipantState(bool new_change, bool dispose /* = false */, WriteParams& )
 {
+    logInfo(RTPS_PDP, "Announcing RTPSParticipant State (new change: " << new_change << ")");
+
     StatefulWriter * pW = dynamic_cast<StatefulWriter*>(mp_PDPWriter);
     assert(pW);
 

--- a/test/unittest/rtps/history/CacheChangePoolTests.cpp
+++ b/test/unittest/rtps/history/CacheChangePoolTests.cpp
@@ -256,7 +256,7 @@ INSTANTIATE_TEST_CASE_P(
             Values(MemoryManagementPolicy_t::PREALLOCATED_MEMORY_MODE,
                    MemoryManagementPolicy_t::PREALLOCATED_WITH_REALLOC_MEMORY_MODE,
                    MemoryManagementPolicy_t::DYNAMIC_RESERVE_MEMORY_MODE,
-                   MemoryManagementPolicy_t::DYNAMIC_REUSABLE_MEMORY_MODE)) );
+                   MemoryManagementPolicy_t::DYNAMIC_REUSABLE_MEMORY_MODE)), );
 
 int main(int argc, char **argv)
 {

--- a/test/unittest/rtps/history/CacheChangePoolTests.cpp
+++ b/test/unittest/rtps/history/CacheChangePoolTests.cpp
@@ -256,7 +256,7 @@ INSTANTIATE_TEST_CASE_P(
             Values(MemoryManagementPolicy_t::PREALLOCATED_MEMORY_MODE,
                    MemoryManagementPolicy_t::PREALLOCATED_WITH_REALLOC_MEMORY_MODE,
                    MemoryManagementPolicy_t::DYNAMIC_RESERVE_MEMORY_MODE,
-                   MemoryManagementPolicy_t::DYNAMIC_REUSABLE_MEMORY_MODE)), );
+                   MemoryManagementPolicy_t::DYNAMIC_REUSABLE_MEMORY_MODE)) );
 
 int main(int argc, char **argv)
 {


### PR DESCRIPTION
Applies the same treatment given to the locators received via DATA, to the locators pass into the RemoteServerAttributes.
Basically the locators become localhost if possible to speed things up.