### PR TITLE
Store endpoint GUID from message <1.9.x> [7610]

### DIFF
--- a/src/cpp/rtps/builtin/data/WriterProxyData.cpp
+++ b/src/cpp/rtps/builtin/data/WriterProxyData.cpp
@@ -712,6 +712,7 @@ bool WriterProxyData::readFromCDRMessage(
                     return false;
                 }
 
+                m_guid = p.guid;
                 for (uint8_t i = 0; i < 16; ++i)
                 {
                     if (i < 12)


### PR DESCRIPTION
This solves issue #1014 
After #1003 the Endpoint GUID received on incoming messages was no longer being stored. This can lead to failing endpoint matching.