### PR TITLE
Avoid problems with template method inlining. [7601]

### DIFF
--- a/include/fastrtps/rtps/builtin/discovery/endpoint/EDPSimple.h
+++ b/include/fastrtps/rtps/builtin/discovery/endpoint/EDPSimple.h
@@ -187,6 +187,36 @@ protected:
     virtual bool createSEDPEndpoints();
 
     /**
+     * Create a cache change on a builtin writer and serialize a WriterProxyData on it.
+     * @param [in] data The WriterProxyData object to be serialized.
+     * @param [in] writer The writer,history pair where the change should be added.
+     * @param [in] remove_same_instance Should previous changes with same key be removed?
+     * @param [out] created_change Where the pointer to the created change should be returned.
+     * @return false if data could not be serialized into the created change.
+     */
+    bool serialize_writer_proxy_data(
+            const WriterProxyData& data,
+            const t_p_StatefulWriter& writer,
+            bool remove_same_instance,
+            CacheChange_t** created_change);
+
+    /**
+     * Create a cache change on a builtin writer and serialize a ReaderProxyData on it.
+     * @param [in] data The ReaderProxyData object to be serialized.
+     * @param [in] writer The writer,history pair where the change should be added.
+     * @param [in] remove_same_instance Should previous changes with same key be removed?
+     * @param [out] created_change Where the pointer to the created change should be returned.
+     * @return false if data could not be serialized into the created change.
+     */
+    bool serialize_reader_proxy_data(
+            const ReaderProxyData& data,
+            const t_p_StatefulWriter& writer,
+            bool remove_same_instance,
+            CacheChange_t** created_change);
+
+private:
+
+    /**
      * Create a cache change on a builtin writer and serialize a ProxyData on it.
      * @param [in] data The ProxyData object to be serialized.
      * @param [in] writer The writer,history pair where the change should be added.
@@ -200,8 +230,6 @@ protected:
             const t_p_StatefulWriter& writer,
             bool remove_same_instance,
             CacheChange_t** created_change);
-
-private:
 
 #if HAVE_SECURITY
     bool create_sedp_secure_endpoints();

--- a/src/cpp/rtps/builtin/discovery/endpoint/EDPClient.cpp
+++ b/src/cpp/rtps/builtin/discovery/endpoint/EDPClient.cpp
@@ -51,7 +51,7 @@ bool EDPClient::processLocalReaderProxyData(
 #endif
 
     CacheChange_t* change = nullptr;
-    bool ret_val = serialize_proxy_data(*rdata, *writer, true, &change);
+    bool ret_val = serialize_reader_proxy_data(*rdata, *writer, true, &change);
     if (change != nullptr)
     {
         // We must key-signed the CacheChange_t to avoid duplications:
@@ -84,7 +84,7 @@ bool EDPClient::processLocalWriterProxyData(
 #endif
 
     CacheChange_t* change = nullptr;
-    bool ret_val = serialize_proxy_data(*wdata, *writer, true, &change);
+    bool ret_val = serialize_writer_proxy_data(*wdata, *writer, true, &change);
     if (change != nullptr)
     {
         // We must key-signed the CacheChange_t to avoid duplications:

--- a/src/cpp/rtps/builtin/discovery/endpoint/EDPServer.cpp
+++ b/src/cpp/rtps/builtin/discovery/endpoint/EDPServer.cpp
@@ -369,7 +369,7 @@ bool EDPServer::processLocalWriterProxyData(
 
     // unlike on EDPSimple we wouldn't remove endpoint outdate info till all
     // client-servers acknowledge reception
-    bool ret_val = serialize_proxy_data(*wdata, *writer, false, &change);
+    bool ret_val = serialize_writer_proxy_data(*wdata, *writer, false, &change);
     if (change != nullptr)
     {
         // We must key-signed the CacheChange_t to avoid duplications:
@@ -397,7 +397,7 @@ bool EDPServer::processLocalReaderProxyData(
 
     // unlike on EDPSimple we wouldn't remove endpoint outdate info till all
     // client-servers acknowledge reception
-    bool ret_val = serialize_proxy_data(*rdata, *writer, false, &change);
+    bool ret_val = serialize_reader_proxy_data(*rdata, *writer, false, &change);
     if (change != nullptr)
     {
         // We must key-signed the CacheChange_t to avoid duplications:

--- a/src/cpp/rtps/builtin/discovery/endpoint/EDPSimple.cpp
+++ b/src/cpp/rtps/builtin/discovery/endpoint/EDPSimple.cpp
@@ -478,7 +478,7 @@ bool EDPSimple::processLocalReaderProxyData(
     }
 #endif
     CacheChange_t* change = nullptr;
-    bool ret_val = serialize_proxy_data(*rdata, *writer, true, &change);
+    bool ret_val = serialize_reader_proxy_data(*rdata, *writer, true, &change);
     if (change != nullptr)
     {
         writer->second->add_change(change);
@@ -503,12 +503,30 @@ bool EDPSimple::processLocalWriterProxyData(
 #endif
 
     CacheChange_t* change = nullptr;
-    bool ret_val = serialize_proxy_data(*wdata, *writer, true, &change);
+    bool ret_val = serialize_writer_proxy_data(*wdata, *writer, true, &change);
     if (change != nullptr)
     {
         writer->second->add_change(change);
     }
     return ret_val;
+}
+
+bool EDPSimple::serialize_writer_proxy_data(
+        const WriterProxyData& data,
+        const t_p_StatefulWriter& writer,
+        bool remove_same_instance,
+        CacheChange_t** created_change)
+{
+    return serialize_proxy_data(data, writer, remove_same_instance, created_change);
+}
+
+bool EDPSimple::serialize_reader_proxy_data(
+        const ReaderProxyData& data,
+        const t_p_StatefulWriter& writer,
+        bool remove_same_instance,
+        CacheChange_t** created_change)
+{
+    return serialize_proxy_data(data, writer, remove_same_instance, created_change);
 }
 
 template<typename ProxyData>


### PR DESCRIPTION
This fixes #1007 by making the template method `EDPSimple::serialize_proxy_data` private and adding two protected proxy methods for the two possible instantiations of the template.

NOTE: CI jobs have been updated to build on release mode