### PR TITLE
Do not compile SHM transport if thirdparty/boost test fail <master> [8064]

### DIFF
--- a/cmake/modules/FindThirdpartyBoost.cmake
+++ b/cmake/modules/FindThirdpartyBoost.cmake
@@ -27,9 +27,12 @@ try_compile(IS_THIRDPARTY_BOOST_OK
          OUTPUT_VARIABLE OUT
     )
 
+set(IS_THIRDPARTY_BOOST_SUPPORTED ${IS_THIRDPARTY_BOOST_OK})
+
 if(NOT IS_THIRDPARTY_BOOST_OK)
-    message(FATAL_ERROR "Couldn't compile thirdparty/boost with current configuration!!!\n" ${OUT})
+    message(STATUS ${OUT} "\nCouldn't compile thirdparty/boost. SHM Transport feature will be disabled!!!\n")
 else()
     message(STATUS "Thirdparty/boost compiled OK")
-    mark_as_advanced(THIRDPARTY_BOOST_INCLUDE_DIR)
 endif()
+
+mark_as_advanced(THIRDPARTY_BOOST_INCLUDE_DIR)

--- a/src/cpp/CMakeLists.txt
+++ b/src/cpp/CMakeLists.txt
@@ -117,12 +117,11 @@ set(${PROJECT_NAME}_source_files
     rtps/transport/UDPv4Transport.cpp
     rtps/transport/TCPTransportInterface.cpp
     rtps/transport/UDPTransportInterface.cpp
-    rtps/transport/shared_mem/SharedMemTransport.cpp
+    rtps/transport/shared_mem/SharedMemTransportDescriptor.cpp
     rtps/transport/TCPv4Transport.cpp
     rtps/transport/UDPv6Transport.cpp
     rtps/transport/TCPv6Transport.cpp
     rtps/transport/test_UDPv4Transport.cpp
-    rtps/transport/shared_mem/test_SharedMemTransport.cpp
     rtps/transport/tcp/TCPControlMessage.cpp
     rtps/transport/tcp/RTCPMessageManager.cpp
 
@@ -197,6 +196,14 @@ set(${PROJECT_NAME}_source_files
     rtps/persistence/PersistenceFactory.cpp
     fastrtps_deprecated/utils/TimedConditionVariable.cpp
     )
+
+# SHM Transport
+if(IS_THIRDPARTY_BOOST_OK)
+    list(APPEND ${PROJECT_NAME}_source_files
+        rtps/transport/shared_mem/test_SharedMemTransport.cpp
+        rtps/transport/shared_mem/SharedMemTransport.cpp
+        )
+endif()
 
 # TLS Support
 if(TLS_FOUND)
@@ -342,7 +349,8 @@ elseif(NOT EPROSIMA_INSTALLER)
         $<$<AND:$<BOOL:${WIN32}>,$<NOT:$<STREQUAL:"${CMAKE_SYSTEM_NAME}","WindowsStore">>>:_WIN32_WINNT=0x0601>
         $<$<AND:$<BOOL:${WIN32}>,$<STREQUAL:"${CMAKE_SYSTEM_NAME}","WindowsStore">>:SQLITE_OS_WINRT>
         $<$<AND:$<BOOL:${ANDROID}>,$<NOT:$<BOOL:${HAVE_CXX14}>>,$<NOT:$<BOOL:${HAVE_CXX1Y}>>>:ASIO_DISABLE_STD_STRING_VIEW>
-		$<$<BOOL:${WIN32}>:_ENABLE_ATOMIC_ALIGNMENT_FIX>
+        $<$<BOOL:${WIN32}>:_ENABLE_ATOMIC_ALIGNMENT_FIX>
+        $<$<NOT:$<BOOL:${IS_THIRDPARTY_BOOST_SUPPORTED}>>:FASTDDS_SHM_TRANSPORT_DISABLED> # Do not compile SHM Transport
         )
 
     # Define public headers

--- a/src/cpp/rtps/network/NetworkFactory.cpp
+++ b/src/cpp/rtps/network/NetworkFactory.cpp
@@ -86,21 +86,26 @@ bool NetworkFactory::RegisterTransport(const TransportDescriptorInterface* descr
     uint32_t minSendBufferSize = std::numeric_limits<uint32_t>::max();
 
     std::unique_ptr<TransportInterface> transport(descriptor->create_transport());
-    if(transport->init())
+
+    if(transport)
     {
-        minSendBufferSize = transport->get_configuration()->min_send_buffer_size();
-        mRegisteredTransports.emplace_back(std::move(transport));
-        wasRegistered = true;
+        if(transport->init())
+        {
+            minSendBufferSize = transport->get_configuration()->min_send_buffer_size();
+            mRegisteredTransports.emplace_back(std::move(transport));
+            wasRegistered = true;
+        }
+
+        if(wasRegistered)
+        {
+            if(descriptor->max_message_size() < maxMessageSizeBetweenTransports_)
+                maxMessageSizeBetweenTransports_ = descriptor->max_message_size();
+
+            if(minSendBufferSize < minSendBufferSize_)
+                minSendBufferSize_ = minSendBufferSize;
+        }
     }
 
-    if(wasRegistered)
-    {
-        if(descriptor->max_message_size() < maxMessageSizeBetweenTransports_)
-            maxMessageSizeBetweenTransports_ = descriptor->max_message_size();
-
-        if(minSendBufferSize < minSendBufferSize_)
-            minSendBufferSize_ = minSendBufferSize;
-    }
     return wasRegistered;
 }
 

--- a/src/cpp/rtps/participant/RTPSParticipantImpl.cpp
+++ b/src/cpp/rtps/participant/RTPSParticipantImpl.cpp
@@ -148,9 +148,27 @@ RTPSParticipantImpl::RTPSParticipantImpl(
     // User defined transports
     for (const auto& transportDescriptor : PParam.userTransports)
     {
-        m_network_Factory.RegisterTransport(transportDescriptor.get());
-
-        has_shm_transport_ |= (dynamic_cast<fastdds::rtps::SharedMemTransportDescriptor*>(transportDescriptor.get()) != nullptr);
+        if(m_network_Factory.RegisterTransport(transportDescriptor.get()))
+        {
+            has_shm_transport_ |= 
+                (dynamic_cast<fastdds::rtps::SharedMemTransportDescriptor*>(transportDescriptor.get()) != nullptr);
+        }
+        else
+        {
+            // SHM transport could be disabled
+            if((dynamic_cast<fastdds::rtps::SharedMemTransportDescriptor*>(transportDescriptor.get()) != nullptr))
+            {
+                logError(RTPS_PARTICIPANT,
+                    "Unable to Register SHM Transport. SHM Transport is not supported in"
+                    " the current platform.");
+            }
+            else
+            {
+                logError(RTPS_PARTICIPANT,
+                    "User transport failed to register.");
+            }
+            
+        }   
     }
 
     mp_userParticipant->mp_impl = this;

--- a/src/cpp/rtps/transport/shared_mem/SharedMemTransport.cpp
+++ b/src/cpp/rtps/transport/shared_mem/SharedMemTransport.cpp
@@ -47,35 +47,6 @@ using LocatorSelectorEntry = fastrtps::rtps::LocatorSelectorEntry;
 using LocatorSelector = fastrtps::rtps::LocatorSelector;
 using PortParameters = fastrtps::rtps::PortParameters;
 
-//*********************************************************
-// SharedMemTransportDescriptor
-//*********************************************************
-
-SharedMemTransportDescriptor::SharedMemTransportDescriptor()
-    : TransportDescriptorInterface(SharedMemTransport::default_segment_size, s_maximumInitialPeersRange)
-    , segment_size_(SharedMemTransport::default_segment_size)
-    , port_queue_capacity_(SharedMemTransport::default_port_queue_capacity)
-    , port_overflow_policy_(SharedMemTransport::default_overflow_policy)
-    , segment_overflow_policy_(SharedMemTransport::default_overflow_policy)
-    , healthy_check_timeout_ms_(SharedMemTransport::default_healthy_check_timeout_ms)
-    , rtps_dump_file_("")
-{
-    maxMessageSize = segment_size_;
-}
-
-SharedMemTransportDescriptor::SharedMemTransportDescriptor(
-        const SharedMemTransportDescriptor& t)
-    : TransportDescriptorInterface(t.segment_size_, s_maximumInitialPeersRange)
-    , segment_size_(t.segment_size_)
-    , port_queue_capacity_(t.port_queue_capacity_)
-    , port_overflow_policy_(t.port_overflow_policy_)
-    , segment_overflow_policy_(t.segment_overflow_policy_)
-    , healthy_check_timeout_ms_(t.healthy_check_timeout_ms_)
-    , rtps_dump_file_(t.rtps_dump_file_)
-{
-    maxMessageSize = t.segment_size_;
-}
-
 TransportInterface* SharedMemTransportDescriptor::create_transport() const
 {
     return new SharedMemTransport(*this);

--- a/src/cpp/rtps/transport/shared_mem/SharedMemTransport.h
+++ b/src/cpp/rtps/transport/shared_mem/SharedMemTransport.h
@@ -43,13 +43,6 @@ class SharedMemTransport : public TransportInterface
 {
 public:
 
-    static const uint32_t maximum_message_size = (std::numeric_limits<uint32_t>::max)();
-    static const uint32_t default_segment_size = 262144;
-    static const uint32_t default_port_queue_capacity = 512;
-    static const SharedMemTransportDescriptor::OverflowPolicy default_overflow_policy =
-            SharedMemTransportDescriptor::OverflowPolicy::DISCARD;
-    static const uint32_t default_healthy_check_timeout_ms = 1000;
-
     RTPS_DllAPI SharedMemTransport(
             const SharedMemTransportDescriptor&);
     void clean();

--- a/src/cpp/rtps/transport/shared_mem/SharedMemTransportDescriptor.cpp
+++ b/src/cpp/rtps/transport/shared_mem/SharedMemTransportDescriptor.cpp
@@ -1,0 +1,68 @@
+// Copyright 2020 Proyectos y Sistemas de Mantenimiento SL (eProsima).
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <fastdds/rtps/transport/TransportInterface.h>
+#include <fastdds/rtps/transport/shared_mem/SharedMemTransportDescriptor.h>
+
+using namespace eprosima::fastdds::rtps;
+
+namespace eprosima {
+namespace fastdds {
+namespace rtps {
+
+static constexpr uint32_t shm_maximum_message_size = (std::numeric_limits<uint32_t>::max)();
+static constexpr uint32_t shm_default_segment_size = 262144;
+static constexpr uint32_t shm_default_port_queue_capacity = 512;
+static constexpr SharedMemTransportDescriptor::OverflowPolicy shm_default_overflow_policy =
+        SharedMemTransportDescriptor::OverflowPolicy::DISCARD;
+static constexpr uint32_t shm_default_healthy_check_timeout_ms = 1000;
+
+} // rtps
+} // fastdds
+} // eprosima
+
+//*********************************************************
+// SharedMemTransportDescriptor
+//*********************************************************
+SharedMemTransportDescriptor::SharedMemTransportDescriptor()
+    : TransportDescriptorInterface(shm_default_segment_size, s_maximumInitialPeersRange)
+    , segment_size_(shm_default_segment_size)
+    , port_queue_capacity_(shm_default_port_queue_capacity)
+    , port_overflow_policy_(shm_default_overflow_policy)
+    , segment_overflow_policy_(shm_default_overflow_policy)
+    , healthy_check_timeout_ms_(shm_default_healthy_check_timeout_ms)
+    , rtps_dump_file_("")
+{
+    maxMessageSize = segment_size_;
+}
+
+SharedMemTransportDescriptor::SharedMemTransportDescriptor(
+        const SharedMemTransportDescriptor& t)
+    : TransportDescriptorInterface(t.segment_size_, s_maximumInitialPeersRange)
+    , segment_size_(t.segment_size_)
+    , port_queue_capacity_(t.port_queue_capacity_)
+    , port_overflow_policy_(t.port_overflow_policy_)
+    , segment_overflow_policy_(t.segment_overflow_policy_)
+    , healthy_check_timeout_ms_(t.healthy_check_timeout_ms_)
+    , rtps_dump_file_(t.rtps_dump_file_)
+{
+    maxMessageSize = t.segment_size_;
+}
+
+#ifdef FASTDDS_SHM_TRANSPORT_DISABLED
+TransportInterface* SharedMemTransportDescriptor::create_transport() const
+{
+    return nullptr;
+}
+#endif

--- a/src/cpp/rtps/transport/shared_mem/SharedMemTransportDescriptor.cpp
+++ b/src/cpp/rtps/transport/shared_mem/SharedMemTransportDescriptor.cpp
@@ -21,7 +21,6 @@ namespace eprosima {
 namespace fastdds {
 namespace rtps {
 
-static constexpr uint32_t shm_maximum_message_size = (std::numeric_limits<uint32_t>::max)();
 static constexpr uint32_t shm_default_segment_size = 262144;
 static constexpr uint32_t shm_default_port_queue_capacity = 512;
 static constexpr SharedMemTransportDescriptor::OverflowPolicy shm_default_overflow_policy =

--- a/test/blackbox/BlackboxTestsTransportSHM.cpp
+++ b/test/blackbox/BlackboxTestsTransportSHM.cpp
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#ifndef FASTDDS_SHM_TRANSPORT_DISABLED
+        
 #include "BlackboxTests.hpp"
 
 #include "PubSubReader.hpp"
@@ -345,5 +347,7 @@ TEST(SHM, SHM_UDPvsUDP)
     // Check that reader receives the unmatched.
     reader.wait_participant_undiscovery();
 }
+
+#endif // EPROSIMA_SHM_TRANSPORT_DISABLED
 
 

--- a/test/blackbox/CMakeLists.txt
+++ b/test/blackbox/CMakeLists.txt
@@ -199,7 +199,9 @@ if(NOT ((MSVC OR MSVC_IDE) AND EPROSIMA_INSTALLER) AND fastcdr_FOUND)
             ${CMAKE_CURRENT_BINARY_DIR}/PubSubReader.xml)
 
         add_executable(BlackboxTests ${BLACKBOXTESTS_SOURCE})
-        target_compile_definitions(BlackboxTests PRIVATE)
+        target_compile_definitions(BlackboxTests PRIVATE
+            $<$<NOT:$<BOOL:${IS_THIRDPARTY_BOOST_SUPPORTED}>>:FASTDDS_SHM_TRANSPORT_DISABLED> # Do not compile SHM Transport
+            )
         target_include_directories(BlackboxTests PRIVATE ${GTEST_INCLUDE_DIRS})
         target_link_libraries(BlackboxTests fastrtps fastcdr foonathan_memory ${GTEST_LIBRARIES})
         add_blackbox_gtest(BlackboxTests SOURCES ${BLACKBOXTESTS_TEST_SOURCE}

--- a/test/unittest/transport/CMakeLists.txt
+++ b/test/unittest/transport/CMakeLists.txt
@@ -182,6 +182,7 @@ if(NOT ((MSVC OR MSVC_IDE) AND EPROSIMA_INSTALLER))
             ${PROJECT_SOURCE_DIR}/src/cpp/fastdds/log/Log.cpp
             ${PROJECT_SOURCE_DIR}/src/cpp/fastdds/log/StdoutConsumer.cpp
             ${PROJECT_SOURCE_DIR}/src/cpp/rtps/transport/shared_mem/SharedMemTransport.cpp
+            ${PROJECT_SOURCE_DIR}/src/cpp/rtps/transport/shared_mem/SharedMemTransportDescriptor.cpp
             ${PROJECT_SOURCE_DIR}/src/cpp/rtps/transport/ChannelResource.cpp
             ${PROJECT_SOURCE_DIR}/src/cpp/fastrtps_deprecated/utils/IPFinder.cpp
             ${PROJECT_SOURCE_DIR}/src/cpp/fastrtps_deprecated/utils/IPLocator.cpp
@@ -285,27 +286,30 @@ if(NOT ((MSVC OR MSVC_IDE) AND EPROSIMA_INSTALLER))
         endif()
         add_gtest(TCPv4Tests SOURCES ${TCPV4TESTS_SOURCE})
 
-        add_executable(SharedMemTests ${SHAREDMEMTESTS_SOURCE})
-        
-        target_compile_definitions(SharedMemTests PRIVATE FASTRTPS_NO_LIB
-        $<$<BOOL:${WIN32}>:_ENABLE_ATOMIC_ALIGNMENT_FIX>)
 
-        target_include_directories(SharedMemTests PRIVATE
-            ${GTEST_INCLUDE_DIRS} ${GMOCK_INCLUDE_DIRS}
-            ${PROJECT_SOURCE_DIR}/test/mock/rtps/MessageReceiver
-            ${PROJECT_SOURCE_DIR}/test/mock/rtps/ReceiverResource
-            ${PROJECT_SOURCE_DIR}/include ${PROJECT_BINARY_DIR}/include
-            ${PROJECT_SOURCE_DIR}/src/cpp
-            ${THIRDPARTY_BOOST_INCLUDE_DIR}
-            )
-        target_link_libraries(SharedMemTests ${GTEST_LIBRARIES} ${MOCKS}
-                $<$<BOOL:${TLS_FOUND}>:OpenSSL::SSL$<SEMICOLON>OpenSSL::Crypto>
-                ${THIRDPARTY_BOOST_LINK_LIBS})
-        if(MSVC OR MSVC_IDE)
-            target_link_libraries(SharedMemTests ${PRIVACY} iphlpapi Shlwapi )
-        else()
-            target_link_libraries(SharedMemTests ${PRIVACY} )
+        if(IS_THIRDPARTY_BOOST_OK)
+            add_executable(SharedMemTests ${SHAREDMEMTESTS_SOURCE})
+            
+            target_compile_definitions(SharedMemTests PRIVATE FASTRTPS_NO_LIB
+            $<$<BOOL:${WIN32}>:_ENABLE_ATOMIC_ALIGNMENT_FIX>)
+
+            target_include_directories(SharedMemTests PRIVATE
+                ${GTEST_INCLUDE_DIRS} ${GMOCK_INCLUDE_DIRS}
+                ${PROJECT_SOURCE_DIR}/test/mock/rtps/MessageReceiver
+                ${PROJECT_SOURCE_DIR}/test/mock/rtps/ReceiverResource
+                ${PROJECT_SOURCE_DIR}/include ${PROJECT_BINARY_DIR}/include
+                ${PROJECT_SOURCE_DIR}/src/cpp
+                ${THIRDPARTY_BOOST_INCLUDE_DIR}
+                )
+            target_link_libraries(SharedMemTests ${GTEST_LIBRARIES} ${MOCKS}
+                    $<$<BOOL:${TLS_FOUND}>:OpenSSL::SSL$<SEMICOLON>OpenSSL::Crypto>
+                    ${THIRDPARTY_BOOST_LINK_LIBS})
+            if(MSVC OR MSVC_IDE)
+                target_link_libraries(SharedMemTests ${PRIVACY} iphlpapi Shlwapi )
+            else()
+                target_link_libraries(SharedMemTests ${PRIVACY} )
+            endif()
+            add_gtest(SharedMemTests SOURCES ${SHAREDMEMTESTS_SOURCE})
         endif()
-        add_gtest(SharedMemTests SOURCES ${SHAREDMEMTESTS_SOURCE})
     endif()
 endif()


### PR DESCRIPTION
A compilation test for thirdparty/boost is performed by cmake, if this test failed, FastRTPS compilation is aborted with an error. As boost may not be supported in all platforms, this PR changes the behaviour. Now, if thirdparty/boost fail the test, the parts of FastRTPS using boost (that is SHM Transport) are not compiled. When the user try to use SHM transport an error will be logged.