### PR TITLE
Protect add_participant_proxy_data on initPDP. <1.9.x> [7531]

### DIFF
--- a/src/cpp/rtps/builtin/discovery/participant/PDP.cpp
+++ b/src/cpp/rtps/builtin/discovery/participant/PDP.cpp
@@ -313,7 +313,11 @@ bool PDP::initPDP(
     }
     //UPDATE METATRAFFIC.
     mp_builtin->updateMetatrafficLocators(this->mp_PDPReader->getAttributes().unicastLocatorList);
+
+    mp_mutex->lock();
     ParticipantProxyData* pdata = add_participant_proxy_data(part->getGuid(), true);
+    mp_mutex->unlock();
+
     if (pdata == nullptr)
     {
         return false;


### PR DESCRIPTION
This should fix one case of #929