### PR TITLE
Bring back removed API on PartitionQosPolicy. [7902]

### DIFF
--- a/include/fastdds/dds/core/policy/QosPolicies.hpp
+++ b/include/fastdds/dds/core/policy/QosPolicies.hpp
@@ -1246,6 +1246,25 @@ public:
      * Returns partition names.
      * @return Vector of partition name strings.
      */
+    RTPS_DllAPI inline const std::vector<std::string> getNames() const
+    {
+        return names();
+    }
+
+    /**
+     * Overrides partition names
+     * @param nam Vector of partition name strings.
+     */
+    RTPS_DllAPI inline void setNames(
+            std::vector<std::string>& nam)
+    {
+        names(nam);
+    }
+
+    /**
+     * Returns partition names.
+     * @return Vector of partition name strings.
+     */
     RTPS_DllAPI inline const std::vector<std::string> names() const
     {
         std::vector<std::string> names;


### PR DESCRIPTION
Methods `getNames` and `setNames` were renamed, so we should keep an alias in order to maintain the old API.