### PR TITLE
Delete history_record when endpoint is unmatched <master> [7603]

### DIFF
--- a/src/cpp/rtps/reader/RTPSReader.cpp
+++ b/src/cpp/rtps/reader/RTPSReader.cpp
@@ -125,11 +125,12 @@ void RTPSReader::remove_persistence_guid(
     GUID_t persistence_guid_stored = (c_Guid_Unknown == persistence_guid) ? guid : persistence_guid;
     history_state_->persistence_guid_map.erase(guid);
     auto count = --history_state_->persistence_guid_count[persistence_guid_stored];
-    if (count == 0)
+    if (count <= 0)
     {
         if (m_att.durabilityKind < TRANSIENT)
         {
             history_state_->history_record.erase(persistence_guid_stored);
+            history_state_->persistence_guid_count.erase(persistence_guid_stored);
         }
     }
 }


### PR DESCRIPTION
This is a port of #1006 from 1.8.x

Only a partial port is done, as the main issue was already corrected during a refactoring

 * Ensure persistence_guid_count_ is deleted when it reaches to zero to free memory
 * Change the condition to delete the records from count == 0 to count <= 0 for robustness