### PR TITLE
Simulate initial acknack on ReaderProxy::start() [7838]

### DIFF
--- a/src/cpp/rtps/writer/ReaderProxy.cpp
+++ b/src/cpp/rtps/writer/ReaderProxy.cpp
@@ -102,6 +102,7 @@ void ReaderProxy::start(
     expects_inline_qos_ = reader_attributes.m_expectsInlineQos;
     is_reliable_ = reader_attributes.m_qos.m_reliability.kind != BEST_EFFORT_RELIABILITY_QOS;
     disable_positive_acks_ = reader_attributes.disable_positive_acks();
+    acked_changes_set(SequenceNumber_t());  // Simulate initial acknack to set low mark
 
     timers_enabled_.store(is_remote_and_reliable());
     if (is_local_reader())
@@ -330,6 +331,10 @@ void ReaderProxy::acked_changes_set(
                 {
                     std::sort(changes_for_reader_.begin(), changes_for_reader_.end(), ChangeForReaderCmp());
                 }
+            }
+            else if (!is_local_reader())
+            {
+                future_low_mark = writer_->next_sequence_number();
             }
         }
     }

--- a/src/cpp/rtps/writer/ReaderProxy.cpp
+++ b/src/cpp/rtps/writer/ReaderProxy.cpp
@@ -290,7 +290,8 @@ void ReaderProxy::acked_changes_set(
         if (seq_num == SequenceNumber_t())
         {
             // Special case. Currently only used on Builtin StatefulWriters
-            // after losing lease duration.
+            // after losing lease duration, and on late joiners to set
+            // changes_low_mark_ to match that of the writer.
             SequenceNumber_t min_sequence = writer_->get_seq_num_min();
             if (min_sequence != SequenceNumber_t::unknown())
             {

--- a/test/mock/rtps/StatefulWriter/fastdds/rtps/writer/StatefulWriter.h
+++ b/test/mock/rtps/StatefulWriter/fastdds/rtps/writer/StatefulWriter.h
@@ -75,6 +75,11 @@ public:
         return SequenceNumber_t(0, 0);
     }
 
+    SequenceNumber_t next_sequence_number() const
+    {
+        return mp_history->next_sequence_number();
+    }
+
 private:
 
     friend class ReaderProxy;

--- a/test/mock/rtps/WriterHistory/fastdds/rtps/history/WriterHistory.h
+++ b/test/mock/rtps/WriterHistory/fastdds/rtps/history/WriterHistory.h
@@ -77,6 +77,11 @@ class WriterHistory
             }
         }
 
+        SequenceNumber_t next_sequence_number() const
+        {
+            return last_sequence_number_ + 1;
+        }
+
         HistoryAttributes m_att;
 
     private:


### PR DESCRIPTION
This PR tackles the #1042 issue.

With it, as part of starting a `ReaderProxy`,  a call to `acked_changes_set(SequenceNumber_t())` is performed to simulate an initial acknack from the reader. This has the effect of setting the ReaderProxy's low mark to the writer's first available change, which avoids the writer need to iterate through all the changes 0 to low mark the first time it sends data to the reader.

This is OK to do, since an initial heartbeat is sent to the reader notifying the writer's state right after discovery, which already tells the reader that the first change is low mark, so there is no need of sending any gap, nor requesting changes older than that.