### PR TITLE
Make sure that default values are enforced when parsing a Duration_t xml tag. [7738]

### DIFF
--- a/resources/xsd/fastRTPS_profiles.xsd
+++ b/resources/xsd/fastRTPS_profiles.xsd
@@ -165,10 +165,18 @@
     </xs:simpleType>
 
     <xs:complexType name="durationType">
-        <xs:all>
-            <xs:element name="sec" type="nonNegativeInteger_Duration_SEC" default="0" minOccurs="0"/>
-            <xs:element name="nanosec" type="nonNegativeInteger_Duration_NSEC" default="0" minOccurs="0"/>
-        </xs:all>
+        <xs:sequence>
+            <xs:choice minOccurs="1">
+                <xs:sequence>
+                    <xs:element name="sec" type="nonNegativeInteger_Duration_SEC" default="0" minOccurs="1" maxOccurs="1"/>
+                    <xs:element name="nanosec" type="nonNegativeInteger_Duration_NSEC" default="0" minOccurs="0" maxOccurs="1"/>
+                </xs:sequence>
+                <xs:sequence>
+                    <xs:element name="nanosec" type="nonNegativeInteger_Duration_NSEC" default="0" minOccurs="1" maxOccurs="1"/>
+                    <xs:element name="sec" type="nonNegativeInteger_Duration_SEC" default="0" minOccurs="0" maxOccurs="1"/>
+                </xs:sequence>
+            </xs:choice>
+        </xs:sequence>
     </xs:complexType>
 
     <xs:complexType name="writerTimesType">

--- a/resources/xsd/fastRTPS_profiles.xsd
+++ b/resources/xsd/fastRTPS_profiles.xsd
@@ -166,8 +166,8 @@
 
     <xs:complexType name="durationType">
         <xs:all>
-            <xs:element name="sec" type="nonNegativeInteger_Duration_SEC" minOccurs="0"/>
-            <xs:element name="nanosec" type="nonNegativeInteger_Duration_NSEC" minOccurs="0"/>
+            <xs:element name="sec" type="nonNegativeInteger_Duration_SEC" default="0" minOccurs="0"/>
+            <xs:element name="nanosec" type="nonNegativeInteger_Duration_NSEC" default="0" minOccurs="0"/>
         </xs:all>
     </xs:complexType>
 

--- a/src/cpp/rtps/xmlparser/XMLElementParser.cpp
+++ b/src/cpp/rtps/xmlparser/XMLElementParser.cpp
@@ -2129,11 +2129,15 @@ XMLP_ret XMLParser::getXMLDuration(
     /*
         <xs:complexType name="durationType">
             <xs:all>
-                <xs:element name="sec" type="nonNegativeInteger_Duration_SEC" minOccurs="0"/>
-                <xs:element name="nanosec" type="nonNegativeInteger_Duration_NSEC" minOccurs="0"/>
+                <xs:element name="sec" type="nonNegativeInteger_Duration_SEC" default="0" minOccurs="0"/>
+                <xs:element name="nanosec" type="nonNegativeInteger_Duration_NSEC" default="0" minOccurs="0"/>
             </xs:all>
         </xs:complexType>
      */
+
+    // set default values
+    duration.seconds = 0;
+    duration.nanosec = 0;
 
     tinyxml2::XMLElement* p_aux0 = nullptr;
     const char* name = nullptr;

--- a/src/cpp/rtps/xmlparser/XMLElementParser.cpp
+++ b/src/cpp/rtps/xmlparser/XMLElementParser.cpp
@@ -2139,10 +2139,16 @@ XMLP_ret XMLParser::getXMLDuration(
     duration.seconds = 0;
     duration.nanosec = 0;
 
+    // it's mandatory to provide a sec or nanocsec child item
+    bool empty = true;
+
     tinyxml2::XMLElement* p_aux0 = nullptr;
     const char* name = nullptr;
     for (p_aux0 = elem->FirstChildElement(); p_aux0 != NULL; p_aux0 = p_aux0->NextSiblingElement())
     {
+        // there is at least a child element
+        empty = false;
+
         name = p_aux0->Name();
         if (strcmp(name, SECONDS) == 0)
         {
@@ -2208,6 +2214,14 @@ XMLP_ret XMLParser::getXMLDuration(
             return XMLP_ret::XML_ERROR;
         }
     }
+
+    // An empty Duration_t xml is forbidden
+    if(empty)
+    {
+        logError(XMLPARSER, "'durationType' elements cannot be empty. At least second or nanoseconds should be provided");
+        return XMLP_ret::XML_ERROR;
+    }
+
     return XMLP_ret::XML_OK;
 }
 


### PR DESCRIPTION
We discovered that several structures like LivelinessQosPolicy were initializing its Duration_t elements to non-default values:

```c++
    RTPS_DllAPI LivelinessQosPolicy()
        : Parameter_t(PID_LIVELINESS, PARAMETER_KIND_LENGTH + PARAMETER_TIME_LENGTH)
        , QosPolicy(true)
        , kind(AUTOMATIC_LIVELINESS_QOS)
        , lease_duration(TIME_T_INFINITE_SECONDS, TIME_T_INFINITE_NANOSECONDS)  <---
        , announcement_period(TIME_T_INFINITE_SECONDS, TIME_T_INFINITE_NANOSECONDS)  <--- 
    {
    }
```
The ``XMLP_ret XMLParser::getXMLDuration( tinyxml2::XMLElement* elem, Duration_t& duration, uint8_t ident)`` override didn't modify this values in absence of the xml tag, thus, non-default values may be introduced. For example:

```xml
        <liveliness>
          <kind>AUTOMATIC</kind>
          <lease_duration>
            <sec>5</sec>
          </lease_duration>
          <announcement_period>
            <sec>2</sec>
          </announcement_period>
        </liveliness>
```
was setting the nanosecond member to **TIME_T_INFINITE_NANOSECONDS** or ``0xffffffff``
 