### PR TITLE
Converting template into macro [7931]

### DIFF
--- a/include/fastdds/dds/core/policy/QosPolicies.hpp
+++ b/include/fastdds/dds/core/policy/QosPolicies.hpp
@@ -839,68 +839,68 @@ public:
 };
 
 /**
- * Class TemplateDataQosPolicy, base template for user data qos policies.
+ * Class TClassName, base template for user data qos policies.
  */
-template<ParameterId_t TPid>
-class TemplateDataQosPolicy : public GenericDataQosPolicy
-{
-public:
-
-    RTPS_DllAPI TemplateDataQosPolicy()
-        : GenericDataQosPolicy(TPid)
-    {
-    }
-
-    RTPS_DllAPI TemplateDataQosPolicy(
-            uint16_t in_length)
-        : GenericDataQosPolicy(TPid, in_length)
-    {
-    }
-
-    /**
-     * Construct from another TemplateDataQosPolicy.
-     *
-     * The resulting TemplateDataQosPolicy will have the same size limits
-     * as the input attribute
-     *
-     * @param data data to copy in the newly created object
-     */
-    RTPS_DllAPI TemplateDataQosPolicy(
-            const TemplateDataQosPolicy& data) = default;
-
-    /**
-     * Construct from underlying collection type.
-     *
-     * Useful to easy integration on old APIs where a traditional container was used.
-     * The resulting TemplateDataQosPolicy will always be unlimited in size
-     *
-     * @param data data to copy in the newly created object
-     */
-    RTPS_DllAPI TemplateDataQosPolicy(
-            const collection_type& data)
-        : GenericDataQosPolicy(TPid, data)
-    {
-    }
-
-    virtual RTPS_DllAPI ~TemplateDataQosPolicy() = default;
-
-    /**
-     * Copies another TemplateDataQosPolicy.
-     *
-     * The resulting TemplateDataQosPolicy will have the same size limit
-     * as the input parameter, so all data in the input will be copied.
-     *
-     * @param b object to be copied
-     * @return reference to the current object.
-     */
-    TemplateDataQosPolicy& operator =(
-            const TemplateDataQosPolicy& b) = default;
-
+#define TEMPLATE_DATA_QOS_POLICY(TClassName, TPid)                                     \
+class TClassName : public GenericDataQosPolicy                                         \
+{                                                                                      \
+public:                                                                                \
+                                                                                       \
+    RTPS_DllAPI TClassName()                                                           \
+        : GenericDataQosPolicy(TPid)                                                   \
+    {                                                                                  \
+    }                                                                                  \
+                                                                                       \
+    RTPS_DllAPI TClassName(                                                            \
+            uint16_t in_length)                                                        \
+        : GenericDataQosPolicy(TPid, in_length)                                        \
+    {                                                                                  \
+    }                                                                                  \
+                                                                                       \
+    /**                                                                                \
+     * Construct from another TClassName.                                              \
+     *                                                                                 \
+     * The resulting TClassName will have the same size limits                         \
+     * as the input attribute                                                          \
+     *                                                                                 \
+     * @param data data to copy in the newly created object                            \
+     */                                                                                \
+    RTPS_DllAPI TClassName(                                                            \
+            const TClassName& data) = default;                                         \
+                                                                                       \
+    /**                                                                                \
+     * Construct from underlying collection type.                                      \
+     *                                                                                 \
+     * Useful to easy integration on old APIs where a traditional container was used.  \
+     * The resulting TClassName will always be unlimited in size                       \
+     *                                                                                 \
+     * @param data data to copy in the newly created object                            \
+     */                                                                                \
+    RTPS_DllAPI TClassName(                                                            \
+            const collection_type& data)                                               \
+        : GenericDataQosPolicy(TPid, data)                                             \
+    {                                                                                  \
+    }                                                                                  \
+                                                                                       \
+    virtual RTPS_DllAPI ~TClassName() = default;                                       \
+                                                                                       \
+    /**                                                                                \
+     * Copies another TClassName.                                                      \
+     *                                                                                 \
+     * The resulting TClassName will have the same size limit                          \
+     * as the input parameter, so all data in the input will be copied.                \
+     *                                                                                 \
+     * @param b object to be copied                                                    \
+     * @return reference to the current object.                                        \
+     */                                                                                \
+    TClassName& operator =(                                                            \
+            const TClassName& b) = default;                                            \
+                                                                                       \
 };
 
-using UserDataQosPolicy = TemplateDataQosPolicy<PID_USER_DATA>;
-using TopicDataQosPolicy = TemplateDataQosPolicy<PID_TOPIC_DATA>;
-using GroupDataQosPolicy = TemplateDataQosPolicy<PID_GROUP_DATA>;
+TEMPLATE_DATA_QOS_POLICY(UserDataQosPolicy, PID_USER_DATA)
+TEMPLATE_DATA_QOS_POLICY(TopicDataQosPolicy, PID_TOPIC_DATA)
+TEMPLATE_DATA_QOS_POLICY(GroupDataQosPolicy, PID_GROUP_DATA)
 
 /**
  * Class TimeBasedFilterQosPolicy, to indicate the Time Based Filter Qos.

--- a/include/fastdds/dds/publisher/qos/PublisherQos.hpp
+++ b/include/fastdds/dds/publisher/qos/PublisherQos.hpp
@@ -87,7 +87,7 @@ public:
     fastrtps::LifespanQosPolicy lifespan;
 
     //!UserData Qos, NOT implemented in the library.
-    UserDataQosPolicy user_data;
+    fastrtps::UserDataQosPolicy user_data;
 
     //!Time Based Filter Qos, NOT implemented in the library.
     fastrtps::TimeBasedFilterQosPolicy time_based_filter;

--- a/include/fastdds/dds/topic/qos/DataReaderQos.hpp
+++ b/include/fastdds/dds/topic/qos/DataReaderQos.hpp
@@ -62,7 +62,7 @@ public:
     fastrtps::ResourceLimitsQosPolicy resource_limits;
 
     //!User Data Qos, NOT implemented in the library.
-    UserDataQosPolicy user_data;
+    fastrtps::UserDataQosPolicy user_data;
 
     //!Ownership Qos, NOT implemented in the library.
     fastrtps::OwnershipQosPolicy ownership;

--- a/include/fastdds/dds/topic/qos/DataWriterQos.hpp
+++ b/include/fastdds/dds/topic/qos/DataWriterQos.hpp
@@ -71,7 +71,7 @@ public:
     fastrtps::LifespanQosPolicy lifespan;
 
     //!User Data Qos, implemented in the library.
-    UserDataQosPolicy user_data;
+    fastrtps::UserDataQosPolicy user_data;
 
     //!Ownership Qos, NOT implemented in the library.
     fastrtps::OwnershipQosPolicy ownership;

--- a/include/fastdds/rtps/builtin/data/ParticipantProxyData.h
+++ b/include/fastdds/rtps/builtin/data/ParticipantProxyData.h
@@ -133,7 +133,7 @@ public:
     //!
     ParameterPropertyList_t m_properties;
     //!
-    fastdds::dds::UserDataQosPolicy m_userData;
+    UserDataQosPolicy m_userData;
     //!
     TimedEvent* lease_duration_event;
     //!

--- a/include/fastrtps/qos/QosPolicies.h
+++ b/include/fastrtps/qos/QosPolicies.h
@@ -72,8 +72,9 @@ constexpr PresentationQosPolicyAccessScopeKind GROUP_PRESENTATION_QOS =
         PresentationQosPolicyAccessScopeKind::GROUP_PRESENTATION_QOS;
 using PresentationQosPolicy = fastdds::dds::PresentationQosPolicy;
 using PartitionQosPolicy = fastdds::dds::PartitionQosPolicy;
-using TopicDataQosPolicy = fastdds::dds::TemplateDataQosPolicy<fastdds::dds::PID_TOPIC_DATA>;
-using GroupDataQosPolicy = fastdds::dds::TemplateDataQosPolicy<fastdds::dds::PID_GROUP_DATA>;
+using UserDataQosPolicy = fastdds::dds::UserDataQosPolicy;
+using TopicDataQosPolicy = fastdds::dds::TopicDataQosPolicy;
+using GroupDataQosPolicy = fastdds::dds::GroupDataQosPolicy;
 using HistoryQosPolicyKind = fastdds::dds::HistoryQosPolicyKind;
 constexpr HistoryQosPolicyKind KEEP_LAST_HISTORY_QOS = HistoryQosPolicyKind::KEEP_LAST_HISTORY_QOS;
 constexpr HistoryQosPolicyKind KEEP_ALL_HISTORY_QOS = HistoryQosPolicyKind::KEEP_ALL_HISTORY_QOS;

--- a/include/fastrtps/xmlparser/XMLParser.h
+++ b/include/fastrtps/xmlparser/XMLParser.h
@@ -397,7 +397,7 @@ protected:
 
     RTPS_DllAPI static XMLP_ret getXMLUserDataQos(
             tinyxml2::XMLElement* elem,
-            fastdds::dds::UserDataQosPolicy& userData,
+            UserDataQosPolicy& userData,
             uint8_t ident);
 
     RTPS_DllAPI static XMLP_ret getXMLLifespanQos(


### PR DESCRIPTION
It seems that compilers are having problems when building (except on release) after #1059 was merged.

This PR helps them work better by avoiding the use of a template that was being aliased more than once.