### PR TITLE
Propagate errors on take_next_data <master> [7702]

### DIFF
--- a/include/fastrtps/subscriber/SubscriberHistory.h
+++ b/include/fastrtps/subscriber/SubscriberHistory.h
@@ -196,7 +196,7 @@ class SubscriberHistory: public rtps::ReaderHistory
                 rtps::CacheChange_t* a_change,
                 std::vector<rtps::CacheChange_t*>& instance_changes);
 
-        void deserialize_change(
+        bool deserialize_change(
                 rtps::CacheChange_t* change,
                 uint32_t ownership_strength,
                 void* data,


### PR DESCRIPTION
This is a port of #962 from 1.9.x

SubscriberHistory::deserialize_change must return the result of the deserialization
and SubscriberHistory::takeNextData should propagate errors on deserialization and removal from history