### PR TITLE
Fixing send semantics [7893]

### DIFF
--- a/src/cpp/rtps/transport/TCPTransportInterface.cpp
+++ b/src/cpp/rtps/transport/TCPTransportInterface.cpp
@@ -998,7 +998,11 @@ bool TCPTransportInterface::send(
 
     while (it != *destination_locators_end)
     {
-        ret &= send(send_buffer, send_buffer_size, channel,*it);
+        if (IsLocatorSupported(*it))
+        {
+            ret &= send(send_buffer, send_buffer_size, channel,*it);
+        }
+
         ++it;
     }
 
@@ -1011,11 +1015,6 @@ bool TCPTransportInterface::send(
         std::shared_ptr<TCPChannelResource>& channel,
         const Locator_t& remote_locator)
 {
-    if (!IsLocatorSupported(remote_locator))
-    {
-        return false;
-    }
-
     bool locator_mismatch = false;
 
     if (channel->locator() != IPLocator::toPhysicalLocator(remote_locator))


### PR DESCRIPTION
Since commit 83380dd1904e8aeadbed70b0279b12bc957cdd09 (PR #908 Transport Refactor: Send receives LocatorsIterator instead Locator_t). Some tests fail when running with Valgrind due to timeouts failure. This is because semantic of the send function in the transports was changed. Before, when timeout is reached the message is tried to be sent with time-out 0 and always return true. Now when timeout function fails.

This PR restores the old semantic.