### PR TITLE
Lock on create_participant <master> [7836]

### DIFF
--- a/examples/C++/DDS/DynamicHelloWorldExample/HelloWorldSubscriber.cpp
+++ b/examples/C++/DDS/DynamicHelloWorldExample/HelloWorldSubscriber.cpp
@@ -39,11 +39,14 @@ bool HelloWorldSubscriber::init()
 {
     eprosima::fastrtps::ParticipantAttributes PParam;
     PParam.rtps.setName("Participant_sub");
-    mp_participant = DomainParticipantFactory::get_instance()->create_participant(PParam, &m_listener);
-
-    if (mp_participant == nullptr)
     {
-        return false;
+        const std::lock_guard<std::mutex> lock(mutex_);
+        mp_participant = DomainParticipantFactory::get_instance()->create_participant(PParam, &m_listener);
+
+        if (mp_participant == nullptr)
+        {
+            return false;
+        }
     }
 
     // CREATE THE COMMON READER ATTRIBUTES
@@ -60,6 +63,12 @@ HelloWorldSubscriber::~HelloWorldSubscriber()
     DomainParticipantFactory::get_instance()->delete_participant(mp_participant);
     readers_.clear();
     datas_.clear();
+}
+
+eprosima::fastdds::dds::DomainParticipant* HelloWorldSubscriber::participant()
+{
+    const std::lock_guard<std::mutex> lock(mutex_);
+    return mp_participant;
 }
 
 void HelloWorldSubscriber::SubListener::on_subscription_matched(
@@ -113,7 +122,7 @@ void HelloWorldSubscriber::SubListener::on_type_discovery(
         eprosima::fastrtps::types::DynamicType_ptr dyn_type)
 {
     TypeSupport m_type(new eprosima::fastrtps::types::DynamicPubSubType(dyn_type));
-    subscriber_->mp_participant->register_type(m_type);
+    subscriber_->participant()->register_type(m_type);
 
     std::cout << "Discovered type: " << m_type->getName() << " from topic " << topic << std::endl;
 

--- a/examples/C++/DDS/DynamicHelloWorldExample/HelloWorldSubscriber.h
+++ b/examples/C++/DDS/DynamicHelloWorldExample/HelloWorldSubscriber.h
@@ -51,6 +51,8 @@ public:
     void run(
             uint32_t number);
 
+    eprosima::fastdds::dds::DomainParticipant* participant();
+
 private:
     eprosima::fastdds::dds::DomainParticipant* mp_participant;
 
@@ -65,6 +67,8 @@ private:
     eprosima::fastrtps::ReaderQos qos_;
 
     eprosima::fastrtps::TopicAttributes topic_;
+
+    std::mutex mutex_;
 
 public:
     class SubListener

--- a/examples/C++/DDS/TypeLookupService/TypeLookupSubscriber.h
+++ b/examples/C++/DDS/TypeLookupService/TypeLookupSubscriber.h
@@ -51,6 +51,8 @@ public:
     void run(
             uint32_t number);
 
+    eprosima::fastdds::dds::DomainParticipant* participant();
+
 private:
     eprosima::fastdds::dds::DomainParticipant* mp_participant;
 
@@ -65,6 +67,8 @@ private:
     eprosima::fastrtps::ReaderQos qos_;
 
     eprosima::fastrtps::TopicAttributes topic_;
+
+    std::mutex mutex_;
 
 public:
     class SubListener

--- a/test/xtypes/TestPublisher.h
+++ b/test/xtypes/TestPublisher.h
@@ -76,6 +76,8 @@ public:
         return disc_type_;
     }
 
+    eprosima::fastdds::dds::DomainParticipant* participant();
+
 private:
     std::string m_Name;
 
@@ -98,6 +100,8 @@ private:
     std::mutex m_mDiscovery;
 
     std::mutex mtx_type_discovery_;
+
+    std::mutex mutex_;
 
     std::condition_variable m_cvDiscovery;
 

--- a/test/xtypes/TestSubscriber.h
+++ b/test/xtypes/TestSubscriber.h
@@ -66,20 +66,6 @@ public:
     bool isMatched() { return m_subListener.n_matched > 0; }
     uint32_t samplesReceived() { return m_subListener.n_samples; }
 
-    void block(std::function<bool()> checker)
-    {
-        std::unique_lock<std::mutex> lock(mutex_);
-        cv_.wait(lock, checker);
-    }
-
-    size_t block_for_at_least(size_t at_least)
-    {
-        block([this, at_least]() -> bool {
-                return samplesReceived() >= at_least;
-                });
-        return samplesReceived();
-    }
-
     eprosima::fastrtps::types::DynamicType_ptr discovered_type() const
     {
         return disc_type_;
@@ -90,6 +76,8 @@ public:
     eprosima::fastdds::dds::DataReader* create_datareader();
 
     void delete_datareader(eprosima::fastdds::dds::DataReader* reader);
+
+    eprosima::fastdds::dds::DomainParticipant* participant();
 
 private:
     std::string m_Name;


### PR DESCRIPTION
Publisher/subscribers should not access the ComainParticipant pointer
until it is fully constructed (i.e., until create_participant returns).

Some of the tests have pubsubs with listeners that access the participant
pointer when receiving a message. Depending on the timing, the receive
resources can be up and running and start receiving before the pointer
is stored internally. When the listener tries to access this pointer,
the test crashes.

Added a mutex lock to sync both parts (participant creation and
listener)