### PR TITLE
Avoid data races between ReceiverResource and Participant initialization [7475]

### DIFF
--- a/src/cpp/rtps/participant/RTPSParticipantImpl.cpp
+++ b/src/cpp/rtps/participant/RTPSParticipantImpl.cpp
@@ -56,10 +56,11 @@
 #include <fastrtps/log/Log.h>
 
 namespace eprosima {
-namespace fastrtps{
+namespace fastrtps {
 namespace rtps {
 
-static EntityId_t TrustedWriter(const EntityId_t& reader)
+static EntityId_t TrustedWriter(
+        const EntityId_t& reader)
 {
     return
         (reader == c_EntityId_SPDPReader) ? c_EntityId_SPDPWriter :
@@ -69,7 +70,8 @@ static EntityId_t TrustedWriter(const EntityId_t& reader)
         c_EntityId_Unknown;
 }
 
-Locator_t& RTPSParticipantImpl::applyLocatorAdaptRule(Locator_t& loc)
+Locator_t& RTPSParticipantImpl::applyLocatorAdaptRule(
+        Locator_t& loc)
 {
     // This is a completely made up rule
     // It is transport responsability to interpret this new port.
@@ -108,21 +110,22 @@ RTPSParticipantImpl::RTPSParticipantImpl(
     // Workaround TCP discovery issues when register
     switch (PParam.builtin.discovery_config.discoveryProtocol)
     {
-    case DiscoveryProtocol::CLIENT:
-    case DiscoveryProtocol::SERVER:
-    case DiscoveryProtocol::BACKUP:
-        // Verify if listening ports are provided
-        for (auto& transportDescriptor : PParam.userTransports)
-        {
-            TCPTransportDescriptor * pT = dynamic_cast<TCPTransportDescriptor *>(transportDescriptor.get());
-            if (pT && pT->listening_ports.empty())
+        case DiscoveryProtocol::CLIENT:
+        case DiscoveryProtocol::SERVER:
+        case DiscoveryProtocol::BACKUP:
+            // Verify if listening ports are provided
+            for (auto& transportDescriptor : PParam.userTransports)
             {
-                logError(RTPS_PARTICIPANT, "Participant " << m_att.getName() << " with GUID " << m_guid
-                    << " tries to use discovery server over TCP without providing a proper listening port");
+                TCPTransportDescriptor* pT = dynamic_cast<TCPTransportDescriptor*>(transportDescriptor.get());
+                if (pT && pT->listening_ports.empty())
+                {
+                    logError(RTPS_PARTICIPANT,
+                            "Participant " << m_att.getName() << " with GUID " << m_guid <<
+                            " tries to use discovery server over TCP without providing a proper listening port");
+                }
             }
-        }
-    default:
-        break;
+        default:
+            break;
     }
 
     // User defined transports
@@ -158,27 +161,31 @@ RTPSParticipantImpl::RTPSParticipantImpl(
     if (m_att.builtin.metatrafficMulticastLocatorList.empty() && m_att.builtin.metatrafficUnicastLocatorList.empty())
     {
         m_network_Factory.getDefaultMetatrafficMulticastLocators(m_att.builtin.metatrafficMulticastLocatorList,
-            metatraffic_multicast_port);
+                metatraffic_multicast_port);
         m_network_Factory.NormalizeLocators(m_att.builtin.metatrafficMulticastLocatorList);
 
         m_network_Factory.getDefaultMetatrafficUnicastLocators(m_att.builtin.metatrafficUnicastLocatorList,
-            metatraffic_unicast_port);
+                metatraffic_unicast_port);
         m_network_Factory.NormalizeLocators(m_att.builtin.metatrafficUnicastLocatorList);
     }
     else
     {
-        std::for_each(m_att.builtin.metatrafficMulticastLocatorList.begin(),
-            m_att.builtin.metatrafficMulticastLocatorList.end(), [&](Locator_t& locator)
-        {
-            m_network_Factory.fillMetatrafficMulticastLocator(locator, metatraffic_multicast_port);
-        });
+        std::for_each(
+            m_att.builtin.metatrafficMulticastLocatorList.begin(),
+            m_att.builtin.metatrafficMulticastLocatorList.end(),
+            [&](Locator_t& locator)
+            {
+                m_network_Factory.fillMetatrafficMulticastLocator(locator, metatraffic_multicast_port);
+            });
         m_network_Factory.NormalizeLocators(m_att.builtin.metatrafficMulticastLocatorList);
 
-        std::for_each(m_att.builtin.metatrafficUnicastLocatorList.begin(),
-            m_att.builtin.metatrafficUnicastLocatorList.end(), [&](Locator_t& locator)
-        {
-            m_network_Factory.fillMetatrafficUnicastLocator(locator, metatraffic_unicast_port);
-        });
+        std::for_each(
+            m_att.builtin.metatrafficUnicastLocatorList.begin(),
+            m_att.builtin.metatrafficUnicastLocatorList.end(),
+            [&](Locator_t& locator)
+            {
+                m_network_Factory.fillMetatrafficUnicastLocator(locator, metatraffic_unicast_port);
+            });
         m_network_Factory.NormalizeLocators(m_att.builtin.metatrafficUnicastLocatorList);
     }
 
@@ -195,7 +202,7 @@ RTPSParticipantImpl::RTPSParticipantImpl(
         std::for_each(initial_peers.begin(), initial_peers.end(),
             [&](Locator_t& locator)
             {
-               m_network_Factory.configureInitialPeerLocator(locator, m_att);
+                m_network_Factory.configureInitialPeerLocator(locator, m_att);
             });
     }
 
@@ -207,7 +214,7 @@ RTPSParticipantImpl::RTPSParticipantImpl(
        of Endpoints, we make some for Unicast only.
        If there is at least one listen locator of any kind, we do not create any default ones.
        If there are no sending locators defined, we create default ones for the transports we implement.
-       */
+     */
     if (m_att.defaultUnicastLocatorList.empty() && m_att.defaultMulticastLocatorList.empty())
     {
         //Default Unicast Locators in case they have not been provided
@@ -219,23 +226,26 @@ RTPSParticipantImpl::RTPSParticipantImpl(
     else
     {
         // Locator with port 0, calculate port.
-        std::for_each(m_att.defaultUnicastLocatorList.begin(), m_att.defaultUnicastLocatorList.end(),
+        std::for_each(
+            m_att.defaultUnicastLocatorList.begin(),
+            m_att.defaultUnicastLocatorList.end(),
             [&](Locator_t& loc)
-        {
-            m_network_Factory.fillDefaultUnicastLocator(loc, m_att);
-        });
+            {
+                m_network_Factory.fillDefaultUnicastLocator(loc, m_att);
+            });
 
     }
 
     // Normalize unicast locators.
     m_network_Factory.NormalizeLocators(m_att.defaultUnicastLocatorList);
-    
+
     if (!hasLocatorsDefined)
     {
-        logInfo(RTPS_PARTICIPANT, m_att.getName() << " Created with NO default Unicast Locator List, adding Locators:"
-            << m_att.defaultUnicastLocatorList);
+        logInfo(RTPS_PARTICIPANT, m_att.getName() <<
+            " Created with NO default Unicast Locator List, adding Locators:" <<
+            m_att.defaultUnicastLocatorList);
     }
-    
+
     createReceiverResources(m_att.builtin.metatrafficMulticastLocatorList, true, false);
     createReceiverResources(m_att.builtin.metatrafficUnicastLocatorList, true, false);
 
@@ -244,7 +254,7 @@ RTPSParticipantImpl::RTPSParticipantImpl(
 
     bool allow_growing_buffers = m_att.allocation.send_buffers.dynamic;
     size_t num_send_buffers = m_att.allocation.send_buffers.preallocated_number;
-    if(num_send_buffers == 0)
+    if (num_send_buffers == 0)
     {
         // Three buffers (user, events and async writer threads)
         num_send_buffers = 3;
@@ -258,7 +268,8 @@ RTPSParticipantImpl::RTPSParticipantImpl(
 #if HAVE_SECURITY
     // Start security
     // TODO(Ricardo) Get returned value in future.
-    m_security_manager_initialized = m_security_manager.init(security_attributes_, PParam.properties, m_is_security_active);
+    m_security_manager_initialized =
+        m_security_manager.init(security_attributes_, PParam.properties, m_is_security_active);
     if (!m_security_manager_initialized)
     {
         // Participant will be deleted, no need to allocate buffers or create builtin endpoints
@@ -292,7 +303,7 @@ void RTPSParticipantImpl::enable()
     }
 
     //Start reception
-    for(auto& receiver : m_receiverResourcelist)
+    for (auto& receiver : m_receiverResourcelist)
     {
         receiver.Receiver->RegisterReceiver(receiver.mp_receiver);
     }
@@ -304,18 +315,18 @@ void RTPSParticipantImpl::disable()
     m_network_Factory.Shutdown();
 
     // Safely abort threads.
-    for(auto& block : m_receiverResourcelist)
+    for (auto& block : m_receiverResourcelist)
     {
         block.Receiver->UnregisterReceiver(block.mp_receiver);
         block.disable();
     }
 
-    while(m_userReaderList.size() > 0)
+    while (m_userReaderList.size() > 0)
     {
         deleteUserEndpoint(static_cast<Endpoint*>(*m_userReaderList.begin()));
     }
 
-    while(m_userWriterList.size() > 0)
+    while (m_userWriterList.size() > 0)
     {
         deleteUserEndpoint(static_cast<Endpoint*>(*m_userWriterList.begin()));
     }
@@ -369,21 +380,22 @@ bool RTPSParticipantImpl::createWriter(
         const EntityId_t& entityId,
         bool isBuiltin)
 {
-    std::string type = (param.endpoint.reliabilityKind == RELIABLE) ? "RELIABLE" :"BEST_EFFORT";
-    logInfo(RTPS_PARTICIPANT," of type " << type);
+    logInfo(RTPS_PARTICIPANT, (param.endpoint.reliabilityKind == RELIABLE) ? 
+        "Creating writer of type RELIABLE" : "Creating writer of type BEST_EFFORT");
+
     EntityId_t entId;
-    if(entityId == c_EntityId_Unknown)
+    if (entityId == c_EntityId_Unknown)
     {
-        if(param.endpoint.topicKind == NO_KEY)
+        if (param.endpoint.topicKind == NO_KEY)
         {
             entId.value[3] = 0x03;
         }
-        else if(param.endpoint.topicKind == WITH_KEY)
+        else if (param.endpoint.topicKind == WITH_KEY)
         {
             entId.value[3] = 0x02;
         }
         uint32_t idnum;
-        if(param.endpoint.getEntityID() > 0)
+        if (param.endpoint.getEntityID() > 0)
         {
             idnum = static_cast<uint32_t>(param.endpoint.getEntityID());
         }
@@ -397,9 +409,9 @@ bool RTPSParticipantImpl::createWriter(
         entId.value[2] = c[0];
         entId.value[1] = c[1];
         entId.value[0] = c[2];
-        if(this->existsEntityId(entId, WRITER))
+        if (this->existsEntityId(entId, WRITER))
         {
-            logError(RTPS_PARTICIPANT,"A writer with the same entityId already exists in this RTPSParticipant");
+            logError(RTPS_PARTICIPANT, "A writer with the same entityId already exists in this RTPSParticipant");
             return false;
         }
     }
@@ -407,35 +419,35 @@ bool RTPSParticipantImpl::createWriter(
     {
         entId = entityId;
     }
-    if(!param.endpoint.unicastLocatorList.isValid())
+    if (!param.endpoint.unicastLocatorList.isValid())
     {
-        logError(RTPS_PARTICIPANT,"Unicast Locator List for Writer contains invalid Locator");
+        logError(RTPS_PARTICIPANT, "Unicast Locator List for Writer contains invalid Locator");
         return false;
     }
-    if(!param.endpoint.multicastLocatorList.isValid())
+    if (!param.endpoint.multicastLocatorList.isValid())
     {
-        logError(RTPS_PARTICIPANT,"Multicast Locator List for Writer contains invalid Locator");
+        logError(RTPS_PARTICIPANT, "Multicast Locator List for Writer contains invalid Locator");
         return false;
     }
-    if(!param.endpoint.remoteLocatorList.isValid())
+    if (!param.endpoint.remoteLocatorList.isValid())
     {
-        logError(RTPS_PARTICIPANT,"Remote Locator List for Writer contains invalid Locator");
+        logError(RTPS_PARTICIPANT, "Remote Locator List for Writer contains invalid Locator");
         return false;
     }
     if (((param.throughputController.bytesPerPeriod != UINT32_MAX && param.throughputController.periodMillisecs != 0) ||
-        (m_att.throughputController.bytesPerPeriod != UINT32_MAX && m_att.throughputController.periodMillisecs != 0))
-        && param.mode != ASYNCHRONOUS_WRITER)
+            (m_att.throughputController.bytesPerPeriod != UINT32_MAX &&
+            m_att.throughputController.periodMillisecs != 0))
+            && param.mode != ASYNCHRONOUS_WRITER)
     {
-        logError(RTPS_PARTICIPANT, "Writer has to be configured to publish asynchronously, because a flowcontroller was configured");
+        logError(RTPS_PARTICIPANT,
+                "Writer has to be configured to publish asynchronously, because a flowcontroller was configured");
         return false;
     }
 
     // Update persistence guidPrefix
     if (param.endpoint.persistence_guid == c_Guid_Unknown && m_persistence_guid != c_Guid_Unknown)
     {
-        param.endpoint.persistence_guid = GUID_t(
-                                                m_persistence_guid.guidPrefix,
-                                                entityId);
+        param.endpoint.persistence_guid = GUID_t(m_persistence_guid.guidPrefix, entityId);
     }
 
     // Get persistence service
@@ -453,7 +465,7 @@ bool RTPSParticipantImpl::createWriter(
     normalize_endpoint_locators(param.endpoint);
 
     RTPSWriter* SWriter = nullptr;
-    GUID_t guid(m_guid.guidPrefix,entId);
+    GUID_t guid(m_guid.guidPrefix, entId);
     if (param.endpoint.reliabilityKind == BEST_EFFORT)
     {
         SWriter = (persistence == nullptr) ?
@@ -473,10 +485,10 @@ bool RTPSParticipantImpl::createWriter(
     }
 
 #if HAVE_SECURITY
-    if(!isBuiltin)
+    if (!isBuiltin)
     {
-        if(!m_security_manager.register_local_writer(SWriter->getGuid(),
-                    param.endpoint.properties, SWriter->getAttributes().security_attributes()))
+        if (!m_security_manager.register_local_writer(SWriter->getGuid(),
+                param.endpoint.properties, SWriter->getAttributes().security_attributes()))
         {
             delete(SWriter);
             return false;
@@ -484,8 +496,8 @@ bool RTPSParticipantImpl::createWriter(
     }
     else
     {
-        if(!m_security_manager.register_local_builtin_writer(SWriter->getGuid(),
-                    SWriter->getAttributes().security_attributes()))
+        if (!m_security_manager.register_local_builtin_writer(SWriter->getGuid(),
+                SWriter->getAttributes().security_attributes()))
         {
             delete(SWriter);
             return false;
@@ -521,7 +533,6 @@ bool RTPSParticipantImpl::createWriter(
     return true;
 }
 
-
 bool RTPSParticipantImpl::createReader(
         RTPSReader** ReaderOut,
         ReaderAttributes& param,
@@ -531,10 +542,11 @@ bool RTPSParticipantImpl::createReader(
         bool isBuiltin,
         bool enable)
 {
-    std::string type = (param.endpoint.reliabilityKind == RELIABLE) ? "RELIABLE" :"BEST_EFFORT";
-    logInfo(RTPS_PARTICIPANT," of type " << type);
+    logInfo(RTPS_PARTICIPANT, (param.endpoint.reliabilityKind == RELIABLE) ?
+        "Creating reader of type RELIABLE" : "Creating writer of type BEST_EFFORT");
+
     EntityId_t entId;
-    if(entityId== c_EntityId_Unknown)
+    if (entityId == c_EntityId_Unknown)
     {
         if (param.endpoint.topicKind == NO_KEY)
         {
@@ -559,9 +571,9 @@ bool RTPSParticipantImpl::createReader(
         entId.value[2] = c[0];
         entId.value[1] = c[1];
         entId.value[0] = c[2];
-        if(this->existsEntityId(entId,WRITER))
+        if (this->existsEntityId(entId, WRITER))
         {
-            logError(RTPS_PARTICIPANT,"A reader with the same entityId already exists in this RTPSParticipant");
+            logError(RTPS_PARTICIPANT, "A reader with the same entityId already exists in this RTPSParticipant");
             return false;
         }
     }
@@ -569,19 +581,19 @@ bool RTPSParticipantImpl::createReader(
     {
         entId = entityId;
     }
-    if(!param.endpoint.unicastLocatorList.isValid())
+    if (!param.endpoint.unicastLocatorList.isValid())
     {
-        logError(RTPS_PARTICIPANT,"Unicast Locator List for Reader contains invalid Locator");
+        logError(RTPS_PARTICIPANT, "Unicast Locator List for Reader contains invalid Locator");
         return false;
     }
-    if(!param.endpoint.multicastLocatorList.isValid())
+    if (!param.endpoint.multicastLocatorList.isValid())
     {
-        logError(RTPS_PARTICIPANT,"Multicast Locator List for Reader contains invalid Locator");
+        logError(RTPS_PARTICIPANT, "Multicast Locator List for Reader contains invalid Locator");
         return false;
     }
-    if(!param.endpoint.remoteLocatorList.isValid())
+    if (!param.endpoint.remoteLocatorList.isValid())
     {
-        logError(RTPS_PARTICIPANT,"Remote Locator List for Reader contains invalid Locator");
+        logError(RTPS_PARTICIPANT, "Remote Locator List for Reader contains invalid Locator");
         return false;
     }
 
@@ -600,7 +612,7 @@ bool RTPSParticipantImpl::createReader(
     normalize_endpoint_locators(param.endpoint);
 
     RTPSReader* SReader = nullptr;
-    GUID_t guid(m_guid.guidPrefix,entId);
+    GUID_t guid(m_guid.guidPrefix, entId);
     if (param.endpoint.reliabilityKind == BEST_EFFORT)
     {
         SReader = (persistence == nullptr) ?
@@ -621,10 +633,10 @@ bool RTPSParticipantImpl::createReader(
 
 #if HAVE_SECURITY
 
-    if(!isBuiltin)
+    if (!isBuiltin)
     {
-        if(!m_security_manager.register_local_reader(SReader->getGuid(),
-                    param.endpoint.properties, SReader->getAttributes().security_attributes()))
+        if (!m_security_manager.register_local_reader(SReader->getGuid(),
+                param.endpoint.properties, SReader->getAttributes().security_attributes()))
         {
             delete(SReader);
             return false;
@@ -632,8 +644,8 @@ bool RTPSParticipantImpl::createReader(
     }
     else
     {
-        if(!m_security_manager.register_local_builtin_reader(SReader->getGuid(),
-                    SReader->getAttributes().security_attributes()))
+        if (!m_security_manager.register_local_builtin_reader(SReader->getGuid(),
+                SReader->getAttributes().security_attributes()))
         {
             delete(SReader);
             return false;
@@ -707,7 +719,8 @@ RTPSWriter* RTPSParticipantImpl::find_local_writer(
     return nullptr;
 }
 
-bool RTPSParticipantImpl::enableReader(RTPSReader *reader)
+bool RTPSParticipantImpl::enableReader(
+        RTPSReader* reader)
 {
     if (!assignEndpointListenResources(reader))
     {
@@ -717,7 +730,8 @@ bool RTPSParticipantImpl::enableReader(RTPSReader *reader)
 }
 
 // Avoid to receive PDPSimple reader a DATA while calling ~PDPSimple and EDP was destroy already.
-void RTPSParticipantImpl::disableReader(RTPSReader *reader)
+void RTPSParticipantImpl::disableReader(
+        RTPSReader* reader)
 {
     m_receiverResourcelistMutex.lock();
     for (auto it = m_receiverResourcelist.begin(); it != m_receiverResourcelist.end(); ++it)
@@ -727,26 +741,37 @@ void RTPSParticipantImpl::disableReader(RTPSReader *reader)
     m_receiverResourcelistMutex.unlock();
 }
 
-bool RTPSParticipantImpl::registerWriter(RTPSWriter* Writer, const TopicAttributes& topicAtt, const WriterQos& wqos)
+bool RTPSParticipantImpl::registerWriter(
+        RTPSWriter* Writer,
+        const TopicAttributes& topicAtt,
+        const WriterQos& wqos)
 {
     return this->mp_builtinProtocols->addLocalWriter(Writer, topicAtt, wqos);
 }
 
-bool RTPSParticipantImpl::registerReader(RTPSReader* reader, const TopicAttributes& topicAtt, const ReaderQos& rqos)
+bool RTPSParticipantImpl::registerReader(
+        RTPSReader* reader,
+        const TopicAttributes& topicAtt,
+        const ReaderQos& rqos)
 {
     return this->mp_builtinProtocols->addLocalReader(reader, topicAtt, rqos);
 }
 
-bool RTPSParticipantImpl::updateLocalWriter(RTPSWriter* Writer, const TopicAttributes& topicAtt, const WriterQos& wqos)
+bool RTPSParticipantImpl::updateLocalWriter(
+        RTPSWriter* Writer,
+        const TopicAttributes& topicAtt,
+        const WriterQos& wqos)
 {
     return this->mp_builtinProtocols->updateLocalWriter(Writer, topicAtt, wqos);
 }
 
-bool RTPSParticipantImpl::updateLocalReader(RTPSReader* reader, const TopicAttributes& topicAtt, const ReaderQos& rqos)
+bool RTPSParticipantImpl::updateLocalReader(
+        RTPSReader* reader,
+        const TopicAttributes& topicAtt,
+        const ReaderQos& rqos)
 {
     return this->mp_builtinProtocols->updateLocalReader(reader, topicAtt, rqos);
 }
-
 
 /*
  *
@@ -756,13 +781,15 @@ bool RTPSParticipantImpl::updateLocalReader(RTPSReader* reader, const TopicAttri
  */
 
 
-bool RTPSParticipantImpl::existsEntityId(const EntityId_t& ent,EndpointKind_t kind) const
+bool RTPSParticipantImpl::existsEntityId(
+        const EntityId_t& ent,
+        EndpointKind_t kind) const
 {
     if (kind == WRITER)
     {
-        for (std::vector<RTPSWriter*>::const_iterator it = m_userWriterList.begin(); it != m_userWriterList.end(); ++it)
+        for (const RTPSWriter* it : m_userWriterList)
         {
-            if (ent == (*it)->getGuid().entityId)
+            if (ent == it->getGuid().entityId)
             {
                 return true;
             }
@@ -770,9 +797,9 @@ bool RTPSParticipantImpl::existsEntityId(const EntityId_t& ent,EndpointKind_t ki
     }
     else
     {
-        for (std::vector<RTPSReader*>::const_iterator it = m_userReaderList.begin(); it != m_userReaderList.end(); ++it)
+        for (const RTPSReader* it : m_userReaderList)
         {
-            if (ent == (*it)->getGuid().entityId)
+            if (ent == it->getGuid().entityId)
             {
                 return true;
             }
@@ -781,20 +808,20 @@ bool RTPSParticipantImpl::existsEntityId(const EntityId_t& ent,EndpointKind_t ki
     return false;
 }
 
-
 /*
  *
  * RECEIVER RESOURCE METHODS
  *
  */
-bool RTPSParticipantImpl::assignEndpointListenResources(Endpoint* endp)
+bool RTPSParticipantImpl::assignEndpointListenResources(
+        Endpoint* endp)
 {
     //Tag the endpoint with the ReceiverResources
     bool valid = true;
 
     /* No need to check for emptiness on the lists, as it was already done on part function
        In case are using the default list of Locators they have already been embedded to the parameters
-    */
+     */
 
     //UNICAST
     assignEndpoint2LocatorList(endp, endp->getAttributes().unicastLocatorList);
@@ -803,17 +830,18 @@ bool RTPSParticipantImpl::assignEndpointListenResources(Endpoint* endp)
     return valid;
 }
 
-bool RTPSParticipantImpl::createAndAssociateReceiverswithEndpoint(Endpoint * pend)
+bool RTPSParticipantImpl::createAndAssociateReceiverswithEndpoint(
+        Endpoint* pend)
 {
     /*	This function...
         - Asks the network factory for new resources
         - Encapsulates the new resources within the ReceiverControlBlock list
         - Associated the endpoint to the new elements in the list
         - Launches the listener thread
-    */
+     */
     // 1 - Ask the network factory to generate the elements that do still not exist
-    std::vector<ReceiverResource> newItems;							//Store the newly created elements
-    std::vector<ReceiverResource> newItemsBuffer;					//Store intermediate results
+    std::vector<ReceiverResource> newItems;                         //Store the newly created elements
+    std::vector<ReceiverResource> newItemsBuffer;                   //Store intermediate results
     //Iterate through the list of unicast and multicast locators the endpoint has... unless its empty
     //In that case, just use the standard
     if (pend->getAttributes().unicastLocatorList.empty() && pend->getAttributes().multicastLocatorList.empty())
@@ -829,7 +857,9 @@ bool RTPSParticipantImpl::createAndAssociateReceiverswithEndpoint(Endpoint * pen
     return true;
 }
 
-bool RTPSParticipantImpl::assignEndpoint2LocatorList(Endpoint* endp, LocatorList_t& list)
+bool RTPSParticipantImpl::assignEndpoint2LocatorList(
+        Endpoint* endp,
+        LocatorList_t& list)
 {
     /* Note:
        The previous version of this function associated (or created) ListenResources and added the endpoint to them.
@@ -838,9 +868,9 @@ bool RTPSParticipantImpl::assignEndpoint2LocatorList(Endpoint* endp, LocatorList
        This has been removed because it is considered redundant. For ReceiveResources that listen on multiple interfaces, only
        one of the supported Locators is needed to make the match, and the case of new ListenResources being created has been removed
        since its the NetworkFactory the one that takes care of Resource creation.
-       */
+     */
     LocatorList_t finalList;
-    for (auto lit = list.begin(); lit != list.end(); ++lit)
+    for (const Locator_t& loc : list)
     {
         //Iteration of all Locators within the Locator list passed down as argument
         std::lock_guard<std::mutex> guard(m_receiverResourcelistMutex);
@@ -849,7 +879,7 @@ bool RTPSParticipantImpl::assignEndpoint2LocatorList(Endpoint* endp, LocatorList
         {
             //Take mutex for the resource since we are going to interact with shared resources
             //std::lock_guard<std::mutex> guard((*it).mtx);
-            if (it->Receiver->SupportsLocator(*lit))
+            if (it->Receiver->SupportsLocator(loc))
             {
                 //Supported! Take mutex and update lists - We maintain reader/writer discrimination just in case
                 it->mp_receiver->associateEndpoint(endp);
@@ -863,7 +893,8 @@ bool RTPSParticipantImpl::assignEndpoint2LocatorList(Endpoint* endp, LocatorList
     return true;
 }
 
-bool RTPSParticipantImpl::createSendResources(Endpoint *pend)
+bool RTPSParticipantImpl::createSendResources(
+        Endpoint* pend)
 {
     if (pend->m_att.remoteLocatorList.empty())
     {
@@ -874,21 +905,24 @@ bool RTPSParticipantImpl::createSendResources(Endpoint *pend)
     std::lock_guard<std::timed_mutex> guard(m_send_resources_mutex_);
 
     //Output locators have been specified, create them
-    for (auto it = pend->m_att.remoteLocatorList.begin(); it != pend->m_att.remoteLocatorList.end(); ++it)
+    for (const Locator_t& loc : pend->m_att.remoteLocatorList)
     {
-        if(!m_network_Factory.build_send_resources(send_resource_list_, (*it)))
+        if (!m_network_Factory.build_send_resources(send_resource_list_, loc))
         {
             logWarning(RTPS_PARTICIPANT, "Cannot create send resource for endpoint remote locator (" <<
-                    pend->getGuid() << ", " << (*it) << ")");
+                    pend->getGuid() << ", " << loc << ")");
         }
     }
 
     return true;
 }
 
-void RTPSParticipantImpl::createReceiverResources(LocatorList_t& Locator_list, bool ApplyMutation, bool RegisterReceiver)
+void RTPSParticipantImpl::createReceiverResources(
+        LocatorList_t& Locator_list,
+        bool ApplyMutation,
+        bool RegisterReceiver)
 {
-    std::vector<std::shared_ptr<ReceiverResource>> newItemsBuffer;
+    std::vector<std::shared_ptr<ReceiverResource> > newItemsBuffer;
 
     uint32_t size = m_network_Factory.get_max_message_size_between_transports();
     for (auto it_loc = Locator_list.begin(); it_loc != Locator_list.end(); ++it_loc)
@@ -923,7 +957,8 @@ void RTPSParticipantImpl::createReceiverResources(LocatorList_t& Locator_list, b
     }
 }
 
-void RTPSParticipantImpl::createSenderResources(const LocatorList_t& locator_list)
+void RTPSParticipantImpl::createSenderResources(
+        const LocatorList_t& locator_list)
 {
     std::unique_lock<std::timed_mutex> lock(m_send_resources_mutex_);
 
@@ -933,14 +968,16 @@ void RTPSParticipantImpl::createSenderResources(const LocatorList_t& locator_lis
     }
 }
 
-void RTPSParticipantImpl::createSenderResources(const Locator_t& locator)
+void RTPSParticipantImpl::createSenderResources(
+        const Locator_t& locator)
 {
     std::unique_lock<std::timed_mutex> lock(m_send_resources_mutex_);
 
     m_network_Factory.build_send_resources(send_resource_list_, locator);
 }
 
-bool RTPSParticipantImpl::deleteUserEndpoint(Endpoint* p_endpoint)
+bool RTPSParticipantImpl::deleteUserEndpoint(
+        Endpoint* p_endpoint)
 {
     m_receiverResourcelistMutex.lock();
     for (auto it = m_receiverResourcelist.begin(); it != m_receiverResourcelist.end(); ++it)
@@ -951,7 +988,7 @@ bool RTPSParticipantImpl::deleteUserEndpoint(Endpoint* p_endpoint)
 
     bool found = false, found_in_users = false;
     {
-        if(p_endpoint->getAttributes().endpointKind == WRITER)
+        if (p_endpoint->getAttributes().endpointKind == WRITER)
         {
             std::lock_guard<std::recursive_mutex> guard(*mp_mutex);
             for (auto wit = m_userWriterList.begin(); wit != m_userWriterList.end(); ++wit)
@@ -1001,7 +1038,7 @@ bool RTPSParticipantImpl::deleteUserEndpoint(Endpoint* p_endpoint)
         }
 
         //REMOVE FOR BUILTINPROTOCOLS
-        if(p_endpoint->getAttributes().endpointKind == WRITER)
+        if (p_endpoint->getAttributes().endpointKind == WRITER)
         {
             if (found_in_users)
             {
@@ -1009,7 +1046,7 @@ bool RTPSParticipantImpl::deleteUserEndpoint(Endpoint* p_endpoint)
             }
 
 #if HAVE_SECURITY
-            if(p_endpoint->getAttributes().security_attributes().is_submessage_protected ||
+            if (p_endpoint->getAttributes().security_attributes().is_submessage_protected ||
                     p_endpoint->getAttributes().security_attributes().is_payload_protected)
             {
                 m_security_manager.unregister_local_writer(p_endpoint->getGuid());
@@ -1024,7 +1061,7 @@ bool RTPSParticipantImpl::deleteUserEndpoint(Endpoint* p_endpoint)
             }
 
 #if HAVE_SECURITY
-            if(p_endpoint->getAttributes().security_attributes().is_submessage_protected ||
+            if (p_endpoint->getAttributes().security_attributes().is_submessage_protected ||
                     p_endpoint->getAttributes().security_attributes().is_payload_protected)
             {
                 m_security_manager.unregister_local_reader(p_endpoint->getGuid());
@@ -1037,7 +1074,8 @@ bool RTPSParticipantImpl::deleteUserEndpoint(Endpoint* p_endpoint)
     return true;
 }
 
-void RTPSParticipantImpl::normalize_endpoint_locators(EndpointAttributes& endpoint_att)
+void RTPSParticipantImpl::normalize_endpoint_locators(
+        EndpointAttributes& endpoint_att)
 {
     // Locators with port 0, calculate port.
     for (Locator_t& loc : endpoint_att.unicastLocatorList)
@@ -1075,7 +1113,7 @@ bool RTPSParticipantImpl::sendSync(
     bool ret_code = false;
     std::unique_lock<std::timed_mutex> lock(m_send_resources_mutex_, std::defer_lock);
 
-    if(lock.try_lock_until(max_blocking_time_point))
+    if (lock.try_lock_until(max_blocking_time_point))
     {
         ret_code = true;
 
@@ -1083,8 +1121,8 @@ bool RTPSParticipantImpl::sendSync(
         {
             // Calculate next timeout.
             std::chrono::microseconds timeout =
-                std::chrono::duration_cast<std::chrono::microseconds>(
-                        max_blocking_time_point - std::chrono::steady_clock::now());
+                    std::chrono::duration_cast<std::chrono::microseconds>(
+                max_blocking_time_point - std::chrono::steady_clock::now());
 
             send_resource->send(msg->buffer, msg->length, destination_loc, timeout);
         }
@@ -1093,7 +1131,8 @@ bool RTPSParticipantImpl::sendSync(
     return ret_code;
 }
 
-void RTPSParticipantImpl::setGuid(GUID_t& guid)
+void RTPSParticipantImpl::setGuid(
+        GUID_t& guid)
 {
     m_guid = guid;
 }
@@ -1119,16 +1158,20 @@ void RTPSParticipantImpl::loose_next_change()
     //this->mp_send_thr->loose_next_change();
 }
 
-bool RTPSParticipantImpl::newRemoteEndpointDiscovered(const GUID_t& pguid, int16_t userDefinedId, EndpointKind_t kind)
+bool RTPSParticipantImpl::newRemoteEndpointDiscovered(
+        const GUID_t& pguid,
+        int16_t userDefinedId,
+        EndpointKind_t kind)
 {
     if (m_att.builtin.discovery_config.discoveryProtocol != DiscoveryProtocol::SIMPLE ||
-        m_att.builtin.discovery_config.use_STATIC_EndpointDiscoveryProtocol == false)
+            m_att.builtin.discovery_config.use_STATIC_EndpointDiscoveryProtocol == false)
     {
-        logWarning(RTPS_PARTICIPANT, "Remote Endpoints can only be activated with static discovery protocol over PDP simple protocol");
+        logWarning(RTPS_PARTICIPANT,
+                "Remote Endpoints can only be activated with static discovery protocol over PDP simple protocol");
         return false;
     }
 
-    if (PDPSimple * pS = dynamic_cast<PDPSimple*>(mp_builtinProtocols->mp_PDP))
+    if (PDPSimple* pS = dynamic_cast<PDPSimple*>(mp_builtinProtocols->mp_PDP))
     {
         return pS->newRemoteEndpointStaticallyDiscovered(pguid, userDefinedId, kind);
     }
@@ -1171,14 +1214,15 @@ uint32_t RTPSParticipantImpl::getMaxDataSize()
     return calculateMaxDataSize(getMaxMessageSize());
 }
 
-uint32_t RTPSParticipantImpl::calculateMaxDataSize(uint32_t length)
+uint32_t RTPSParticipantImpl::calculateMaxDataSize(
+        uint32_t length)
 {
     uint32_t maxDataSize = length;
 
 #if HAVE_SECURITY
     // If there is rtps messsage protection, reduce max size for messages,
     // because extra data is added on encryption.
-    if(security_attributes_.is_rtps_protected)
+    if (security_attributes_.is_rtps_protected)
     {
         maxDataSize -= m_security_manager.calculate_extra_size_for_rtps_message();
     }
@@ -1195,8 +1239,9 @@ bool RTPSParticipantImpl::networkFactoryHasRegisteredTransports() const
 }
 
 #if HAVE_SECURITY
-bool RTPSParticipantImpl::pairing_remote_reader_with_local_writer_after_security(const GUID_t& local_writer,
-    const ReaderProxyData& remote_reader_data)
+bool RTPSParticipantImpl::pairing_remote_reader_with_local_writer_after_security(
+        const GUID_t& local_writer,
+        const ReaderProxyData& remote_reader_data)
 {
     bool return_value;
 
@@ -1211,8 +1256,9 @@ bool RTPSParticipantImpl::pairing_remote_reader_with_local_writer_after_security
     return return_value;
 }
 
-bool RTPSParticipantImpl::pairing_remote_writer_with_local_reader_after_security(const GUID_t& local_reader,
-    const WriterProxyData& remote_writer_data)
+bool RTPSParticipantImpl::pairing_remote_writer_with_local_reader_after_security(
+        const GUID_t& local_reader,
+        const WriterProxyData& remote_writer_data)
 {
     bool return_value;
 
@@ -1239,7 +1285,9 @@ WLP* RTPSParticipantImpl::wlp()
     return mp_builtinProtocols->mp_WLP;
 }
 
-bool RTPSParticipantImpl::get_remote_writer_info(const GUID_t& writerGuid, WriterProxyData& returnedInfo)
+bool RTPSParticipantImpl::get_remote_writer_info(
+        const GUID_t& writerGuid,
+        WriterProxyData& returnedInfo)
 {
     if (this->mp_builtinProtocols->mp_PDP->lookupWriterProxyData(writerGuid, returnedInfo))
     {
@@ -1248,7 +1296,9 @@ bool RTPSParticipantImpl::get_remote_writer_info(const GUID_t& writerGuid, Write
     return false;
 }
 
-bool RTPSParticipantImpl::get_remote_reader_info(const GUID_t& readerGuid, ReaderProxyData& returnedInfo)
+bool RTPSParticipantImpl::get_remote_reader_info(
+        const GUID_t& readerGuid,
+        ReaderProxyData& returnedInfo)
 {
     if (this->mp_builtinProtocols->mp_PDP->lookupReaderProxyData(readerGuid, returnedInfo))
     {
@@ -1257,14 +1307,15 @@ bool RTPSParticipantImpl::get_remote_reader_info(const GUID_t& readerGuid, Reade
     return false;
 }
 
-IPersistenceService* RTPSParticipantImpl::get_persistence_service(const EndpointAttributes& param)
+IPersistenceService* RTPSParticipantImpl::get_persistence_service(
+        const EndpointAttributes& param)
 {
     IPersistenceService* ret_val;
 
     ret_val = PersistenceFactory::create_persistence_service(param.properties);
     return ret_val != nullptr ?
-        ret_val :
-        PersistenceFactory::create_persistence_service(m_att.properties);
+           ret_val :
+           PersistenceFactory::create_persistence_service(m_att.properties);
 }
 
 std::unique_ptr<RTPSMessageGroup_t> RTPSParticipantImpl::get_send_buffer()
@@ -1272,7 +1323,8 @@ std::unique_ptr<RTPSMessageGroup_t> RTPSParticipantImpl::get_send_buffer()
     return send_buffers_->get_buffer(this);
 }
 
-void RTPSParticipantImpl::return_send_buffer(std::unique_ptr <RTPSMessageGroup_t>&& buffer)
+void RTPSParticipantImpl::return_send_buffer(
+        std::unique_ptr <RTPSMessageGroup_t>&& buffer)
 {
     send_buffers_->return_buffer(std::move(buffer));
 }

--- a/src/cpp/rtps/participant/RTPSParticipantImpl.h
+++ b/src/cpp/rtps/participant/RTPSParticipantImpl.h
@@ -563,13 +563,15 @@ private:
     std::vector<RTPSWriter*>::iterator userWritersListEnd(){return m_userWriterList.end();};
 
     /** Helper function that creates ReceiverResources based on a Locator_t List, possibly mutating
-      some and updating the list. DOES NOT associate endpoints with it.
-      @param Locator_list - Locator list to be used to create the ReceiverResources
-      @param ApplyMutation - True if we want to create a Resource with a "similar" locator if the one we provide is unavailable
-      */
+     * some and updating the list. DOES NOT associate endpoints with it.
+     * @param Locator_list - Locator list to be used to create the ReceiverResources
+     * @param ApplyMutation - True if we want to create a Resource with a "similar" locator if the one we provide is unavailable
+     * @param RegisterReceiver - True if we want the receiver to be registered. Useful for receivers created after participant is enabled.
+     */
     void createReceiverResources(
             LocatorList_t& Locator_list,
-            bool ApplyMutation);
+            bool ApplyMutation,
+            bool RegisterReceiver);
     
     void createSenderResources(
             const LocatorList_t& locator_list);


### PR DESCRIPTION
If the ReceiverResources are registered during the RTPSParticipantImpl construction, they may start receiving data before the Participant initialization is finished, causing a system crash.

This PR delays the registering the ReceiverResource until RTPSParticipantImpl::enable.

A new parameter on RTPSParticipantImpl::createReceiverResources specifies if the resource registration should be defered (for example, on resources created on initialization) or performed immediately (for resources created after initialization).