### PR TITLE
Removed unused field on info_IP [8070]

### DIFF
--- a/include/fastrtps/utils/IPFinder.h
+++ b/include/fastrtps/utils/IPFinder.h
@@ -54,7 +54,6 @@ class IPFinder
         typedef struct info_IP
         {
             IPTYPE type;
-            uint32_t scope_id;
             std::string name;
             std::string dev;
             Locator_t locator;

--- a/src/cpp/fastrtps_deprecated/utils/IPFinder.cpp
+++ b/src/cpp/fastrtps_deprecated/utils/IPFinder.cpp
@@ -108,11 +108,6 @@ bool IPFinder::getIPs(std::vector<info_IP>* vec_name, bool return_loopback)
                     {
                         parseIP6(info);
                     }
-                    if (info.type == IP6 || info.type == IP6_LOCAL)
-                    {
-                        sockaddr_in6* so = (sockaddr_in6*)ua->Address.lpSockaddr;
-                        info.scope_id = so->sin6_scope_id;
-                    }
 
                     if(return_loopback || (info.type != IP6_LOCAL && info.type != IP4_LOCAL))
                     {
@@ -182,9 +177,6 @@ bool IPFinder::getIPs(std::vector<info_IP>* vec_name, bool return_loopback)
             info.dev = std::string(ifa->ifa_name);
             if(parseIP6(info))
             {
-                const int offset = offsetof(sockaddr_in6, sin6_scope_id);
-                memcpy(&info.scope_id, ifa->ifa_addr + offset, sizeof(info.scope_id));
-
                 if (return_loopback || info.type != IP6_LOCAL)
                     vec_name->push_back(info);
             }


### PR DESCRIPTION
The `scope_id` field on `info_IP` structure was never being used. Removing it solves the valgrind issues that appeared after enabling IPv6 on the CI dockers.