### PR TITLE
Fixing unsent_change_added_to_history with no readers [7927]

### DIFF
--- a/src/cpp/rtps/writer/StatefulWriter.cpp
+++ b/src/cpp/rtps/writer/StatefulWriter.cpp
@@ -209,6 +209,14 @@ void StatefulWriter::unsent_change_added_to_history(
 {
     std::lock_guard<RecursiveTimedMutex> guard(mp_mutex);
 
+    if (liveliness_lease_duration_ < c_TimeInfinite)
+    {
+        mp_RTPSParticipant->wlp()->assert_liveliness(
+            getGuid(),
+            liveliness_kind_,
+            liveliness_lease_duration_);
+    }
+
 #if HAVE_SECURITY
     encrypt_cachechange(change);
 #endif
@@ -393,14 +401,6 @@ void StatefulWriter::unsent_change_added_to_history(
 
             ack_event_->update_interval_millisec((double)duration_cast<milliseconds>(interval).count());
             ack_event_->restart_timer(max_blocking_time);
-        }
-
-        if (liveliness_lease_duration_ < c_TimeInfinite)
-        {
-            mp_RTPSParticipant->wlp()->assert_liveliness(
-                getGuid(),
-                liveliness_kind_,
-                liveliness_lease_duration_);
         }
     }
     else

--- a/src/cpp/rtps/writer/StatelessWriter.cpp
+++ b/src/cpp/rtps/writer/StatelessWriter.cpp
@@ -195,6 +195,14 @@ void StatelessWriter::unsent_change_added_to_history(
 {
     std::lock_guard<RecursiveTimedMutex> guard(mp_mutex);
 
+    if (liveliness_lease_duration_ < c_TimeInfinite)
+    {
+        mp_RTPSParticipant->wlp()->assert_liveliness(
+            getGuid(),
+            liveliness_kind_,
+            liveliness_lease_duration_);
+    }
+
     if (!fixed_locators_.empty() || matched_readers_.size() > 0)
     {
 #if HAVE_SECURITY
@@ -290,14 +298,6 @@ void StatelessWriter::unsent_change_added_to_history(
         {
             unsent_changes_.push_back(ChangeForReader_t(change));
             mp_RTPSParticipant->async_thread().wake_up(this, max_blocking_time);
-        }
-
-        if (liveliness_lease_duration_ < c_TimeInfinite)
-        {
-            mp_RTPSParticipant->wlp()->assert_liveliness(
-                getGuid(),
-                liveliness_kind_,
-                liveliness_lease_duration_);
         }
     }
     else

--- a/src/cpp/rtps/writer/StatelessWriter.cpp
+++ b/src/cpp/rtps/writer/StatelessWriter.cpp
@@ -203,12 +203,12 @@ void StatelessWriter::unsent_change_added_to_history(
             liveliness_lease_duration_);
     }
 
-    if (!fixed_locators_.empty() || matched_readers_.size() > 0)
-    {
 #if HAVE_SECURITY
-        encrypt_cachechange(change);
+    encrypt_cachechange(change);
 #endif
 
+    if (!fixed_locators_.empty() || matched_readers_.size() > 0)
+    {
         if (!isAsync())
         {
             try


### PR DESCRIPTION
I've seen some of the liveliness tests passing correctly but after a very long time (more than 50 seconds). I checked that 50 seconds is what the DATA(p) announcement period is set to on those tests. All of them were manual_by_topic and non-intraprocess.

The problem was that liveliness was not asserted when matched_readers_ was empty.

I have also seen that the call to `encrypt_cachechange` was suffering from the same problem on `StatelessWriter`. May have been the reason for the failures on `SimpleCommunicationSecureBestEffort`.

This PR fixes both problems.