### PR TITLE
[ros2-eloquent] Simulate initial acknack on ReaderProxy::start() [7974]

### DIFF
--- a/test/mock/rtps/StatefulWriter/fastrtps/rtps/writer/StatefulWriter.h
+++ b/test/mock/rtps/StatefulWriter/fastrtps/rtps/writer/StatefulWriter.h
@@ -75,6 +75,11 @@ public:
         return SequenceNumber_t(0, 0);
     }
 
+    SequenceNumber_t next_sequence_number() const
+    {
+        return mp_history->next_sequence_number();
+    }
+
 private:
 
     friend class ReaderProxy;

--- a/test/mock/rtps/WriterHistory/fastrtps/rtps/history/WriterHistory.h
+++ b/test/mock/rtps/WriterHistory/fastrtps/rtps/history/WriterHistory.h
@@ -77,6 +77,11 @@ class WriterHistory
             }
         }
 
+        SequenceNumber_t next_sequence_number() const
+        {
+            return last_sequence_number_ + 1;
+        }
+
         HistoryAttributes m_att;
 
     private:


### PR DESCRIPTION
This is a backport of #1045