### PR TITLE
Fixed build without security after #938

### DIFF
--- a/include/fastrtps/rtps/messages/RTPSMessageGroup.h
+++ b/include/fastrtps/rtps/messages/RTPSMessageGroup.h
@@ -222,9 +222,9 @@ class RTPSMessageGroup_t;
 
         GuidPrefix_t current_dst_;
 
-#if HAVE_SECURITY
         RTPSParticipantImpl* participant_;
 
+#if HAVE_SECURITY
         CDRMessage_t* encrypt_msg_;
 #endif
 


### PR DESCRIPTION
This fixes a build error introduced on #938 when building without security.

Skipping tests, as they are always run with security enabled.