### PR TITLE
Server-Client trimming form discovery info update [8056]

### DIFF
--- a/include/fastdds/rtps/builtin/discovery/endpoint/EDPServer.h
+++ b/include/fastdds/rtps/builtin/discovery/endpoint/EDPServer.h
@@ -129,6 +129,12 @@ public:
                 *subscriptions_writer_.first, *subscriptions_writer_.second, &ParticipantProxyData::m_readers);
     }
 
+    //! returns true if loading info from persistency database
+    bool ongoingDeserialization();
+
+    //! Process the info recorded in the persistence database
+    void processPersistentData();
+
     protected:
 
     /**

--- a/include/fastdds/rtps/builtin/discovery/endpoint/EDPSimple.h
+++ b/include/fastdds/rtps/builtin/discovery/endpoint/EDPSimple.h
@@ -214,6 +214,9 @@ protected:
             bool remove_same_instance,
             CacheChange_t** created_change);
 
+    //! Process the info recorded in the persistence database
+    static void processPersistentData(t_p_StatefulReader & reader, t_p_StatefulWriter & writer);
+
 private:
     /**
      * Create a cache change on a builtin writer and serialize a ProxyData on it.

--- a/include/fastdds/rtps/builtin/discovery/participant/PDPServer.h
+++ b/include/fastdds/rtps/builtin/discovery/participant/PDPServer.h
@@ -228,6 +228,12 @@ public:
     std::string GetPersistenceFileName();
 #endif
 
+    //! returns true if loading info from persistency database
+    bool ongoingDeserialization();
+
+    //! Process the info recorded in the persistence database
+    void processPersistentData();
+
     //! Wakes up the DServerEvent for new matching or trimming
     void awakeServerThread() { mp_sync->restart_timer(); }
 

--- a/src/cpp/rtps/RTPSDomain.cpp
+++ b/src/cpp/rtps/RTPSDomain.cpp
@@ -137,6 +137,7 @@ RTPSParticipant* RTPSDomain::createParticipant(
     {
         // Make a new participant GuidPrefix_t up
         int pid = System::GetPID();
+        pid += static_cast<unsigned int>(time(NULL));
 
         guidP.value[0] = c_VendorId_eProsima[0];
         guidP.value[1] = c_VendorId_eProsima[1];

--- a/src/cpp/rtps/RTPSDomain.cpp
+++ b/src/cpp/rtps/RTPSDomain.cpp
@@ -137,7 +137,6 @@ RTPSParticipant* RTPSDomain::createParticipant(
     {
         // Make a new participant GuidPrefix_t up
         int pid = System::GetPID();
-        pid += static_cast<unsigned int>(time(NULL));
 
         guidP.value[0] = c_VendorId_eProsima[0];
         guidP.value[1] = c_VendorId_eProsima[1];

--- a/src/cpp/rtps/builtin/discovery/endpoint/EDPServer.cpp
+++ b/src/cpp/rtps/builtin/discovery/endpoint/EDPServer.cpp
@@ -294,9 +294,11 @@ bool EDPServer::addEndpointFromHistory(
 void EDPServer::removePublisherFromHistory(
         const InstanceHandle_t& key)
 {
-    std::lock_guard<std::recursive_mutex> guardP(*mp_PDP->getMutex());
+    {
+        std::lock_guard<std::recursive_mutex> guardP(*mp_PDP->getMutex());
+        _PUBdemises.insert(key);
+    }
 
-    _PUBdemises.insert(key);
     if ( !trimPUBWriterHistory() )
     {
         PDPServer* pS = dynamic_cast<PDPServer*>(mp_PDP);
@@ -308,9 +310,10 @@ void EDPServer::removePublisherFromHistory(
 void EDPServer::removeSubscriberFromHistory(
         const InstanceHandle_t& key)
 {
-    std::lock_guard<std::recursive_mutex> guardP(*mp_PDP->getMutex());
-
-    _SUBdemises.insert(key);
+    {
+        std::lock_guard<std::recursive_mutex> guardP(*mp_PDP->getMutex());
+        _SUBdemises.insert(key);
+    }
 
     if (!trimSUBWriterHistory())
     {

--- a/src/cpp/rtps/builtin/discovery/endpoint/EDPServer.cpp
+++ b/src/cpp/rtps/builtin/discovery/endpoint/EDPServer.cpp
@@ -148,6 +148,8 @@ bool EDPServer::trimWriterHistory(
         WriterHistory& history,
         ProxyCont ParticipantProxyData::* pC)
 {
+    logInfo(RTPS_PDPSERVER_TRIM,"In trimWriteHistory EDP history count: " << history.getHistorySize());
+
     // trim demises container
     key_list disposal, aux;
 
@@ -155,8 +157,6 @@ bool EDPServer::trimWriterHistory(
     {
         return true;
     }
-
-    std::lock_guard<std::recursive_mutex> guardP(*mp_PDP->getMutex());
 
     // sweep away any resurrected endpoint
     for (auto iD = mp_PDP->ParticipantProxiesBegin(); iD != mp_PDP->ParticipantProxiesEnd(); ++iD)
@@ -187,6 +187,9 @@ bool EDPServer::trimWriterHistory(
             return _demises.find(chan->instanceHandle) != _demises.cend();
         });
 
+    logInfo(RTPS_PDPSERVER_TRIM,"I've classified the following EDP history data for removal "
+        << std::distance(removal.begin(), removal.end()) );
+
     if (removal.empty())
     {
         return true;
@@ -200,16 +203,26 @@ bool EDPServer::trimWriterHistory(
     {
         if (writer.is_acked_by_all(pCh))
         {
+            logInfo(RTPS_PDPSERVER_TRIM, "EDPServer is removing DATA("
+                << (pCh->kind == ALIVE ? "w|r" : "w|r[UD]" ) << ") of participant "
+                << pCh->instanceHandle << " from history");
+
             history.remove_change(pCh);
         }
         else
         {
+            logInfo(RTPS_PDPSERVER_TRIM, "EDPServer is procrastinating DATA("
+                << (pCh->kind == ALIVE ? "w|r" : "w|r[UD]" ) << ") of participant "
+                << pCh->instanceHandle << " from history");
+
             pending.insert(pCh->instanceHandle);
         }
     }
 
     // update demises
     _demises.swap(pending);
+
+    logInfo(RTPS_PDPSERVER_TRIM,"After trying to trim EDP we still must remove " << _demises.size() );
 
     return _demises.empty(); // is finished?
 
@@ -313,17 +326,17 @@ bool EDPServer::removeLocalReader(
     logInfo(RTPS_EDP, R->getGuid().entityId);
 
     auto* writer = &subscriptions_writer_;
+    GUID_t guid = R->getGuid();
+    bool ret = mp_PDP->removeReaderProxyData(guid);
 
     if (writer->first != nullptr)
     {
-        InstanceHandle_t iH;
-        iH = (R->getGuid());
         CacheChange_t* change = writer->first->new_change(
             [this]() -> uint32_t
             {
                 return mp_PDP->builtin_attributes().writerPayloadSize;
             },
-            NOT_ALIVE_DISPOSED_UNREGISTERED, iH);
+            NOT_ALIVE_DISPOSED_UNREGISTERED, guid);
         if (change != nullptr)
         {
             // unlike on EDPSimple we would remove old WriterHistory related entities when all
@@ -341,7 +354,7 @@ bool EDPServer::removeLocalReader(
             removeSubscriberFromHistory(change->instanceHandle);
         }
     }
-    return mp_PDP->removeReaderProxyData(R->getGuid());
+    return ret;
 }
 
 bool EDPServer::removeLocalWriter(
@@ -350,17 +363,17 @@ bool EDPServer::removeLocalWriter(
     logInfo(RTPS_EDP, W->getGuid().entityId);
 
     auto* writer = &publications_writer_;
+    GUID_t guid = W->getGuid();
+    bool ret = mp_PDP->removeWriterProxyData(guid);
 
     if (writer->first != nullptr)
     {
-        InstanceHandle_t iH;
-        iH = W->getGuid();
         CacheChange_t* change = writer->first->new_change(
             [this]() -> uint32_t
             {
                 return mp_PDP->builtin_attributes().writerPayloadSize;
             },
-            NOT_ALIVE_DISPOSED_UNREGISTERED, iH);
+            NOT_ALIVE_DISPOSED_UNREGISTERED, guid);
         if (change != nullptr)
         {
             // unlike on EDPSimple we would remove old WriterHistory related
@@ -378,7 +391,7 @@ bool EDPServer::removeLocalWriter(
             removePublisherFromHistory(change->instanceHandle);
         }
     }
-    return mp_PDP->removeWriterProxyData(W->getGuid());
+    return ret;
 }
 
 bool EDPServer::processLocalWriterProxyData(

--- a/src/cpp/rtps/builtin/discovery/endpoint/EDPSimple.cpp
+++ b/src/cpp/rtps/builtin/discovery/endpoint/EDPSimple.cpp
@@ -152,6 +152,45 @@ bool EDPSimple::initEDP(
     return true;
 }
 
+//! Process the info recorded in the persistence database
+void EDPSimple::processPersistentData(t_p_StatefulReader & reader, t_p_StatefulWriter & writer)
+{
+    std::lock_guard<RecursiveTimedMutex> guardR(reader.first->getMutex());
+    std::lock_guard<RecursiveTimedMutex> guardW(writer.first->getMutex());
+
+    std::for_each(writer.second->changesBegin(),
+        writer.second->changesEnd(),
+        [&reader](CacheChange_t* change)
+    {
+        CacheChange_t* change_to_add = nullptr;
+
+        if (!reader.first->reserveCache(&change_to_add, change->serializedPayload.length)) //Reserve a new cache from the corresponding cache pool
+        {
+            logError(RTPS_EDP, "Problem reserving CacheChange in EDPServer reader");
+            return;
+        }
+
+        if (!change_to_add->copy(change))
+        {
+            logWarning(RTPS_EDP,"Problem copying CacheChange, received data is: " 
+                << change->serializedPayload.length << " bytes and max size in EDPServer reader"
+                << " is " << change_to_add->serializedPayload.max_size);
+
+            reader.first->releaseCache(change_to_add);
+            return ;
+        }
+
+        if (!reader.first->change_received(change_to_add, nullptr))
+        {
+            logInfo(RTPS_EDP, "EDPServer couldn't process database data not add change "
+                << change_to_add->sequenceNumber);
+            reader.first->releaseCache(change_to_add);
+        }
+
+        // change_to_add would be released within change_received
+    });
+}
+
 void EDPSimple::set_builtin_reader_history_attributes(
         HistoryAttributes& attributes)
 {

--- a/src/cpp/rtps/builtin/discovery/endpoint/EDPSimpleListeners.cpp
+++ b/src/cpp/rtps/builtin/discovery/endpoint/EDPSimpleListeners.cpp
@@ -152,7 +152,7 @@ bool EDPListener::ongoingDeserialization(
     EDP* edp)
 {
     EDPServer * pServer = dynamic_cast<EDPServer*>(edp);
-    
+
     if(pServer)
     {
         return pServer->ongoingDeserialization();

--- a/src/cpp/rtps/builtin/discovery/endpoint/EDPSimpleListeners.h
+++ b/src/cpp/rtps/builtin/discovery/endpoint/EDPSimpleListeners.h
@@ -51,6 +51,11 @@ public:
      */
     bool computeKey(
             CacheChange_t* change);
+
+protected:
+
+    //! returns true if loading info from persistency database
+    static bool ongoingDeserialization(EDP* edp);
 };
 
 /**

--- a/src/cpp/rtps/builtin/discovery/participant/PDPServer.cpp
+++ b/src/cpp/rtps/builtin/discovery/participant/PDPServer.cpp
@@ -485,7 +485,6 @@ void PDPServer::match_all_clients_EDP_endpoints()
 bool PDPServer::trimWriterHistory()
 {
     assert(mp_mutex && mp_PDPWriter);
-    std::lock_guard<std::recursive_mutex> guardP(*getMutex());
 
     logInfo(RTPS_PDPSERVER_TRIM, "Trying to trim the history. HistorySize:" << mp_PDPWriterHistory->getHistorySize()
         << " Demises:" << _demises.size());
@@ -639,11 +638,14 @@ bool PDPServer::addRelayedChangeToHistory(
 void PDPServer::removeParticipantFromHistory(
         const InstanceHandle_t& key)
 {
-    std::lock_guard<std::recursive_mutex> guardP(*mp_mutex);
+    {
+        std::lock_guard<std::recursive_mutex> guardP(*mp_mutex);
 
-    logInfo(RTPS_PDP,"PDPServer marks participant " << key << " for disposal");
+        logInfo(RTPS_PDP,"PDPServer marks participant " << key << " for disposal");
 
-    _demises.insert(key);
+        _demises.insert(key);
+    }
+
     trimWriterHistory();
 }
 
@@ -1051,8 +1053,6 @@ bool PDPServer::remove_remote_participant(
     // only DATA acknowledge by all clients would be actually removed
     if(res)
     {
-        std::lock_guard<std::recursive_mutex> lock(*getMutex());
-
         InstanceHandle_t ih;
 
         removeParticipantFromHistory(ih = partGUID);

--- a/src/cpp/rtps/builtin/discovery/participant/PDPServerListener.cpp
+++ b/src/cpp/rtps/builtin/discovery/participant/PDPServerListener.cpp
@@ -69,6 +69,8 @@ void PDPServerListener::onNewCacheChangeAdded(
     // update the PDP Writer with this reader info
     if (!parent_server_pdp_->addRelayedChangeToHistory(*change))
     {
+        logInfo(RTPS_PDP, "Ignoring a DATA(p) that was already received");
+
         parent_pdp_->mp_PDPReaderHistory->remove_change(change);
         return; // already there
     }
@@ -117,6 +119,8 @@ void PDPServerListener::onNewCacheChangeAdded(
 
             if(pdata == nullptr)
             {
+                logInfo(RTPS_PDP, "Registering a new participant: " << writer_guid);
+
                 // Create a new one when not found
                 pdata = parent_pdp_->createParticipantProxyData(local_data, writer_guid);
                 if (pdata != nullptr)

--- a/src/cpp/rtps/builtin/discovery/participant/PDPServerListener.cpp
+++ b/src/cpp/rtps/builtin/discovery/participant/PDPServerListener.cpp
@@ -80,7 +80,8 @@ void PDPServerListener::onNewCacheChangeAdded(
     if(change->kind == ALIVE)
     {
         // Ignore announcement from own RTPSParticipant
-        if (guid == parent_pdp_->getRTPSParticipant()->getGuid())
+        if (guid == parent_pdp_->getRTPSParticipant()->getGuid()
+            && !parent_server_pdp_->ongoingDeserialization() )
         {
             logInfo(RTPS_PDP, "Message from own RTPSParticipant, removing");
             parent_pdp_->mp_PDPReaderHistory->remove_change(change);

--- a/src/cpp/rtps/builtin/discovery/participant/timedevent/DServerEvent.cpp
+++ b/src/cpp/rtps/builtin/discovery/participant/timedevent/DServerEvent.cpp
@@ -60,6 +60,12 @@ bool DServerEvent::event()
     // messges_enabled is only modified from this thread
     if (!messages_enabled_)
     {
+        if(mp_PDP->_durability == TRANSIENT)
+        {
+            // backup servers must process its own data before before receiving any callbacks
+            mp_PDP->processPersistentData();
+        }
+
         messages_enabled_ = true;
         mp_PDP->getRTPSParticipant()->enableReader(mp_PDP->mp_PDPReader);
     }

--- a/src/cpp/rtps/participant/RTPSParticipantImpl.cpp
+++ b/src/cpp/rtps/participant/RTPSParticipantImpl.cpp
@@ -125,9 +125,10 @@ RTPSParticipantImpl::RTPSParticipantImpl(
     // Workaround TCP discovery issues when register
     switch (PParam.builtin.discovery_config.discoveryProtocol)
     {
+        case DiscoveryProtocol::BACKUP:
+            m_persistence_guid = m_guid;
         case DiscoveryProtocol::CLIENT:
         case DiscoveryProtocol::SERVER:
-        case DiscoveryProtocol::BACKUP:
         // Verify if listening ports are provided
         for (auto& transportDescriptor : PParam.userTransports)
         {

--- a/src/cpp/rtps/participant/RTPSParticipantImpl.cpp
+++ b/src/cpp/rtps/participant/RTPSParticipantImpl.cpp
@@ -475,7 +475,8 @@ bool RTPSParticipantImpl::createWriter(
         return false;
     }
 
-    // Update persistence guidPrefix
+    // Update persistence guidPrefix, restore this change later to keep param unblemished
+    GUID_t former_persistence_guid = param.endpoint.persistence_guid;
     if (param.endpoint.persistence_guid == c_Guid_Unknown && m_persistence_guid != c_Guid_Unknown)
     {
         param.endpoint.persistence_guid = GUID_t(
@@ -511,6 +512,9 @@ bool RTPSParticipantImpl::createWriter(
                 new StatefulWriter(this, guid, param, hist, listen) :
                 new StatefulPersistentWriter(this, guid, param, hist, listen, persistence);
     }
+
+    // restore attributes
+    param.endpoint.persistence_guid = former_persistence_guid;
 
     if (SWriter == nullptr)
     {

--- a/src/cpp/rtps/participant/RTPSParticipantImpl.cpp
+++ b/src/cpp/rtps/participant/RTPSParticipantImpl.cpp
@@ -129,7 +129,7 @@ RTPSParticipantImpl::RTPSParticipantImpl(
             m_persistence_guid = m_guid;
             // keep setting up transport
             #pragma warning(suppress:5030)
-            [[gnu::fallthrough]];
+            [[clang::fallthrough]];
         case DiscoveryProtocol::CLIENT:
         case DiscoveryProtocol::SERVER:
         // Verify if listening ports are provided

--- a/src/cpp/rtps/participant/RTPSParticipantImpl.cpp
+++ b/src/cpp/rtps/participant/RTPSParticipantImpl.cpp
@@ -127,6 +127,9 @@ RTPSParticipantImpl::RTPSParticipantImpl(
     {
         case DiscoveryProtocol::BACKUP:
             m_persistence_guid = m_guid;
+            // keep setting up transport
+            #pragma warning(suppress:5030)
+            [[gnu::fallthrough]];
         case DiscoveryProtocol::CLIENT:
         case DiscoveryProtocol::SERVER:
         // Verify if listening ports are provided

--- a/src/cpp/rtps/participant/RTPSParticipantImpl.cpp
+++ b/src/cpp/rtps/participant/RTPSParticipantImpl.cpp
@@ -309,6 +309,15 @@ RTPSParticipantImpl::RTPSParticipantImpl(
     }
 #endif
 
+    if((PParam.builtin.discovery_config.discoveryProtocol == DiscoveryProtocol_t::SERVER
+        || PParam.builtin.discovery_config.discoveryProtocol == DiscoveryProtocol_t::BACKUP)
+        && !(PParam.builtin.metatrafficUnicastLocatorList == m_att.builtin.metatrafficUnicastLocatorList))
+    {
+        logError(RTPS_PARTICIPANT, "Cannot create server participant,"
+            " because the desired locators were not available.");
+        return;
+    }
+
     mp_builtinProtocols = new BuiltinProtocols();
 
     //Start reception


### PR DESCRIPTION
During #1091 pull request works some issues which the PDP and EDP WriterHistory trimming were noticed. This pull request must be merged after #1091.

When an endpoint destruction notification is received then all its associated changes in the history should be removed. This removal cannot be done at once, the server must wait till all the clients acknowledge the changes. Thus, there is a collection of changes marked for disposal.

The disposal must be aborted if the endpoint we want to remove appears again. In order to detect that eventuality before removing an endpoint changes we check this endpoint is not in the discovery database (not alive). There was a bug on this step that is now repaired.

During the testing of trim operation under heavy exchange of discovery data several ABBA locks were detected and solved.

It was also detected that if a server cannot open the ports assigned to its addresses no error was notified. This situation is odd but it actually happen so a notification was introduced.

