### PR TITLE
[eloquent] Stateless writer delivery improvement [7880]

### DIFF
--- a/src/cpp/rtps/writer/StatelessWriter.cpp
+++ b/src/cpp/rtps/writer/StatelessWriter.cpp
@@ -187,6 +187,15 @@ void StatelessWriter::unsent_change_added_to_history(
                 }
                 else
                 {
+                    for (ReaderLocator& it : matched_readers_)
+                    {
+                        if (it.is_local_reader())
+                        {
+                            intraprocess_delivery(change, it);
+                        }
+                    }
+
+                    if(there_are_remote_readers_ || !fixed_locators_.empty())
                     {
                         RTPSMessageGroup group(mp_RTPSParticipant, this, *this, max_blocking_time);
 
@@ -196,13 +205,6 @@ void StatelessWriter::unsent_change_added_to_history(
                         }
                     }
 
-                    for (ReaderLocator& it : matched_readers_)
-                    {
-                        if (it.is_local_reader())
-                        {
-                            intraprocess_delivery(change, it);
-                        }
-                    }
                 }
 
                 if (mp_listener != nullptr)


### PR DESCRIPTION
With this PR, the StatelessWriter synchronous delivery order is set to:
1. Intra-process.
2. Inter-process, but only if there are remote readers or fixed locators.

This posses a performance improvement for the intra-process case, since the RTPSMessageGroup construction only happens when it's needed (remote readers or fixed locators).

Note: this has been backported from #946 