### PR TITLE
[7138] Updated PDP to solve discovery-server issue on localhost.

### DIFF
--- a/include/fastdds/rtps/builtin/BuiltinProtocols.h
+++ b/include/fastdds/rtps/builtin/BuiltinProtocols.h
@@ -24,7 +24,7 @@
 #include <list>
 
 #include <fastdds/rtps/attributes/RTPSParticipantAttributes.h>
-
+#include <fastdds/rtps/network/NetworkFactory.h>
 
 namespace eprosima {
 
@@ -86,6 +86,14 @@ public:
      */
     bool updateMetatrafficLocators(
             LocatorList_t& loclist);
+
+    /**
+     * Traverses the list of discover servers translating from remote to local locators
+     * if possible
+     * @param nf NetworkFactory used to make the translation
+     */
+    void transform_server_remote_locators(
+            NetworkFactory & nf);
 
     //!BuiltinAttributes of the builtin protocols.
     BuiltinAttributes m_att;

--- a/src/cpp/rtps/builtin/BuiltinProtocols.cpp
+++ b/src/cpp/rtps/builtin/BuiltinProtocols.cpp
@@ -156,7 +156,8 @@ bool BuiltinProtocols::updateMetatrafficLocators(LocatorList_t& loclist)
     return true;
 }
 
-void BuiltinProtocols::transform_server_remote_locators(NetworkFactory & nf)
+void BuiltinProtocols::transform_server_remote_locators(
+        NetworkFactory & nf)
 {
     for(RemoteServerAttributes & rs : m_DiscoveryServers)
     {

--- a/src/cpp/rtps/builtin/BuiltinProtocols.cpp
+++ b/src/cpp/rtps/builtin/BuiltinProtocols.cpp
@@ -83,6 +83,8 @@ bool BuiltinProtocols::initBuiltinProtocols(
     m_initialPeersList = m_att.initialPeersList;
     m_DiscoveryServers = m_att.discovery_config.m_DiscoveryServers;
 
+    transform_server_remote_locators(p_part->network_factory());
+
     const RTPSParticipantAllocationAttributes& allocation = p_part->getRTPSParticipantAttributes().allocation;
 
     // PDP
@@ -152,6 +154,21 @@ bool BuiltinProtocols::updateMetatrafficLocators(LocatorList_t& loclist)
 {
     m_metatrafficUnicastLocatorList = loclist;
     return true;
+}
+
+void BuiltinProtocols::transform_server_remote_locators(NetworkFactory & nf)
+{
+    for(RemoteServerAttributes & rs : m_DiscoveryServers)
+    {
+        for(Locator_t & loc : rs.metatrafficUnicastLocatorList)
+        {
+            Locator_t localized;
+            if(nf.transform_remote_locator(loc, localized))
+            {
+                loc = localized;
+            }
+        }
+    }
 }
 
 bool BuiltinProtocols::addLocalWriter(

--- a/src/cpp/rtps/builtin/discovery/participant/PDPServer.cpp
+++ b/src/cpp/rtps/builtin/discovery/participant/PDPServer.cpp
@@ -714,6 +714,8 @@ bool PDPServer::match_servers_EDP_endpoints()
 
 void PDPServer::announceParticipantState(bool new_change, bool dispose /* = false */, WriteParams& )
 {
+    logInfo(RTPS_PDP, "Announcing RTPSParticipant State (new change: " << new_change << ")");
+
     StatefulWriter * pW = dynamic_cast<StatefulWriter*>(mp_PDPWriter);
     assert(pW);
 


### PR DESCRIPTION
Applies the same treatment given to the locators received via DATA, to the locators pass into the RemoteServerAttributes.
Basically the locators become localhost if possible to speed things up.