### PR TITLE
Account for multiple expired changes on lifespan_expired. [8059]

### DIFF
--- a/src/cpp/fastrtps_deprecated/publisher/PublisherImpl.cpp
+++ b/src/cpp/fastrtps_deprecated/publisher/PublisherImpl.cpp
@@ -471,40 +471,41 @@ bool PublisherImpl::lifespan_expired()
     std::unique_lock<RecursiveTimedMutex> lock(mp_writer->getMutex());
 
     CacheChange_t* earliest_change;
-    if (!m_history.get_earliest_change(&earliest_change))
+    while (m_history.get_earliest_change(&earliest_change))
     {
-        return false;
-    }
+        auto source_timestamp = system_clock::time_point() + nanoseconds(earliest_change->sourceTimestamp.to_ns());
+        auto now = system_clock::now();
 
-    auto source_timestamp = system_clock::time_point() + nanoseconds(earliest_change->sourceTimestamp.to_ns());
-    auto now = system_clock::now();
+        // Check that the earliest change has expired (the change which started the timer could have been removed from the history)
+        if (now - source_timestamp < lifespan_duration_us_)
+        {
+            auto interval = source_timestamp - now + lifespan_duration_us_;
+            lifespan_timer_->update_interval_millisec((double)duration_cast<milliseconds>(interval).count());
+            return true;
+        }
 
-    // Check that the earliest change has expired (the change which started the timer could have been removed from the history)
-    if (now - source_timestamp < lifespan_duration_us_)
-    {
+        // The earliest change has expired
+        m_history.remove_change_pub(earliest_change);
+
+        // Set the timer for the next change if there is one
+        if (!m_history.get_earliest_change(&earliest_change))
+        {
+            return false;
+        }
+
+        // Calculate when the next change is due to expire and restart
+        source_timestamp = system_clock::time_point() + nanoseconds(earliest_change->sourceTimestamp.to_ns());
+        now = system_clock::now();
         auto interval = source_timestamp - now + lifespan_duration_us_;
-        lifespan_timer_->update_interval_millisec((double)duration_cast<milliseconds>(interval).count());
-        return true;
+
+        if (interval.count() > 0)
+        {
+            lifespan_timer_->update_interval_millisec((double)duration_cast<milliseconds>(interval).count());
+            return true;
+        }
     }
 
-    // The earliest change has expired
-    m_history.remove_change_pub(earliest_change);
-
-    // Set the timer for the next change if there is one
-    if (!m_history.get_earliest_change(&earliest_change))
-    {
-        return false;
-    }
-
-    // Calculate when the next change is due to expire and restart
-    source_timestamp = system_clock::time_point() + nanoseconds(earliest_change->sourceTimestamp.to_ns());
-    now = system_clock::now();
-    auto interval = source_timestamp - now + lifespan_duration_us_;
-
-    assert(interval.count() > 0);
-
-    lifespan_timer_->update_interval_millisec((double)duration_cast<milliseconds>(interval).count());
-    return true;
+    return false;
 }
 
 void PublisherImpl::get_liveliness_lost_status(

--- a/src/cpp/fastrtps_deprecated/subscriber/SubscriberImpl.cpp
+++ b/src/cpp/fastrtps_deprecated/subscriber/SubscriberImpl.cpp
@@ -401,40 +401,41 @@ bool SubscriberImpl::lifespan_expired()
     std::unique_lock<RecursiveTimedMutex> lock(mp_reader->getMutex());
 
     CacheChange_t* earliest_change;
-    if (!m_history.get_earliest_change(&earliest_change))
+    while (m_history.get_earliest_change(&earliest_change))
     {
-        return false;
-    }
+        auto source_timestamp = system_clock::time_point() + nanoseconds(earliest_change->sourceTimestamp.to_ns());
+        auto now = system_clock::now();
 
-    auto source_timestamp = system_clock::time_point() + nanoseconds(earliest_change->sourceTimestamp.to_ns());
-    auto now = system_clock::now();
+        // Check that the earliest change has expired (the change which started the timer could have been removed from the history)
+        if (now - source_timestamp < lifespan_duration_us_)
+        {
+            auto interval = source_timestamp - now + lifespan_duration_us_;
+            lifespan_timer_->update_interval_millisec((double)duration_cast<milliseconds>(interval).count());
+            return true;
+        }
 
-    // Check that the earliest change has expired (the change which started the timer could have been removed from the history)
-    if (now - source_timestamp < lifespan_duration_us_)
-    {
+        // The earliest change has expired
+        m_history.remove_change_sub(earliest_change);
+
+        // Set the timer for the next change if there is one
+        if (!m_history.get_earliest_change(&earliest_change))
+        {
+            return false;
+        }
+
+        // Calculate when the next change is due to expire and restart
+        source_timestamp = system_clock::time_point() + nanoseconds(earliest_change->sourceTimestamp.to_ns());
+        now = system_clock::now();
         auto interval = source_timestamp - now + lifespan_duration_us_;
-        lifespan_timer_->update_interval_millisec((double)duration_cast<milliseconds>(interval).count());
-        return true;
+
+        if (interval.count() > 0)
+        {
+            lifespan_timer_->update_interval_millisec((double)duration_cast<milliseconds>(interval).count());
+            return true;
+        }
     }
 
-    // The earliest change has expired
-    m_history.remove_change_sub(earliest_change);
-
-    // Set the timer for the next change if there is one
-    if (!m_history.get_earliest_change(&earliest_change))
-    {
-        return false;
-    }
-
-    // Calculate when the next change is due to expire and restart
-    source_timestamp = system_clock::time_point() + nanoseconds(earliest_change->sourceTimestamp.to_ns());
-    now = system_clock::now();
-    auto interval = source_timestamp - now + lifespan_duration_us_;
-
-    assert(interval.count() > 0);
-
-    lifespan_timer_->update_interval_millisec((double)duration_cast<milliseconds>(interval).count());
-    return true;
+    return false;
 }
 
 void SubscriberImpl::get_liveliness_changed_status(LivelinessChangedStatus &status)


### PR DESCRIPTION
It may be the case that lifetime has expired for several samples when the timer expires. This has been seen on some nightlies and on issue #1049 

This PR changes the behavior of the `lifespan_expired` method on the publisher and subscriber, so that several changes are processed until either a non-expired one is found or the history is empty.