### PR TITLE
Repairing client-server BACKUP operation [8027]

### DIFF
--- a/include/fastdds/rtps/builtin/discovery/endpoint/EDPServer.h
+++ b/include/fastdds/rtps/builtin/discovery/endpoint/EDPServer.h
@@ -129,6 +129,12 @@ public:
                 *subscriptions_writer_.first, *subscriptions_writer_.second, &ParticipantProxyData::m_readers);
     }
 
+    //! returns true if loading info from persistency database
+    bool ongoingDeserialization();
+
+    //! Process the info recorded in the persistence database
+    void processPersistentData();
+
     protected:
 
     /**

--- a/include/fastdds/rtps/builtin/discovery/endpoint/EDPSimple.h
+++ b/include/fastdds/rtps/builtin/discovery/endpoint/EDPSimple.h
@@ -214,6 +214,9 @@ protected:
             bool remove_same_instance,
             CacheChange_t** created_change);
 
+    //! Process the info recorded in the persistence database
+    static void processPersistentData(t_p_StatefulReader & reader, t_p_StatefulWriter & writer);
+
 private:
     /**
      * Create a cache change on a builtin writer and serialize a ProxyData on it.

--- a/include/fastdds/rtps/builtin/discovery/participant/PDPServer.h
+++ b/include/fastdds/rtps/builtin/discovery/participant/PDPServer.h
@@ -228,6 +228,12 @@ public:
     std::string GetPersistenceFileName();
 #endif
 
+    //! returns true if loading info from persistency database
+    bool ongoingDeserialization();
+
+    //! Process the info recorded in the persistence database
+    void processPersistentData();
+
     //! Wakes up the DServerEvent for new matching or trimming
     void awakeServerThread() { mp_sync->restart_timer(); }
 

--- a/src/cpp/rtps/builtin/discovery/endpoint/EDPSimple.cpp
+++ b/src/cpp/rtps/builtin/discovery/endpoint/EDPSimple.cpp
@@ -152,6 +152,45 @@ bool EDPSimple::initEDP(
     return true;
 }
 
+//! Process the info recorded in the persistence database
+void EDPSimple::processPersistentData(t_p_StatefulReader & reader, t_p_StatefulWriter & writer)
+{
+    std::lock_guard<RecursiveTimedMutex> guardR(reader.first->getMutex());
+    std::lock_guard<RecursiveTimedMutex> guardW(writer.first->getMutex());
+
+    std::for_each(writer.second->changesBegin(),
+        writer.second->changesEnd(),
+        [&reader](CacheChange_t* change)
+    {
+        CacheChange_t* change_to_add = nullptr;
+
+        if (!reader.first->reserveCache(&change_to_add, change->serializedPayload.length)) //Reserve a new cache from the corresponding cache pool
+        {
+            logError(RTPS_EDP, "Problem reserving CacheChange in EDPServer reader");
+            return;
+        }
+
+        if (!change_to_add->copy(change))
+        {
+            logWarning(RTPS_EDP,"Problem copying CacheChange, received data is: " 
+                << change->serializedPayload.length << " bytes and max size in EDPServer reader"
+                << " is " << change_to_add->serializedPayload.max_size);
+
+            reader.first->releaseCache(change_to_add);
+            return ;
+        }
+
+        if (!reader.first->change_received(change_to_add, nullptr))
+        {
+            logInfo(RTPS_EDP, "EDPServer couldn't process database data not add change "
+                << change_to_add->sequenceNumber);
+            reader.first->releaseCache(change_to_add);
+        }
+
+        // change_to_add would be released within change_received
+    });
+}
+
 void EDPSimple::set_builtin_reader_history_attributes(
         HistoryAttributes& attributes)
 {

--- a/src/cpp/rtps/builtin/discovery/endpoint/EDPSimpleListeners.cpp
+++ b/src/cpp/rtps/builtin/discovery/endpoint/EDPSimpleListeners.cpp
@@ -152,7 +152,7 @@ bool EDPListener::ongoingDeserialization(
     EDP* edp)
 {
     EDPServer * pServer = dynamic_cast<EDPServer*>(edp);
-    
+
     if(pServer)
     {
         return pServer->ongoingDeserialization();

--- a/src/cpp/rtps/builtin/discovery/endpoint/EDPSimpleListeners.h
+++ b/src/cpp/rtps/builtin/discovery/endpoint/EDPSimpleListeners.h
@@ -51,6 +51,11 @@ public:
      */
     bool computeKey(
             CacheChange_t* change);
+
+protected:
+
+    //! returns true if loading info from persistency database
+    static bool ongoingDeserialization(EDP* edp);
 };
 
 /**

--- a/src/cpp/rtps/builtin/discovery/participant/PDPServerListener.cpp
+++ b/src/cpp/rtps/builtin/discovery/participant/PDPServerListener.cpp
@@ -80,7 +80,8 @@ void PDPServerListener::onNewCacheChangeAdded(
     if(change->kind == ALIVE)
     {
         // Ignore announcement from own RTPSParticipant
-        if (guid == parent_pdp_->getRTPSParticipant()->getGuid())
+        if (guid == parent_pdp_->getRTPSParticipant()->getGuid()
+            && !parent_server_pdp_->ongoingDeserialization() )
         {
             logInfo(RTPS_PDP, "Message from own RTPSParticipant, removing");
             parent_pdp_->mp_PDPReaderHistory->remove_change(change);

--- a/src/cpp/rtps/builtin/discovery/participant/timedevent/DServerEvent.cpp
+++ b/src/cpp/rtps/builtin/discovery/participant/timedevent/DServerEvent.cpp
@@ -60,6 +60,12 @@ bool DServerEvent::event()
     // messges_enabled is only modified from this thread
     if (!messages_enabled_)
     {
+        if(mp_PDP->_durability == TRANSIENT)
+        {
+            // backup servers must process its own data before before receiving any callbacks
+            mp_PDP->processPersistentData();
+        }
+
         messages_enabled_ = true;
         mp_PDP->getRTPSParticipant()->enableReader(mp_PDP->mp_PDPReader);
     }

--- a/src/cpp/rtps/participant/RTPSParticipantImpl.cpp
+++ b/src/cpp/rtps/participant/RTPSParticipantImpl.cpp
@@ -125,9 +125,10 @@ RTPSParticipantImpl::RTPSParticipantImpl(
     // Workaround TCP discovery issues when register
     switch (PParam.builtin.discovery_config.discoveryProtocol)
     {
+        case DiscoveryProtocol::BACKUP:
+            m_persistence_guid = m_guid;
         case DiscoveryProtocol::CLIENT:
         case DiscoveryProtocol::SERVER:
-        case DiscoveryProtocol::BACKUP:
         // Verify if listening ports are provided
         for (auto& transportDescriptor : PParam.userTransports)
         {

--- a/src/cpp/rtps/participant/RTPSParticipantImpl.cpp
+++ b/src/cpp/rtps/participant/RTPSParticipantImpl.cpp
@@ -475,7 +475,8 @@ bool RTPSParticipantImpl::createWriter(
         return false;
     }
 
-    // Update persistence guidPrefix
+    // Update persistence guidPrefix, restore this change later to keep param unblemished
+    GUID_t former_persistence_guid = param.endpoint.persistence_guid;
     if (param.endpoint.persistence_guid == c_Guid_Unknown && m_persistence_guid != c_Guid_Unknown)
     {
         param.endpoint.persistence_guid = GUID_t(
@@ -511,6 +512,9 @@ bool RTPSParticipantImpl::createWriter(
                 new StatefulWriter(this, guid, param, hist, listen) :
                 new StatefulPersistentWriter(this, guid, param, hist, listen, persistence);
     }
+
+    // restore attributes
+    param.endpoint.persistence_guid = former_persistence_guid;
 
     if (SWriter == nullptr)
     {

--- a/src/cpp/rtps/participant/RTPSParticipantImpl.cpp
+++ b/src/cpp/rtps/participant/RTPSParticipantImpl.cpp
@@ -129,7 +129,7 @@ RTPSParticipantImpl::RTPSParticipantImpl(
             m_persistence_guid = m_guid;
             // keep setting up transport
             #pragma warning(suppress:5030)
-            [[gnu::fallthrough]];
+            [[clang::fallthrough]];
         case DiscoveryProtocol::CLIENT:
         case DiscoveryProtocol::SERVER:
         // Verify if listening ports are provided

--- a/src/cpp/rtps/participant/RTPSParticipantImpl.cpp
+++ b/src/cpp/rtps/participant/RTPSParticipantImpl.cpp
@@ -127,6 +127,9 @@ RTPSParticipantImpl::RTPSParticipantImpl(
     {
         case DiscoveryProtocol::BACKUP:
             m_persistence_guid = m_guid;
+            // keep setting up transport
+            #pragma warning(suppress:5030)
+            [[gnu::fallthrough]];
         case DiscoveryProtocol::CLIENT:
         case DiscoveryProtocol::SERVER:
         // Verify if listening ports are provided

--- a/src/cpp/rtps/participant/RTPSParticipantImpl.cpp
+++ b/src/cpp/rtps/participant/RTPSParticipantImpl.cpp
@@ -122,14 +122,16 @@ RTPSParticipantImpl::RTPSParticipantImpl(
         m_network_Factory.RegisterTransport(&descriptor);
     }
 
-    // Workaround TCP discovery issues when register
+    // BACKUP servers guid is its persistence one
+    if (PParam.builtin.discovery_config.discoveryProtocol == DiscoveryProtocol::BACKUP)
+    {
+        m_persistence_guid = m_guid;
+    }
+
+    // Client-server discovery protocol requires that every TCP transport has a listening port
     switch (PParam.builtin.discovery_config.discoveryProtocol)
     {
         case DiscoveryProtocol::BACKUP:
-            m_persistence_guid = m_guid;
-            // keep setting up transport
-            #pragma warning(suppress:5030)
-            [[clang::fallthrough]];
         case DiscoveryProtocol::CLIENT:
         case DiscoveryProtocol::SERVER:
         // Verify if listening ports are provided
@@ -146,6 +148,7 @@ RTPSParticipantImpl::RTPSParticipantImpl(
     default:
         break;
     }
+
 
     // User defined transports
     for (const auto& transportDescriptor : PParam.userTransports)


### PR DESCRIPTION
Repairing client-server BACKUP operation

Former pull-request #662 introduce changes that prevent the proper operation of the BACKUP setup.

For ordinary SERVER participants an strategy was needed to handle *communication lost* vs *participant crash*. That is
because crashes require the clients to ignore any former assumption on the server participant state and start anew. This
was solved by adding a specific `GUID_t` to the SERVER participant (a per-instance one) that allow the clients to identify the
SERVER as a new instance (there was a crash).

For BACKUP server the above strategy is not required because they recover all its internal state from the backup file.
Clients can resume communication exactly in the same fashion as for a communication lost scenario. 