### PR TITLE
[7885] Modify Duration_t xml schema and parsing to match documented behaviour

### DIFF
--- a/resources/xsd/fastRTPS_profiles.xsd
+++ b/resources/xsd/fastRTPS_profiles.xsd
@@ -153,20 +153,39 @@
     </xs:complexType>
 
     <xs:simpleType name="nonNegativeInteger_Duration_SEC">
-        <xs:restriction base="xs:string">
-            <xs:pattern value="(DURATION_INFINITY|DURATION_INFINITE_SEC|([0-9])*)?"/>
-        </xs:restriction>
+        <xs:union>
+            <xs:simpleType>
+                <xs:restriction base="xs:string">
+                    <xs:pattern value="\s*(DURATION_INFINITY|DURATION_INFINITE_SEC)\s*"/>
+                </xs:restriction>
+            </xs:simpleType>
+            <xs:simpleType>
+                <xs:restriction base="xs:unsignedInt"/>
+            </xs:simpleType>
+        </xs:union>
     </xs:simpleType>
 
     <xs:simpleType name="nonNegativeInteger_Duration_NSEC">
-        <xs:restriction base="xs:string">
-            <xs:pattern value="(DURATION_INFINITY|DURATION_INFINITE_NSEC|([0-9])*)?"/>
-        </xs:restriction>
+        <xs:union>
+            <xs:simpleType>
+                <xs:restriction base="xs:string">
+                    <xs:pattern value="\s*(DURATION_INFINITY|DURATION_INFINITE_NSEC)\s*"/>
+                </xs:restriction>
+            </xs:simpleType>
+            <xs:simpleType>
+                <xs:restriction base="xs:unsignedInt"/>
+            </xs:simpleType>
+        </xs:union>
     </xs:simpleType>
 
-    <xs:complexType name="durationType">
+    <!-- xml schema constrains doesn't allow to validate that:
+        + durationType has either text or tags
+        + durationType associated text matches DURATION_INFINITY
+     -->
+
+    <xs:complexType name="durationType" mixed="true">
         <xs:sequence>
-            <xs:choice minOccurs="1">
+            <xs:choice minOccurs="0">
                 <xs:sequence>
                     <xs:element name="sec" type="nonNegativeInteger_Duration_SEC" default="0" minOccurs="1" maxOccurs="1"/>
                     <xs:element name="nanosec" type="nonNegativeInteger_Duration_NSEC" default="0" minOccurs="0" maxOccurs="1"/>
@@ -732,7 +751,7 @@
 
     <xs:complexType name="TransportDescriptorListType">
       <xs:sequence>
-        <xs:element name="transport_descriptor" type="rtpsTransportDescriptorType"/>
+        <xs:element name="transport_descriptor" type="rtpsTransportDescriptorType" maxOccurs="unbounded"/>
       </xs:sequence>
     </xs:complexType>
 

--- a/src/cpp/rtps/xmlparser/XMLElementParser.cpp
+++ b/src/cpp/rtps/xmlparser/XMLElementParser.cpp
@@ -2266,14 +2266,14 @@ XMLP_ret XMLParser::getXMLDuration(
     if (text != nullptr && std::regex_match(text, infinite))
     {
         empty = false;
-        duration = c_TimeInfinite; 
-        
+        duration = c_TimeInfinite;
+
         if(elem->FirstChildElement() != nullptr)
         {
             logError(XMLPARSER, "If a Duration_t type element is defined as DURATION_INFINITY it cannot have <sec> or"
             " <nanosec> subelements.");
             return XMLP_ret::XML_ERROR;
-        }     
+        }
     }
 
     tinyxml2::XMLElement* p_aux0 = nullptr;
@@ -2308,9 +2308,8 @@ XMLP_ret XMLParser::getXMLDuration(
             }
             else if (std::regex_match(text, infinite_sec))
             {
-                duration = c_TimeInfinite;
-
                 // if either SECONDS or NANOSECONDS is set to infinity then all of it is
+                duration = c_TimeInfinite;
                 return XMLP_ret::XML_OK;
             }
             else if (XMLP_ret::XML_OK != getXMLInt(p_aux0, &duration.seconds, ident))
@@ -2343,9 +2342,8 @@ XMLP_ret XMLParser::getXMLDuration(
             }
             else if (std::regex_match(text, infinite_nsec))
             {
-                duration = c_TimeInfinite;
-
                 // if either SECONDS or NANOSECONDS is set to infinity then all of it is
+                duration = c_TimeInfinite;
                 return XMLP_ret::XML_OK;
             }
             else if (XMLP_ret::XML_OK != getXMLUint(p_aux0, &duration.nanosec, ident))
@@ -2364,7 +2362,8 @@ XMLP_ret XMLParser::getXMLDuration(
     // An empty Duration_t xml is forbidden
     if(empty)
     {
-        logError(XMLPARSER, "'durationType' elements cannot be empty. At least second or nanoseconds should be provided");
+        logError(XMLPARSER, "'durationType' elements cannot be empty."
+            "At least second or nanoseconds should be provided");
         return XMLP_ret::XML_ERROR;
     }
 

--- a/src/cpp/rtps/xmlparser/XMLElementParser.cpp
+++ b/src/cpp/rtps/xmlparser/XMLElementParser.cpp
@@ -2234,12 +2234,20 @@ XMLP_ret XMLParser::getXMLDuration(
         uint8_t ident)
 {
     /*
-        <xs:complexType name="durationType">
-            <xs:all>
-                <xs:element name="sec" type="nonNegativeInteger_Duration_SEC" default="0" minOccurs="0"/>
-                <xs:element name="nanosec" type="nonNegativeInteger_Duration_NSEC" default="0" minOccurs="0"/>
-            </xs:all>
-        </xs:complexType>
+    <xs:complexType name="durationType" mixed="true">
+      <xs:sequence>
+        <xs:choice minOccurs="0">
+         <xs:sequence>
+          <xs:element name="sec" type="nonNegativeInteger_Duration_SEC" default="0" minOccurs="1" maxOccurs="1"/>
+          <xs:element name="nanosec" type="nonNegativeInteger_Duration_NSEC" default="0" minOccurs="0" maxOccurs="1"/>
+         </xs:sequence>
+         <xs:sequence>
+          <xs:element name="nanosec" type="nonNegativeInteger_Duration_NSEC" default="0" minOccurs="1" maxOccurs="1"/>
+          <xs:element name="sec" type="nonNegativeInteger_Duration_SEC" default="0" minOccurs="0" maxOccurs="1"/>
+        </xs:sequence>
+       </xs:choice>
+      </xs:sequence>
+    </xs:complexType>
      */
 
     // set default values
@@ -2253,13 +2261,14 @@ XMLP_ret XMLParser::getXMLDuration(
     std::regex infinite(DURATION_INFINITY);
     std::regex infinite_sec(DURATION_INFINITE_SEC);
     std::regex infinite_nsec(DURATION_INFINITE_NSEC);
+    const char* text = elem->GetText();
 
-    if (std::regex_match(elem->GetText(), infinite))
+    if (text != nullptr && std::regex_match(text, infinite))
     {
         empty = false;
         duration = c_TimeInfinite; 
         
-        if(!elem->NoChildren())
+        if(elem->FirstChildElement() != nullptr)
         {
             logError(XMLPARSER, "If a Duration_t type element is defined as DURATION_INFINITY it cannot have <sec> or"
             " <nanosec> subelements.");
@@ -2278,13 +2287,20 @@ XMLP_ret XMLParser::getXMLDuration(
         if (strcmp(name, SECONDS) == 0)
         {
             /*
-                <xs:simpleType name="nonNegativeInteger_Duration_SEC">
-                    <xs:restriction base="xs:string">
-                        <xs:pattern value="(DURATION_INFINITY|DURATION_INFINITE_SEC|([0-9])*)?"/>
-                    </xs:restriction>
+               <xs:simpleType name="nonNegativeInteger_Duration_SEC">
+                    <xs:union>
+                        <xs:simpleType>
+                            <xs:restriction base="xs:string">
+                                <xs:pattern value="\s*(DURATION_INFINITY|DURATION_INFINITE_SEC)\s*"/>
+                            </xs:restriction>
+                        </xs:simpleType>
+                        <xs:simpleType>
+                            <xs:restriction base="xs:unsignedInt"/>
+                        </xs:simpleType>
+                    </xs:union>
                 </xs:simpleType>
              */
-            const char* text = p_aux0->GetText();
+            text = p_aux0->GetText();
             if (nullptr == text)
             {
                 logError(XMLPARSER, "Node 'SECONDS' without content");
@@ -2307,12 +2323,19 @@ XMLP_ret XMLParser::getXMLDuration(
         {
             /*
                 <xs:simpleType name="nonNegativeInteger_Duration_NSEC">
-                    <xs:restriction base="xs:string">
-                        <xs:pattern value="(DURATION_INFINITY|DURATION_INFINITE_NSEC|([0-9])*)?"/>
-                    </xs:restriction>
+                    <xs:union>
+                        <xs:simpleType>
+                            <xs:restriction base="xs:string">
+                                <xs:pattern value="\s*(DURATION_INFINITY|DURATION_INFINITE_NSEC)\s*"/>
+                            </xs:restriction>
+                        </xs:simpleType>
+                        <xs:simpleType>
+                            <xs:restriction base="xs:unsignedInt"/>
+                        </xs:simpleType>
+                    </xs:union>
                 </xs:simpleType>
              */
-            const char* text = p_aux0->GetText();
+            text = p_aux0->GetText();
             if (nullptr == text)
             {
                 logError(XMLPARSER, "Node 'NANOSECONDS' without content");

--- a/src/cpp/rtps/xmlparser/XMLParserCommon.cpp
+++ b/src/cpp/rtps/xmlparser/XMLParserCommon.cpp
@@ -154,10 +154,13 @@ const char* SECONDS = "sec";
 const char* NANOSECONDS = "nanosec";
 const char* SHARED = "SHARED";
 const char* EXCLUSIVE = "EXCLUSIVE";
-const char* DURATION_INFINITY = R"xsd(\s*DURATION_INFINITY\s*)xsd";
-const char* DURATION_INFINITE_SEC = R"xsd(\s*(DURATION_INFINITY|DURATION_INFINITE_SEC)\s*)xsd";
-const char* DURATION_INFINITE_NSEC = R"xsd(\s*(DURATION_INFINITY|DURATION_INFINITE_NSEC)\s*)xsd";
-
+// For backward compatibility we allow any DURATION_XXX in duration_t element and any subelement
+// const char* DURATION_INFINITY = R"xsd(\s*DURATION_INFINITY\s*)xsd";
+// const char* DURATION_INFINITE_SEC = R"xsd(\s*(DURATION_INFINITY|DURATION_INFINITE_SEC)\s*)xsd";
+// const char* DURATION_INFINITE_NSEC = R"xsd(\s*(DURATION_INFINITY|DURATION_INFINITE_NSEC)\s*)xsd";
+const char* DURATION_INFINITY = R"xsd(\s*(DURATION_INFINITY|DURATION_INFINITE_SEC|DURATION_INFINITE_NSEC)\s*)xsd";
+const char* DURATION_INFINITE_SEC = DURATION_INFINITY; 
+const char* DURATION_INFINITE_NSEC = DURATION_INFINITY; 
 /// QOS
 const char* DURABILITY = "durability";
 const char* DURABILITY_SRV = "durabilityService";

--- a/src/cpp/rtps/xmlparser/XMLParserCommon.cpp
+++ b/src/cpp/rtps/xmlparser/XMLParserCommon.cpp
@@ -150,13 +150,13 @@ const char* NACK_RESP_DELAY = "nackResponseDelay";
 const char* NACK_SUPRESSION = "nackSupressionDuration";
 const char* BY_NAME = "durationbyname";
 const char* BY_VAL = "durationbyval";
-const char* DURATION_INFINITY = "DURATION_INFINITY";
-const char* DURATION_INFINITE_SEC = "DURATION_INFINITE_SEC";
-const char* DURATION_INFINITE_NSEC = "DURATION_INFINITE_NSEC";
 const char* SECONDS = "sec";
 const char* NANOSECONDS = "nanosec";
 const char* SHARED = "SHARED";
 const char* EXCLUSIVE = "EXCLUSIVE";
+const char* DURATION_INFINITY = R"xsd(\s*DURATION_INFINITY\s*)xsd";
+const char* DURATION_INFINITE_SEC = R"xsd(\s*(DURATION_INFINITY|DURATION_INFINITE_SEC)\s*)xsd";
+const char* DURATION_INFINITE_NSEC = R"xsd(\s*(DURATION_INFINITY|DURATION_INFINITE_NSEC)\s*)xsd";
 
 /// QOS
 const char* DURABILITY = "durability";

--- a/test/performance/latency/CMakeLists.txt
+++ b/test/performance/latency/CMakeLists.txt
@@ -86,14 +86,21 @@ if(PYTHONINTERP_FOUND)
             TEST performance.latency.${latency_test_name}
             APPEND PROPERTY ENVIRONMENT "LATENCY_TEST_BIN=$<TARGET_FILE:LatencyTest>"
         )
+
+        # Add environment
         if(WIN32)
             set(WIN_PATH "$ENV{PATH}")
-            set(WIN_PATH "$<TARGET_FILE_DIR:${PROJECT_NAME}>;$ENV{PATH}")
+            get_target_property(LINK_LIBRARIES_ ${PROJECT_NAME} LINK_LIBRARIES)
+            if(NOT "${LINK_LIBRARIES_}" STREQUAL "LINK_LIBRARIES_-NOTFOUND")
+            list(APPEND LINK_LIBRARIES_ ${PROJECT_NAME})
+                foreach(LIBRARY_LINKED ${LINK_LIBRARIES_})
+                    if(TARGET ${LIBRARY_LINKED})
+                        set(WIN_PATH "$<TARGET_FILE_DIR:${LIBRARY_LINKED}>;${WIN_PATH}")
+                    endif()
+                endforeach()
+            endif()
             string(REPLACE ";" "\\;" WIN_PATH "${WIN_PATH}")
-            set_property(
-                TEST performance.latency.${latency_test_name}
-                APPEND PROPERTY ENVIRONMENT "PATH=${WIN_PATH}"
-            )
+            set_property(TEST performance.latency.${latency_test_name}  APPEND PROPERTY ENVIRONMENT "PATH=${WIN_PATH}")
         endif()
 
         # If there is security, add a secure test as well

--- a/test/performance/throughput/CMakeLists.txt
+++ b/test/performance/throughput/CMakeLists.txt
@@ -92,14 +92,21 @@ if(PYTHONINTERP_FOUND)
             TEST performance.throughput.${throughput_test_name}
             APPEND PROPERTY ENVIRONMENT "CMAKE_CURRENT_SOURCE_DIR=${CMAKE_CURRENT_SOURCE_DIR}"
         )
+
+        # Add environment
         if(WIN32)
             set(WIN_PATH "$ENV{PATH}")
-            set(WIN_PATH "$<TARGET_FILE_DIR:${PROJECT_NAME}>;$ENV{PATH}")
+            get_target_property(LINK_LIBRARIES_ ${PROJECT_NAME} LINK_LIBRARIES)
+            if(NOT "${LINK_LIBRARIES_}" STREQUAL "LINK_LIBRARIES_-NOTFOUND")
+            list(APPEND LINK_LIBRARIES_ ${PROJECT_NAME})
+                foreach(LIBRARY_LINKED ${LINK_LIBRARIES_})
+                    if(TARGET ${LIBRARY_LINKED})
+                        set(WIN_PATH "$<TARGET_FILE_DIR:${LIBRARY_LINKED}>;${WIN_PATH}")
+                    endif()
+                endforeach()
+            endif()
             string(REPLACE ";" "\\;" WIN_PATH "${WIN_PATH}")
-            set_property(
-                TEST performance.throughput.${throughput_test_name}
-                APPEND PROPERTY ENVIRONMENT "PATH=${WIN_PATH}"
-            )
+            set_property(TEST performance.throughput.${throughput_test_name}  APPEND PROPERTY ENVIRONMENT "PATH=${WIN_PATH}")
         endif()
 
         if(SECURITY AND (${throughput_test_name} MATCHES "^interprocess"))


### PR DESCRIPTION
Notice that this pull request must be merged after #1046.

We noticed that Duration_t was ignoring the ``DURATION_INFINITY``, ``DURATION_INFINITE_SEC`` and ``DURATION_INFINITE_NSEC`` specifications given in the xml configuration files.

XSD schema was adapt to match, as much as possible, the documented behavior. XSD doesn't admit to restrict complex types with mixed test and subelements, thus, ``DURATION_INFINITY`` is only verified on parsing and ignored on validations against the schema.

Solving this problem another was detected on the performance test. The CTestFiles generated didn't include fastrtps dependencies on windows leading to systematic test failures. Because our continuos integration tests use colcon this behaviour wasn't noticed before (colcon populates the environment with all dependencies).