### PR TITLE
DomainParticipant create_subscriber

### DIFF
--- a/examples/C++/DDS/DynamicHelloWorldExample/HelloWorldSubscriber.cpp
+++ b/examples/C++/DDS/DynamicHelloWorldExample/HelloWorldSubscriber.cpp
@@ -128,13 +128,13 @@ void HelloWorldSubscriber::SubListener::on_type_discovery(
 
     if (subscriber_->mp_subscriber == nullptr)
     {
-        eprosima::fastrtps::SubscriberAttributes Rparam;
-        Rparam = subscriber_->att_;
-        Rparam.topic = subscriber_->topic_;
-        Rparam.topic.topicName = topic;
-        Rparam.qos = subscriber_->qos_;
+        //eprosima::fastrtps::SubscriberAttributes Rparam;
+        //Rparam = subscriber_->att_;
+        //Rparam.topic = subscriber_->topic_;
+        //Rparam.topic.topicName = topic;
+        //Rparam.qos = subscriber_->qos_;
         subscriber_->mp_subscriber = subscriber_->mp_participant->create_subscriber(
-            SUBSCRIBER_QOS_DEFAULT, Rparam, nullptr);
+            SUBSCRIBER_QOS_DEFAULT, nullptr);
 
         if (subscriber_->mp_subscriber == nullptr)
         {

--- a/examples/C++/DDS/HelloWorldExample/HelloWorldSubscriber.cpp
+++ b/examples/C++/DDS/HelloWorldExample/HelloWorldSubscriber.cpp
@@ -48,8 +48,7 @@ bool HelloWorldSubscriber::init()
     type_.register_type(participant_, type_->getName());
 
     //CREATE THE SUBSCRIBER
-    eprosima::fastrtps::SubscriberAttributes sub_att;
-    subscriber_ = participant_->create_subscriber(SUBSCRIBER_QOS_DEFAULT, sub_att, nullptr);
+    subscriber_ = participant_->create_subscriber(SUBSCRIBER_QOS_DEFAULT, nullptr);
 
     if (subscriber_ == nullptr)
     {

--- a/examples/C++/DDS/TypeLookupService/TypeLookupSubscriber.cpp
+++ b/examples/C++/DDS/TypeLookupService/TypeLookupSubscriber.cpp
@@ -155,13 +155,13 @@ void TypeLookupSubscriber::SubListener::on_type_information_received(
 
                 if (subscriber_->mp_subscriber == nullptr)
                 {
-                    SubscriberAttributes Rparam;
-                    Rparam = subscriber_->att_;
-                    Rparam.topic = subscriber_->topic_;
-                    Rparam.topic.topicName = topic_name;
-                    Rparam.qos = subscriber_->qos_;
+                    //SubscriberAttributes Rparam;
+                    //Rparam = subscriber_->att_;
+                    //Rparam.topic = subscriber_->topic_;
+                    //Rparam.topic.topicName = topic_name;
+                    //Rparam.qos = subscriber_->qos_;
                     subscriber_->mp_subscriber = subscriber_->mp_participant->create_subscriber(
-                        SUBSCRIBER_QOS_DEFAULT, Rparam, nullptr);
+                        SUBSCRIBER_QOS_DEFAULT, nullptr);
 
                     if (subscriber_->mp_subscriber == nullptr)
                     {

--- a/include/dds/domain/DomainParticipant.hpp
+++ b/include/dds/domain/DomainParticipant.hpp
@@ -29,12 +29,9 @@
 #include <dds/core/Time.hpp>
 #include <dds/core/Entity.hpp>
 #include <dds/domain/qos/DomainParticipantQos.hpp>
-
 //#include <dds/topic/qos/TopicQos.hpp>
-
 #include <dds/pub/qos/PublisherQos.hpp>
-//#include <dds/sub/qos/SubscriberQos.hpp>
-
+#include <dds/sub/qos/SubscriberQos.hpp>
 #include <dds/domain/detail/DomainParticipant.hpp>
 
 namespace dds {
@@ -411,7 +408,7 @@ public:
      *                  The Data Distribution Service ran out of resources to
      *                  complete this operation.
      */
-    //    OMG_DDS_API dds::sub::qos::SubscriberQos default_subscriber_qos() const;
+    OMG_DDS_API dds::sub::qos::SubscriberQos default_subscriber_qos() const;
 
     /**
      * Sets the default SubscriberQos of the DomainParticipant.
@@ -438,8 +435,8 @@ public:
      *                  The Data Distribution Service ran out of resources to
      *                  complete this operation.
      */
-    //    OMG_DDS_API DomainParticipant& default_subscriber_qos(
-    //            const ::dds::sub::qos::SubscriberQos& qos);
+    OMG_DDS_API DomainParticipant& default_subscriber_qos(
+            const ::dds::sub::qos::SubscriberQos& qos);
 
     /**
      * Gets the default TopicQos of the DomainParticipant.

--- a/include/dds/sub/Subscriber.hpp
+++ b/include/dds/sub/Subscriber.hpp
@@ -68,8 +68,8 @@ public:
      *                  The Data Distribution Service ran out of resources to
      *                  complete this operation.
      */
-    OMG_DDS_API Subscriber(
-            const dds::domain::DomainParticipant& dp);
+//    OMG_DDS_API Subscriber(
+//            const dds::domain::DomainParticipant& dp);
 
     /**
      * Create a new Subscriber.

--- a/include/dds/sub/Subscriber.hpp
+++ b/include/dds/sub/Subscriber.hpp
@@ -1,0 +1,268 @@
+/*
+ * Copyright 2020, Proyectos y Sistemas de Mantenimiento SL (eProsima).
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef OMG_DDS_SUB_SUBSCRIBER_HPP_
+#define OMG_DDS_SUB_SUBSCRIBER_HPP_
+
+#include <dds/sub/detail/Subscriber.hpp>
+
+#include <dds/core/Entity.hpp>
+//#include <dds/sub/qos/DataReaderQos.hpp>
+#include <dds/sub/qos/SubscriberQos.hpp>
+#include <dds/domain/DomainParticipant.hpp>
+
+namespace dds {
+namespace sub {
+
+class SubscriberListener;
+
+/**
+ * @brief
+ * The Subscriber acts on the behalf of one or several DataReader objects
+ * that belong to it.
+ *
+ * @see @ref DCPS_Modules_Subscriber "Subscriber"
+ */
+class Subscriber : public dds::core::TEntity<detail::Subscriber>
+{
+public:
+
+    /**
+     * Local convenience typedef for dds::pub::SubscriberListener.
+     */
+    typedef SubscriberListener Listener;
+
+    OMG_DDS_REF_TYPE_PROTECTED_DC(
+        Subscriber,
+        dds::core::TEntity,
+        detail::Subscriber)
+
+    OMG_DDS_IMPLICIT_REF_BASE(
+        Subscriber)
+
+    /**
+     * Create a new Subscriber.
+     *
+     * The Subscriber will be created with the QoS values specified on the last
+     * successful call to @link dds::domain::DomainParticipant::default_subscriber_qos(const ::dds::pub::qos::SubscriberQos& qos)
+     * dp.default_subscriber_qos(qos) @endlink or, if the call was never made, the
+     * @ref anchor_dds_pub_subscriber_qos_defaults "default" values.
+     *
+     * @param dp the domain participant
+     * @throws dds::core::Error
+     *                  An internal error has occurred.
+     * @throws dds::core::OutOfResourcesError
+     *                  The Data Distribution Service ran out of resources to
+     *                  complete this operation.
+     */
+    OMG_DDS_API Subscriber(
+            const dds::domain::DomainParticipant& dp);
+
+    /**
+     * Create a new Subscriber.
+     *
+     * The Subscriber will be created with the given QosPolicy settings and if
+     * applicable, attaches the optionally specified SubscriberListener to it.
+     *
+     * See @ref DCPS_Modules_Infrastructure_Listener "listener" for more information
+     * about listeners and possible status propagation to other entities.
+     *
+     * @param dp the domain participant to create the Subscriber with.
+     * @param qos a collection of QosPolicy settings for the new Subscriber. In case
+     *            these settings are not self consistent, no Subscriber is created.
+     * @param listener the subscriber listener
+     * @param mask the mask of events notified to the listener
+     * @throws dds::core::Error
+     *                  An internal error has occurred.
+     * @throws dds::core::OutOfResourcesError
+     *                  The Data Distribution Service ran out of resources to
+     *                  complete this operation.
+     * @throws dds::core::InconsistentPolicyError
+     *                  The parameter qos contains conflicting QosPolicy settings.
+     */
+    OMG_DDS_API Subscriber(
+            const dds::domain::DomainParticipant& dp,
+            const qos::SubscriberQos& qos,
+            SubscriberListener* listener = NULL,
+            const dds::core::status::StatusMask& mask = dds::core::status::StatusMask::none());
+
+    /** @cond */
+    virtual OMG_DDS_API ~Subscriber();
+    /** @endcond */
+
+    //==========================================================================
+
+    /**
+     * Gets the SubscriberQos setting for this instance.
+     *
+     * @return the qos
+     * @throws dds::core::Error
+     *                  An internal error has occurred.
+     * @throws dds::core::NullReferenceError
+     *                  The entity was not properly created and references to dds::core::null.
+     * @throws dds::core::AlreadyClosedError
+     *                  The entity has already been closed.
+     * @throws dds::core::OutOfResourcesError
+     *                  The Data Distribution Service ran out of resources to
+     *                  complete this operation.
+     */
+    const qos::SubscriberQos& qos() const;
+
+
+    /**
+     * Sets the SubscriberQos setting for this instance.
+     *
+     * @param qos the qos
+     * @throws dds::core::Error
+     *                  An internal error has occurred.
+     * @throws dds::core::NullReferenceError
+     *                  The entity was not properly created and references to dds::core::null.
+     * @throws dds::core::AlreadyClosedError
+     *                  The entity has already been closed.
+     * @throws dds::core::OutOfResourcesError
+     *                  The Data Distribution Service ran out of resources to
+     *                  complete this operation.
+     */
+    void qos(
+            const qos::SubscriberQos& qos);
+
+    /** @copydoc dds::pub::Subscriber::qos(const dds::pub::qos::SubscriberQos& qos) */
+    Subscriber& operator <<(
+            const qos::SubscriberQos& qos);
+
+    /** @copydoc dds::pub::Subscriber::qos() */
+    Subscriber& operator >>(
+            qos::SubscriberQos& qos);
+
+    /**
+     * Sets the default DataWriterQos of the Subscriber.
+     *
+     * This operation sets the default SubscriberQos of the Subscriber which
+     * is used for newly created Subscriber objects, when no QoS is provided.
+     *
+     * This operation checks if the DataReaderQos is self consistent. If it is not, the
+     * operation has no effect and throws dds::core::InconsistentPolicyError.
+     *
+     * The values set by this operation are returned by dds::pub::Subscriber::default_datareader_qos().
+     *
+     * @param qos the default DataReaderQos
+     * @throws dds::core::Error
+     *                  An internal error has occurred.
+     * @throws dds::core::NullReferenceError
+     *                  The entity was not properly created and references to dds::core::null.
+     * @throws dds::core::AlreadyClosedError
+     *                  The entity has already been closed.
+     * @throws dds::core::UnsupportedError
+     *                  One or more of the selected QosPolicy values are
+     *                  currently not supported.
+     * @throws dds::core::InconsistentPolicyError
+     *                  The parameter qos contains conflicting QosPolicy settings,
+     * @throws dds::core::OutOfResourcesError
+     *                  The Data Distribution Service ran out of resources to
+     *                  complete this operation.
+     */
+    //    Subscriber& default_datareader_qos(
+    //            const qos::DataReaderQos& qos);
+
+    /**
+     * Gets the default DataReaderQos of the Subscriber.
+     *
+     * This operation gets an object with the default DataReader QosPolicy settings of
+     * the Subscriber (that is the DataReaderQos) which is used for newly
+     * created DataReader objects, in case no QoS was provided during the creation.
+     *
+     * The values retrieved by this operation match the set of values specified on the last
+     * successful call to
+     * dds::pub::Subscriber::default_datareader_qos(const dds::pub::qos::DataReaderQos& qos),
+     * or, if the call was never made, the @ref anchor_dds_pub_datareader_qos_defaults "default" values.
+     *
+     * @return the default DataReaderQos
+     * @throws dds::core::Error
+     *                  An internal error has occurred.
+     * @throws dds::core::NullReferenceError
+     *                  The entity was not properly created and references to dds::core::null.
+     * @throws dds::core::AlreadyClosedError
+     *                  The entity has already been closed.
+     * @throws dds::core::OutOfResourcesError
+     *                  The Data Distribution Service ran out of resources to
+     *                  complete this operation.
+     */
+    //    qos::DataReaderQos default_datareader_qos() const;
+
+    //==========================================================================
+
+    /**
+     * Register a listener with the Subscriber.
+     *
+     * The notifications received by the listener depend on the
+     * status mask with which it was registered.
+     *
+     * Listener un-registration is performed by setting the listener to NULL.
+     *
+     * See also @ref DCPS_Modules_Infrastructure_Listener "listener information".
+     *
+     * @param plistener the listener
+     * @param mask      the mask defining the events for which the listener
+     *                  will be notified.
+     * @throws dds::core::Error
+     *                  An internal error has occurred.
+     * @throws dds::core::NullReferenceError
+     *                  The entity was not properly created and references to dds::core::null.
+     * @throws dds::core::AlreadyClosedError
+     *                  The entity has already been closed.
+     * @throws dds::core::UnsupportedError
+     *                  A status was selected that cannot be supported because
+     *                  the infrastructure does not maintain the required connectivity information.
+     * @throws dds::core::OutOfResourcesError
+     *                  The Data Distribution Service ran out of resources to
+     *                  complete this operation.
+     */
+    void listener(
+            Listener* plistener,
+            const dds::core::status::StatusMask& mask);
+
+    /**
+     * Get the listener of this Subscriber.
+     *
+     * See also @ref DCPS_Modules_Infrastructure_Listener "listener information".
+     *
+     * @return the listener
+     * @throws dds::core::NullReferenceError
+     *                  The entity was not properly created and references to dds::core::null.
+     */
+    Listener* listener() const;
+
+    /**
+     * Return the DomainParticipant that owns this Subscriber.
+     *
+     * @return the DomainParticipant
+     * @throws dds::core::Error
+     *                  An internal error has occurred.
+     * @throws dds::core::NullReferenceError
+     *                  The entity was not properly created and references to dds::core::null.
+     * @throws dds::core::AlreadyClosedError
+     *                  The entity has already been closed.
+     */
+    const dds::domain::DomainParticipant& participant() const;
+
+    dds::domain::DomainParticipant* participant_;
+
+};
+
+} //namespace sub
+} //namespace dds
+
+#endif //OMG_DDS_SUB_SUBSCRIBER_HPP_

--- a/include/dds/sub/SubscriberListener.hpp
+++ b/include/dds/sub/SubscriberListener.hpp
@@ -1,0 +1,154 @@
+/*
+ * Copyright 2020, Proyectos y Sistemas de Mantenimiento SL (eProsima).
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef OMG_DDS_SUB_SUBSCRIBER_LISTENER_HPP_
+#define OMG_DDS_SUB_SUBSCRIBER_LISTENER_HPP_
+
+// TODO Remove when PSM DDS Listeners are ready to be used.
+#include <fastdds/dds/subscriber/SubscriberListener.hpp>
+
+// TODO uncomment when PSM DDS Listeners are ready to be used.
+//#include <dds/sub/AnyDataReaderListener.hpp>
+
+namespace dds {
+namespace sub {
+
+class SubscriberListener;
+class NoOpSubscriberListener;
+
+/**
+ * @brief
+ * Subscriber events Listener
+ *
+ * Since a Subscriber is an Entity, it has the ability to have a Listener
+ * associated with it. In this case, the associated Listener should be of type
+ * SubscriberListener. This interface must be implemented by the
+ * application. A user-defined class must be provided by the application which must
+ * extend from the SubscriberListener class.
+ *
+ * <b><i>
+ * All operations for this interface must be implemented in the user-defined class, it is
+ * up to the application whether an operation is empty or contains some functionality.
+ * </i></b>
+ *
+ * The SubscriberListener provides a generic mechanism (actually a
+ * callback function) for the Data Distribution Service to notify the application of
+ * relevant asynchronous status change events, such as a missed deadline, violation of
+ * a QosPolicy setting, etc. The SubscriberListener is related to
+ * changes in communication status StatusConditions.
+ *
+ * @code{.cpp}
+ * // Application example listener
+ * class ExampleListener :
+ *                public virtual dds::pub::SubscriberListener
+ * {
+ * public:
+ *     virtual void on_new_data_message (
+ *         dds::pub::AnyDataReader& reader,
+ *         const dds::core::status::NewDataMessageStatus& status)
+ *     {
+ *         std::cout << "on_new_data_message" << std::endl;
+ *     }
+ *
+ *     virtual void on_subscription_matched (
+ *         dds::pub::AnyDataReader& reader,
+ *         const dds::core::status::SubscriptionMatchedStatus& status)
+ *     {
+ *         std::cout << "on_subscription_matched" << std::endl;
+ *     }
+ *
+ *     virtual void on_requested_deadline_missed (
+ *         dds::pub::AnyDataReader& reader,
+ *         const dds::core::status::RequestedDeadlineMissedStatus& status)
+ *     {
+ *         std::cout << "on_requested_deadline_missed" << std::endl;
+ *     }
+ *
+ *     virtual void on_liveliness_changed (
+ *         dds::pub::AnyDataReader& reader,
+ *         const dds::core::status::LivelinessChangedStatus& status)
+ *     {
+ *         std::cout << "on_liveliness_changed" << std::endl;
+ *     }
+ * };
+ *
+ * // Create Publisher with the listener
+ * dds::domain::DomainParticipant participant(org::opensplice::domain::default_id());
+ * dds::sub::Subscriber subscriber(participant,
+ *                               participant.default_Subscriber_qos(),
+ *                               new ExampleListener(),
+ *                               dds::core::status::StatusMask::all());
+ *
+ * @endcode
+ *
+ * @see @ref DCPS_Modules_Subscriber "Subscriber"
+ * @see @ref DCPS_Modules_Infrastructure_Listener "Listener information"
+ */
+// TODO Uncomment when PSM listeners are implemented.
+//class OMG_DDS_API SubscriberListener : public virtual AnyDataReaderListener
+// TODO Remove the PSM listeners are implemented.
+class SubscriberListener : public eprosima::fastdds::dds::SubscriberListener
+{
+public:
+
+    /** @cond */
+    virtual ~SubscriberListener()
+    {
+    }
+
+    /** @endcond */
+};
+
+/**
+ * @brief
+ * Subscriber events Listener
+ *
+ * This listener is just like SubscriberListener, except
+ * that the application doesn't have to implement all operations.
+ *
+ * @code{.cpp}
+ * class ExampleListener : public virtual dds::pub::NoOpSubscriberListener
+ * {
+ *    // Not necessary to implement any Listener operations.
+ * };
+ * @endcode
+ *
+ * @see dds::pub::SubscriberListener
+ */
+
+// TODO Uncomment when PSM DDS listeners are ready to be used
+/*
+   class OMG_DDS_API NoOpSubscriberListener :
+        public virtual SubscriberListener,
+        public virtual NoOpAnyDataReaderListener
+ */
+// TODO Remove the PSM listeners are implemented.
+class NoOpSubscriberListener : public virtual SubscriberListener
+{
+public:
+
+    /** @cond */
+    virtual ~NoOpSubscriberListener()
+    {
+    }
+
+    /** @endcond */
+};
+
+} //namespace sub
+} //namespace dds
+
+#endif //OMG_DDS_SUB_SUBSCRIBER_LISTENER_HPP_

--- a/include/dds/sub/detail/Subscriber.hpp
+++ b/include/dds/sub/detail/Subscriber.hpp
@@ -1,0 +1,48 @@
+/*
+ * Copyright 2020, Proyectos y Sistemas de Mantenimiento SL (eProsima).
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+#ifndef EPROSIMA_DDS_SUB_DETAIL_SUBSCRIBER_HPP_
+#define EPROSIMA_DDS_SUB_DETAIL_SUBSCRIBER_HPP_
+
+#include <fastdds/dds/subscriber/Subscriber.hpp>
+
+/**
+ * @cond
+ * Ignore this file in the API
+ */
+
+namespace eprosima {
+namespace fastdds {
+namespace dds {
+class Subscriber;
+}
+}
+}
+
+namespace dds {
+namespace sub {
+namespace detail {
+
+using Subscriber = eprosima::fastdds::dds::Subscriber;
+
+} //namespace detail
+} //namespace sub
+} //namespace dds
+
+/** @endcond */
+
+#endif //EPROSIMA_DDS_SUB_DETAIL_SUBSCRIBER_HPP_

--- a/include/dds/sub/qos/SubscriberQos.hpp
+++ b/include/dds/sub/qos/SubscriberQos.hpp
@@ -1,0 +1,32 @@
+/*
+ * Copyright 2020, Proyectos y Sistemas de Mantenimiento SL (eProsima).
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef OMG_DDS_QOS_SUBSCRIBER_QOS_HPP_
+#define OMG_DDS_QOS_SUBSCRIBER_QOS_HPP_
+
+#include <dds/sub/qos/detail/SubscriberQos.hpp>
+
+namespace dds {
+namespace sub {
+namespace qos {
+
+typedef dds::sub::qos::detail::SubscriberQos SubscriberQos;
+
+} //namespace qos
+} //namespace sub
+} //namespace dds
+
+#endif //OMG_DDS_QOS_SUBSCRIBER_QOS_HPP_

--- a/include/dds/sub/qos/detail/SubscriberQos.hpp
+++ b/include/dds/sub/qos/detail/SubscriberQos.hpp
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2020, Proyectos y Sistemas de Mantenimiento SL (eProsima).
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+#ifndef EPROSIMA_DDS_SUB_QOS_DETAIL_SUBSCRIBER_QOS_HPP_
+#define EPROSIMA_DDS_SUB_QOS_DETAIL_SUBSCRIBER_QOS_HPP_
+
+#include <fastdds/dds/subscriber/qos/SubscriberQos.hpp>
+
+namespace dds {
+namespace sub {
+namespace qos {
+namespace detail {
+
+using SubscriberQos = eprosima::fastdds::dds::SubscriberQos;
+
+} //namespace detail
+} //namespace qos
+} //namespace sub
+} //namespace detail
+
+#endif //EPROSIMA_DDS_SUB_QOS_DETAIL_SUBSCRIBER_QOS_HPP_

--- a/include/fastdds/dds/domain/DomainParticipant.hpp
+++ b/include/fastdds/dds/domain/DomainParticipant.hpp
@@ -114,14 +114,14 @@ public:
     /**
      * Create a Subscriber in this Participant.
      * @param qos QoS of the Subscriber.
-     * @param att Attributes of the Subscriber. TopicAttributes and ReaderQos will be ignored using DDS interface.
-     * @param listen Pointer to the listener.
+     * @param listener Pointer to the listener.
+     * @param mask StatusMask that holds statuses the listener responds to
      * @return Pointer to the created Subscriber.
      */
     RTPS_DllAPI Subscriber* create_subscriber(
-            const fastdds::dds::SubscriberQos& qos,
-            const fastrtps::SubscriberAttributes& att,
-            SubscriberListener* listen = nullptr);
+            const SubscriberQos& qos,
+            SubscriberListener* listener = nullptr,
+            const StatusMask& mask = StatusMask::all());
 
     /**
      * Deletes an existing Subscriber.

--- a/include/fastdds/dds/domain/DomainParticipant.hpp
+++ b/include/fastdds/dds/domain/DomainParticipant.hpp
@@ -264,7 +264,7 @@ public:
      * @return if given qos was applied as default.
      */
     RTPS_DllAPI ReturnCode_t set_default_subscriber_qos(
-            const fastdds::dds::SubscriberQos& qos);
+            const SubscriberQos& qos);
 
     /**
      * This operation retrieves the default value of the Subscriber QoS, that is, the QoS policies which will be used
@@ -275,7 +275,7 @@ public:
      * call to set_default_subscriber_qos, or else, if the call was never made, the default values.
      * @return Current default subscriber qos.
      */
-    RTPS_DllAPI const fastdds::dds::SubscriberQos& get_default_subscriber_qos() const;
+    RTPS_DllAPI const SubscriberQos& get_default_subscriber_qos() const;
 
     /**
      * This operation retrieves the default value of the Subscriber QoS, that is, the QoS policies which will be used
@@ -288,7 +288,7 @@ public:
      * @return Always true.
      */
     RTPS_DllAPI ReturnCode_t get_default_subscriber_qos(
-            fastdds::dds::SubscriberQos& qos) const;
+            SubscriberQos& qos) const;
 
     // TODO Get/Set default Topic Qos
 

--- a/include/fastdds/dds/publisher/Publisher.hpp
+++ b/include/fastdds/dds/publisher/Publisher.hpp
@@ -27,8 +27,6 @@
 #include <fastdds/dds/core/Entity.hpp>
 #include <fastdds/dds/publisher/qos/PublisherQos.hpp>
 
-#include <dds/pub/Publisher.hpp>
-
 using eprosima::fastrtps::types::ReturnCode_t;
 
 namespace dds {

--- a/include/fastdds/dds/subscriber/Subscriber.hpp
+++ b/include/fastdds/dds/subscriber/Subscriber.hpp
@@ -25,6 +25,7 @@
 #include <fastdds/dds/subscriber/DataReaderListener.hpp>
 #include <fastdds/dds/subscriber/qos/SubscriberQos.hpp>
 #include <fastrtps/types/TypesBase.h>
+#include <fastdds/dds/core/Entity.hpp>
 
 using eprosima::fastrtps::types::ReturnCode_t;
 
@@ -52,7 +53,7 @@ class ReaderQos;
  * DomainRTPSParticipant class should be used to correctly create this element.
  * @ingroup FASTDDS_MODULE
  */
-class RTPS_DllAPI Subscriber
+class Subscriber : public DomainEntity
 {
     friend class SubscriberImpl;
     friend class DomainParticipantImpl;
@@ -61,28 +62,31 @@ class RTPS_DllAPI Subscriber
      * Constructor from a SubscriberImpl pointer
      * @param pimpl Actual implementation of the subscriber
      */
-    Subscriber(
-            SubscriberImpl* pimpl)
-        : impl_(pimpl)
-    {
-    }
+    RTPS_DllAPI Subscriber(
+            SubscriberImpl* pimpl,
+            const StatusMask& mask = StatusMask::all());
 
-    virtual ~Subscriber()
-    {
-    }
-
+    RTPS_DllAPI Subscriber(
+            DomainParticipant* dp,
+            const SubscriberQos& qos = SUBSCRIBER_QOS_DEFAULT,
+            SubscriberListener* listener = nullptr,
+            const StatusMask& mask = StatusMask::all());
 public:
+
+    RTPS_DllAPI virtual ~Subscriber()
+    {
+    }
 
     /**
      * Allows accessing the Subscriber Qos.
      */
-    const SubscriberQos& get_qos() const;
+    RTPS_DllAPI const SubscriberQos& get_qos() const;
 
     /**
      * Retrieves the Subscriber Qos.
      * @return true
      */
-    ReturnCode_t get_qos(
+    RTPS_DllAPI ReturnCode_t get_qos(
             SubscriberQos& qos) const;
 
     /**
@@ -91,20 +95,20 @@ public:
      * @param qos
      * @return False if IMMUTABLE_POLICY or INCONSISTENT_POLICY occurs. True if updated.
      */
-    ReturnCode_t set_qos(
+    RTPS_DllAPI ReturnCode_t set_qos(
             const SubscriberQos& qos);
 
     /**
      * Retrieves the attached SubscriberListener.
      */
-    const SubscriberListener* get_listener() const;
+    RTPS_DllAPI const SubscriberListener* get_listener() const;
 
     /**
      * Modifies the SubscriberListener.
      * @param listener
      * @return if successfully set.
      */
-    ReturnCode_t set_listener(
+    RTPS_DllAPI ReturnCode_t set_listener(
             SubscriberListener* listener);
 
     /**
@@ -114,7 +118,7 @@ public:
      * @param listener
      * @return Pointer to the created DataReader. nullptr if failed.
      */
-    DataReader* create_datareader(
+    RTPS_DllAPI DataReader* create_datareader(
             const fastrtps::TopicAttributes& topic_attr,
             const ReaderQos& reader_qos,
             DataReaderListener* listener);
@@ -127,7 +131,7 @@ public:
      * return false.
      * @param reader
      */
-    ReturnCode_t delete_datareader(
+    RTPS_DllAPI ReturnCode_t delete_datareader(
             DataReader* reader);
 
     /**
@@ -138,7 +142,7 @@ public:
      * one of them. It is not specified which one.
      * @param topic_name
      */
-    DataReader* lookup_datareader(
+    RTPS_DllAPI DataReader* lookup_datareader(
             const std::string& topic_name) const;
 
     /**
@@ -146,14 +150,14 @@ public:
      * @param readers
      * @return true
      */
-    ReturnCode_t get_datareaders(
+    RTPS_DllAPI ReturnCode_t get_datareaders(
             std::vector<DataReader*>& readers) const;
 
     /**
      * This operation checks if the subscriber has DataReaders
      * @return true if the subscriber has one or several DataReaders, false in other case
      */
-    bool has_datareaders() const;
+    RTPS_DllAPI bool has_datareaders() const;
 
     /* TODO
        bool begin_access();
@@ -171,7 +175,7 @@ public:
      * That way the SubscriberListener can delegate to the DataReaderListener objects the handling of the data.
      * @return
      */
-    ReturnCode_t notify_datareaders() const;
+    RTPS_DllAPI ReturnCode_t notify_datareaders() const;
 
     /* TODO
        bool delete_contained_entities();
@@ -189,7 +193,7 @@ public:
      * if the set_default_datareader_qos operation had never been called.
      * @param qos
      */
-    ReturnCode_t set_default_datareader_qos(
+    RTPS_DllAPI ReturnCode_t set_default_datareader_qos(
             const ReaderQos& qos);
 
     /**
@@ -201,7 +205,7 @@ public:
      * call to get_default_datareader_qos, or else, if the call was never made, the default values.
      * @return Current default ReaderQos.
      */
-    const ReaderQos& get_default_datareader_qos() const;
+    RTPS_DllAPI const ReaderQos& get_default_datareader_qos() const;
 
     /**
      * This operation retrieves the default value of the DataReader QoS, that is, the QoS policies which will be
@@ -213,7 +217,7 @@ public:
      * @param qos Current default ReaderQos.
      * @return Always true.
      */
-    ReturnCode_t get_default_datareader_qos(
+    RTPS_DllAPI ReturnCode_t get_default_datareader_qos(
             ReaderQos& qos) const;
 
     /* TODO
@@ -223,29 +227,15 @@ public:
      */
 
     /**
-     * Update the Attributes of the subscriber;
-     * @param att Reference to a SubscriberAttributes object to update the parameters;
-     * @return True if correctly updated, false if ANY of the updated parameters cannot be updated
-     */
-    bool set_attributes(
-            const fastrtps::SubscriberAttributes& att);
-
-    /**
-     * Get the Attributes of the Subscriber.
-     * @return Attributes of the Subscriber.
-     */
-    const fastrtps::SubscriberAttributes& get_attributes() const;
-
-    /**
      * This operation returns the DomainParticipant to which the Subscriber belongs.
      */
-    const DomainParticipant* get_participant() const;
+    RTPS_DllAPI const DomainParticipant* get_participant() const;
 
     /**
      * Returns the Subscriber's handle.
      * @return InstanceHandle of this Subscriber.
      */
-    const fastrtps::rtps::InstanceHandle_t& get_instance_handle() const;
+    RTPS_DllAPI const fastrtps::rtps::InstanceHandle_t& get_instance_handle() const;
 
 private:
 

--- a/include/fastdds/dds/subscriber/Subscriber.hpp
+++ b/include/fastdds/dds/subscriber/Subscriber.hpp
@@ -79,6 +79,7 @@ class Subscriber : public DomainEntity
             const SubscriberQos& qos = SUBSCRIBER_QOS_DEFAULT,
             SubscriberListener* listener = nullptr,
             const StatusMask& mask = StatusMask::all());
+
 public:
 
     RTPS_DllAPI virtual ~Subscriber()

--- a/include/fastdds/dds/subscriber/Subscriber.hpp
+++ b/include/fastdds/dds/subscriber/Subscriber.hpp
@@ -26,8 +26,17 @@
 #include <fastdds/dds/subscriber/qos/SubscriberQos.hpp>
 #include <fastrtps/types/TypesBase.h>
 #include <fastdds/dds/core/Entity.hpp>
+#include <fastdds/dds/subscriber/qos/SubscriberQos.hpp>
 
 using eprosima::fastrtps::types::ReturnCode_t;
+
+namespace dds {
+namespace sub {
+
+class Subscriber;
+
+} // namespace sub
+} // namespace dds
 
 namespace eprosima {
 namespace fastrtps {
@@ -42,7 +51,6 @@ namespace dds {
 class DomainParticipant;
 class SubscriberListener;
 class SubscriberImpl;
-class SubscriberQos;
 class DataReader;
 class DataReaderListener;
 class ReaderQos;
@@ -240,6 +248,8 @@ public:
 private:
 
     SubscriberImpl* impl_;
+
+    friend class ::dds::sub::Subscriber;
 };
 
 } /* namespace dds */

--- a/include/fastdds/dds/subscriber/qos/SubscriberQos.hpp
+++ b/include/fastdds/dds/subscriber/qos/SubscriberQos.hpp
@@ -20,7 +20,8 @@
 #ifndef _FASTDDS_SUBSCRIBERQOS_HPP_
 #define _FASTDDS_SUBSCRIBERQOS_HPP_
 
-#include <fastrtps/qos/QosPolicies.h>
+#include <fastdds/dds/core/policy/QosPolicies.hpp>
+#include <fastrtps/attributes/SubscriberAttributes.h>
 
 namespace eprosima {
 namespace fastdds {
@@ -36,86 +37,18 @@ namespace dds {
 class SubscriberQos
 {
 public:
-    RTPS_DllAPI SubscriberQos()
-    {}
+    RTPS_DllAPI SubscriberQos() = default;
 
-    RTPS_DllAPI virtual ~SubscriberQos()
-    {}
+    RTPS_DllAPI virtual ~SubscriberQos() = default;
 
     bool operator==(
             const SubscriberQos& b) const
     {
-        return (this->durability == b.durability) &&
-               (this->deadline == b.deadline) &&
-               (this->latency_budget == b.latency_budget) &&
-               (this->liveliness == b.liveliness) &&
-               (this->reliability == b.reliability) &&
-               (this->ownership == b.ownership) &&
-               (this->destination_order == b.destination_order) &&
-               (this->user_data == b.user_data) &&
-               (this->time_based_filter == b.time_based_filter) &&
-               (this->presentation == b.presentation) &&
-               (this->partition == b.partition) &&
-               (this->topic_data == b.topic_data) &&
-               (this->group_data == b.group_data) &&
-               (this->durability_service == b.durability_service) &&
-               (this->lifespan == b.lifespan) &&
-               (this->disable_positive_acks == b.disable_positive_acks);
+        return (presentation_ == b.presentation_) &&
+               (partition_ == b.partition_) &&
+               (group_data_ == b.group_data_) &&
+               (entity_factory_ == b.entity_factory_);
     }
-
-    //!Durability Qos, implemented in the library.
-    fastrtps::DurabilityQosPolicy durability;
-
-    //!Deadline Qos, implemented in the library.
-    fastrtps::DeadlineQosPolicy deadline;
-
-    //!Latency Budget Qos, NOT implemented in the library.
-    fastrtps::LatencyBudgetQosPolicy latency_budget;
-
-    //!Liveliness Qos, implemented in the library.
-    fastrtps::LivelinessQosPolicy liveliness;
-
-    //!ReliabilityQos, implemented in the library.
-    fastrtps::ReliabilityQosPolicy reliability;
-
-    //!Ownership Qos, NOT implemented in the library.
-    fastrtps::OwnershipQosPolicy ownership;
-
-    //!Destinatio Order Qos, NOT implemented in the library.
-    fastrtps::DestinationOrderQosPolicy destination_order;
-
-    //!UserData Qos, NOT implemented in the library.
-    UserDataQosPolicy user_data;
-
-    //!Time Based Filter Qos, NOT implemented in the library.
-    fastrtps::TimeBasedFilterQosPolicy time_based_filter;
-
-    //!Presentation Qos, NOT implemented in the library.
-    fastrtps::PresentationQosPolicy presentation;
-
-    //!Partition Qos, implemented in the library.
-    fastrtps::PartitionQosPolicy partition;
-
-    //!Topic Data Qos, NOT implemented in the library.
-    fastrtps::TopicDataQosPolicy topic_data;
-
-    //!GroupData Qos, NOT implemented in the library.
-    fastrtps::GroupDataQosPolicy group_data;
-
-    //!Durability Service Qos, NOT implemented in the library.
-    fastrtps::DurabilityServiceQosPolicy durability_service;
-
-    //!Lifespan Qos, NOT implemented in the library.
-    fastrtps::LifespanQosPolicy lifespan;
-
-    //!Data Representation Qos, implemented in the library.
-    fastrtps::DataRepresentationQosPolicy representation;
-
-    //!Type consistency enforcement Qos, NOT implemented in the library.
-    fastrtps::TypeConsistencyEnforcementQosPolicy type_consistency;
-
-    //!Disable positive ACKs QoS
-    fastrtps::DisablePositiveACKsQosPolicy disable_positive_acks;
 
     /**
      * Set Qos from another class
@@ -139,6 +72,133 @@ public:
      */
     RTPS_DllAPI bool can_qos_be_updated(
             const SubscriberQos& qos) const;
+
+
+    /**
+     * Getter for PresentationQosPolicy
+     * @return PresentationQosPolicy reference
+     */
+    const PresentationQosPolicy& presentation() const
+    {
+        return presentation_;
+    }
+
+    /**
+     * Getter for PresentationQosPolicy
+     * @return PresentationQosPolicy reference
+     */
+    PresentationQosPolicy& presentation()
+    {
+        return presentation_;
+    }
+
+    /**
+     * Setter for PresentationQosPolicy
+     * @param presentation
+     */
+    void presentation(
+            const PresentationQosPolicy& presentation)
+    {
+        presentation_ = presentation;
+    }
+
+    /**
+     * Getter for PartitionQosPolicy
+     * @return PartitionQosPolicy reference
+     */
+    const PartitionQosPolicy& partition() const
+    {
+        return partition_;
+    }
+
+    /**
+     * Getter for PartitionQosPolicy
+     * @return PartitionQosPolicy reference
+     */
+    PartitionQosPolicy& partition()
+    {
+        return partition_;
+    }
+
+    /**
+     * Setter for PartitionQosPolicy
+     * @param partition
+     */
+    void partition(
+            const PartitionQosPolicy& partition)
+    {
+        partition_ = partition;
+    }
+
+    /**
+     * Getter for GroupDataQosPolicy
+     * @return GroupDataQosPolicy reference
+     */
+    const GroupDataQosPolicy& group_data() const
+    {
+        return group_data_;
+    }
+
+    /**
+     * Getter for GroupDataQosPolicy
+     * @return GroupDataQosPolicy reference
+     */
+    GroupDataQosPolicy& group_data()
+    {
+        return group_data_;
+    }
+
+    /**
+     * Setter for GroupDataQosPolicy
+     * @param group_data
+     */
+    void group_data(
+            const GroupDataQosPolicy& group_data)
+    {
+        group_data_ = group_data;
+    }
+
+    /**
+     * Getter for EntityFactoryQosPolicy
+     * @return EntityFactoryQosPolicy reference
+     */
+    const EntityFactoryQosPolicy& entity_factory() const
+    {
+        return entity_factory_;
+    }
+
+    /**
+     * Getter for EntityFactoryQosPolicy
+     * @return EntityFactoryQosPolicy reference
+     */
+    EntityFactoryQosPolicy& entity_factory()
+    {
+        return entity_factory_;
+    }
+
+    /**
+     * Setter for EntityFactoryQosPolicy
+     * @param entity_factory
+     */
+    void entity_factory(
+            const EntityFactoryQosPolicy& entity_factory)
+    {
+        entity_factory_ = entity_factory;
+    }
+
+private:
+
+    //!Presentation Qos, NOT implemented in the library.
+    PresentationQosPolicy presentation_;
+
+    //!Partition Qos, implemented in the library.
+    PartitionQosPolicy partition_;
+
+    //!Group Data Qos, NOT implemented in the library.
+    GroupDataQosPolicy group_data_;
+
+    //!Entity Factory Qos, implemented in the library
+    EntityFactoryQosPolicy entity_factory_;
 };
 
 RTPS_DllAPI extern const SubscriberQos SUBSCRIBER_QOS_DEFAULT;

--- a/include/fastdds/dds/subscriber/qos/SubscriberQos.hpp
+++ b/include/fastdds/dds/subscriber/qos/SubscriberQos.hpp
@@ -37,11 +37,12 @@ namespace dds {
 class SubscriberQos
 {
 public:
-    RTPS_DllAPI SubscriberQos() = default;
 
-    RTPS_DllAPI virtual ~SubscriberQos() = default;
+    RTPS_DllAPI SubscriberQos();
 
-    bool operator==(
+    RTPS_DllAPI virtual ~SubscriberQos();
+
+    bool operator ==(
             const SubscriberQos& b) const
     {
         return (presentation_ == b.presentation_) &&

--- a/include/fastrtps/attributes/SubscriberAttributes.h
+++ b/include/fastrtps/attributes/SubscriberAttributes.h
@@ -91,6 +91,11 @@ class SubscriberAttributes
                 (this->properties == b.properties);
         }
 
+        bool operator!=(const SubscriberAttributes& b) const
+        {
+            return !(*this == b);
+        }
+
         /**
          * Get the user defined ID
          * @return User defined ID

--- a/src/cpp/CMakeLists.txt
+++ b/src/cpp/CMakeLists.txt
@@ -201,6 +201,7 @@ set(${PROJECT_NAME}_source_files
     dds/core/Exception.cpp
     dds/domain/DomainParticipant.cpp
     dds/pub/Publisher.cpp
+    dds/sub/Subscriber.cpp
     )
 
 # SHM Transport

--- a/src/cpp/dds/domain/DomainParticipant.cpp
+++ b/src/cpp/dds/domain/DomainParticipant.cpp
@@ -133,17 +133,17 @@ DomainParticipant& DomainParticipant::default_publisher_qos(
     return *this;
 }
 
-dds::sub::qos::SubscriberQos DomainParticipant::default_subscriber_qos() const
-{
-    return this->delegate()->get_default_subscriber_qos();
-}
+//dds::sub::qos::SubscriberQos DomainParticipant::default_subscriber_qos() const
+//{
+//    return this->delegate()->get_default_subscriber_qos();
+//}
 
-DomainParticipant& DomainParticipant::default_subscriber_qos(
-        const ::dds::sub::qos::SubscriberQos& qos)
-{
-    this->delegate()->set_default_subscriber_qos(qos);
-    return *this;
-}
+//DomainParticipant& DomainParticipant::default_subscriber_qos(
+//        const ::dds::sub::qos::SubscriberQos& qos)
+//{
+//    this->delegate()->set_default_subscriber_qos(qos);
+//    return *this;
+//}
 
 //dds::topic::qos::TopicQos DomainParticipant::default_topic_qos() const
 //{

--- a/src/cpp/dds/domain/DomainParticipant.cpp
+++ b/src/cpp/dds/domain/DomainParticipant.cpp
@@ -133,17 +133,17 @@ DomainParticipant& DomainParticipant::default_publisher_qos(
     return *this;
 }
 
-//dds::sub::qos::SubscriberQos DomainParticipant::default_subscriber_qos() const
-//{
-//    return this->delegate()->get_default_subscriber_qos();
-//}
+dds::sub::qos::SubscriberQos DomainParticipant::default_subscriber_qos() const
+{
+    return this->delegate()->get_default_subscriber_qos();
+}
 
-//DomainParticipant& DomainParticipant::default_subscriber_qos(
-//        const ::dds::sub::qos::SubscriberQos& qos)
-//{
-//    this->delegate()->set_default_subscriber_qos(qos);
-//    return *this;
-//}
+DomainParticipant& DomainParticipant::default_subscriber_qos(
+        const ::dds::sub::qos::SubscriberQos& qos)
+{
+    this->delegate()->set_default_subscriber_qos(qos);
+    return *this;
+}
 
 //dds::topic::qos::TopicQos DomainParticipant::default_topic_qos() const
 //{

--- a/src/cpp/dds/sub/Subscriber.cpp
+++ b/src/cpp/dds/sub/Subscriber.cpp
@@ -28,17 +28,17 @@
 namespace dds {
 namespace sub {
 
-Subscriber::Subscriber(
-        const dds::domain::DomainParticipant& dp)
-    : ::dds::core::Reference<detail::Subscriber>(
-        new detail::Subscriber(
-            dp.delegate().get(),
-            dp.default_subscriber_qos(),
-            nullptr,
-            dds::core::status::StatusMask::all()))
-    , participant_(nullptr)
-{
-}
+//Subscriber::Subscriber(
+//        const dds::domain::DomainParticipant& dp)
+//    : ::dds::core::Reference<detail::Subscriber>(
+//        new detail::Subscriber(
+//            dp.delegate().get(),
+//            dp.default_subscriber_qos(),
+//            nullptr,
+//            dds::core::status::StatusMask::all()))
+//    , participant_(nullptr)
+//{
+//}
 
 Subscriber::Subscriber(
         const dds::domain::DomainParticipant& dp,

--- a/src/cpp/dds/sub/Subscriber.cpp
+++ b/src/cpp/dds/sub/Subscriber.cpp
@@ -1,0 +1,124 @@
+/*
+ * Copyright 2020, Proyectos y Sistemas de Mantenimiento SL (eProsima).
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+/**
+ * @file
+ */
+
+/*
+ * OMG PSM class declaration
+ */
+#include <dds/sub/Subscriber.hpp>
+#include <dds/sub/SubscriberListener.hpp>
+
+namespace dds {
+namespace sub {
+
+Subscriber::Subscriber(
+        const dds::domain::DomainParticipant& dp)
+    : ::dds::core::Reference<detail::Subscriber>(
+        new detail::Subscriber(
+            dp.delegate().get(),
+            dp.default_subscriber_qos(),
+            nullptr,
+            dds::core::status::StatusMask::all()))
+    , participant_(nullptr)
+{
+}
+
+Subscriber::Subscriber(
+        const dds::domain::DomainParticipant& dp,
+        const qos::SubscriberQos& qos,
+        SubscriberListener* listener,
+        const dds::core::status::StatusMask& mask)
+    : ::dds::core::Reference<detail::Subscriber>(
+        new detail::Subscriber(
+            dp.delegate().get(), qos, listener, mask))
+    , participant_(nullptr)
+{
+}
+
+Subscriber::~Subscriber()
+{
+}
+
+//const qos::SubscriberQos& Subscriber::qos() const
+//{
+//    return delegate()->get_qos();
+//}
+
+//void Subscriber::qos(
+//        const qos::SubscriberQos& pqos)
+//{
+//    delegate()->set_qos(pqos);
+//}
+
+//Subscriber& Subscriber::operator <<(
+//        const qos::SubscriberQos& qos)
+//{
+//    this->qos(qos);
+//    return *this;
+//}
+
+//Subscriber& Subscriber::operator >>(
+//        qos::SubscriberQos& qos)
+//{
+//    qos = this->qos();
+//    return *this;
+//}
+
+//Subscriber& Subscriber::default_datareader_qos(
+//        const qos::DataReaderQos& drqos)
+//{
+//    // TODO Use DataReaderQos instead of ReaderQos
+//    //delegate()->set_default_datareader_qos(drqos);
+//    (void)drqos;
+//    return *this;
+//}
+
+//qos::DataReaderQos Subscriber::default_datareader_qos() const
+//{
+//    //    return this->delegate()->default_datareader_qos();
+//    // TODO Use DataReaderQos instead of ReaderQos
+//    //return delegate()->get_default_datareader_qos();
+//    return qos::DataReaderQos();
+//}
+
+//void Subscriber::listener(
+//        Listener* plistener,
+//        const dds::core::status::StatusMask& /*event_mask*/)
+//{
+//    delegate()->set_listener(plistener /*, event_mask*/);
+//}
+
+//typename Subscriber::Listener* Subscriber::listener() const
+//{
+//    return dynamic_cast<Listener*>(delegate()->get_listener());
+//}
+
+//const dds::domain::DomainParticipant& Subscriber::participant() const
+//{
+//    eprosima::fastdds::dds::DomainParticipant p = delegate()->get_participant();
+//    std::shared_ptr<eprosima::fastdds::dds::DomainParticipant> ptr(&p);
+//    participant_->delegate().swap(ptr);
+
+//    return *participant_;
+//}
+
+} //namespace sub
+} //namespace dds
+

--- a/src/cpp/fastdds/domain/DomainParticipant.cpp
+++ b/src/cpp/fastdds/domain/DomainParticipant.cpp
@@ -178,18 +178,18 @@ ReturnCode_t DomainParticipant::get_default_publisher_qos(
 }
 
 ReturnCode_t DomainParticipant::set_default_subscriber_qos(
-        const fastdds::dds::SubscriberQos& qos)
+        const SubscriberQos& qos)
 {
     return impl_->set_default_subscriber_qos(qos);
 }
 
-const fastdds::dds::SubscriberQos& DomainParticipant::get_default_subscriber_qos() const
+const SubscriberQos& DomainParticipant::get_default_subscriber_qos() const
 {
     return impl_->get_default_subscriber_qos();
 }
 
 ReturnCode_t DomainParticipant::get_default_subscriber_qos(
-        fastdds::dds::SubscriberQos& qos) const
+        SubscriberQos& qos) const
 {
     qos = impl_->get_default_subscriber_qos();
     return ReturnCode_t::RETCODE_OK;

--- a/src/cpp/fastdds/domain/DomainParticipant.cpp
+++ b/src/cpp/fastdds/domain/DomainParticipant.cpp
@@ -71,11 +71,11 @@ ReturnCode_t DomainParticipant::delete_publisher(
 }
 
 Subscriber* DomainParticipant::create_subscriber(
-        const fastdds::dds::SubscriberQos& qos,
-        const fastrtps::SubscriberAttributes& att,
-        SubscriberListener* listen)
+        const SubscriberQos& qos,
+        SubscriberListener* listener,
+        const StatusMask& mask)
 {
-    return impl_->create_subscriber(qos, att, listen);
+    return impl_->create_subscriber(qos, listener, mask);
 }
 
 ReturnCode_t DomainParticipant::delete_subscriber(

--- a/src/cpp/fastdds/domain/DomainParticipantImpl.cpp
+++ b/src/cpp/fastdds/domain/DomainParticipantImpl.cpp
@@ -467,44 +467,17 @@ std::vector<std::string> DomainParticipantImpl::get_participant_names() const
 
 Subscriber* DomainParticipantImpl::create_subscriber(
         const SubscriberQos& qos,
-        const fastrtps::SubscriberAttributes& att,
-        SubscriberListener* listen)
+        SubscriberListener* listener,
+        const StatusMask& mask)
 {
-    if (qos_.wire_protocol().builtin.discovery_config.use_STATIC_EndpointDiscoveryProtocol)
-    {
-        if (att.getUserDefinedID() <= 0)
-        {
-            logError(PARTICIPANT, "Static EDP requires user defined Id");
-            return nullptr;
-        }
-    }
-
-    if (!att.unicastLocatorList.isValid())
-    {
-        logError(PARTICIPANT, "Unicast Locator List for Subscriber contains invalid Locator");
-        return nullptr;
-    }
-
-    if (!att.multicastLocatorList.isValid())
-    {
-        logError(PARTICIPANT, " Multicast Locator List for Subscriber contains invalid Locator");
-        return nullptr;
-    }
-
-    if (!att.remoteLocatorList.isValid())
-    {
-        logError(PARTICIPANT, "Output Locator List for Subscriber contains invalid Locator");
-        return nullptr;
-    }
-
-    if (!qos.check_qos() || !att.qos.checkQos() || !att.topic.checkQos())
+    if (!qos.check_qos())
     {
         return nullptr;
     }
 
     //TODO CONSTRUIR LA IMPLEMENTACION DENTRO DEL OBJETO DEL USUARIO.
-    SubscriberImpl* subimpl = new SubscriberImpl(this, qos, att, listen);
-    Subscriber* sub = new Subscriber(subimpl);
+    SubscriberImpl* subimpl = new SubscriberImpl(this, qos, listener);
+    Subscriber* sub = new Subscriber(subimpl, mask);
     subimpl->user_subscriber_ = sub;
     subimpl->rtps_participant_ = this->rtps_participant_;
 
@@ -524,10 +497,11 @@ Subscriber* DomainParticipantImpl::create_subscriber(
     subscribers_by_handle_[sub_handle] = sub;
     subscribers_[sub] = subimpl;
 
-    if (att.topic.auto_fill_type_object || att.topic.auto_fill_type_information)
-    {
-        register_dynamic_type_to_factories(att.topic.getTopicDataType().to_string());
-    }
+    //TODO: Register the dynamic type when the datareader is created
+    //if (qos.subscriber_attr.topic.auto_fill_type_object || qos.subscriber_attr.topic.auto_fill_type_information)
+    //{
+    //    register_dynamic_type_to_factories(qos.subscriber_attr.topic.getTopicDataType().to_string());
+    //}
 
     return sub;
 }

--- a/src/cpp/fastdds/domain/DomainParticipantImpl.hpp
+++ b/src/cpp/fastdds/domain/DomainParticipantImpl.hpp
@@ -111,14 +111,14 @@ public:
     /**
      * Create a Subscriber in this Participant.
      * @param qos QoS of the Subscriber.
-     * @param att Attributes of the Subscriber
      * @param listen Pointer to the listener.
+     * @param mask StatusMask that holds statuses the listener responds to
      * @return Pointer to the created Subscriber.
      */
     Subscriber* create_subscriber(
-            const fastdds::dds::SubscriberQos& qos,
-            const fastrtps::SubscriberAttributes& att,
-            SubscriberListener* listen = nullptr);
+            const SubscriberQos& qos,
+            SubscriberListener* listener = nullptr,
+            const StatusMask& mask = StatusMask::all());
 
     ReturnCode_t delete_subscriber(
             Subscriber* subscriber);

--- a/src/cpp/fastdds/publisher/qos/PublisherQos.cpp
+++ b/src/cpp/fastdds/publisher/qos/PublisherQos.cpp
@@ -20,9 +20,11 @@
 #include <fastdds/dds/publisher/qos/PublisherQos.hpp>
 #include <fastdds/dds/log/Log.hpp>
 
-using namespace eprosima::fastdds::dds;
+namespace eprosima {
+namespace fastdds {
+namespace dds {
 
-RTPS_DllAPI const PublisherQos eprosima::fastdds::dds::PUBLISHER_QOS_DEFAULT;
+RTPS_DllAPI const PublisherQos PUBLISHER_QOS_DEFAULT;
 
 PublisherQos::PublisherQos()
 {
@@ -70,3 +72,7 @@ bool PublisherQos::can_qos_be_updated(
     return true;
 
 }
+
+} /* namespace dds */
+} /* namespace fastdds */
+} /* namespace eprosima */

--- a/src/cpp/fastdds/subscriber/Subscriber.cpp
+++ b/src/cpp/fastdds/subscriber/Subscriber.cpp
@@ -24,6 +24,24 @@
 using namespace eprosima;
 using namespace eprosima::fastdds::dds;
 
+Subscriber::Subscriber(
+        SubscriberImpl* pimpl,
+        const StatusMask& mask)
+    : DomainEntity(mask)
+    , impl_(pimpl)
+{
+}
+
+Subscriber::Subscriber(
+        DomainParticipant* dp,
+        const SubscriberQos& qos,
+        SubscriberListener* listener,
+        const StatusMask& mask)
+    : DomainEntity(mask)
+    , impl_(dp->create_subscriber(qos, listener, mask)->impl_)
+{
+}
+
 const SubscriberQos& Subscriber::get_qos() const
 {
     return impl_->get_qos();
@@ -136,17 +154,6 @@ bool Subscriber::copy_from_topic_qos(
     return impl_->copy_from_topic_qos(reader_qos, topic_qos);
 }
 */
-
-bool Subscriber::set_attributes(
-        const fastrtps::SubscriberAttributes& att)
-{
-    return impl_->set_attributes(att);
-}
-
-const fastrtps::SubscriberAttributes& Subscriber::get_attributes() const
-{
-    return impl_->get_attributes();
-}
 
 const DomainParticipant* Subscriber::get_participant() const
 {

--- a/src/cpp/fastdds/subscriber/SubscriberImpl.cpp
+++ b/src/cpp/fastdds/subscriber/SubscriberImpl.cpp
@@ -39,11 +39,9 @@ namespace dds {
 SubscriberImpl::SubscriberImpl(
         DomainParticipantImpl* p,
         const SubscriberQos& qos,
-        const fastrtps::SubscriberAttributes& att,
         SubscriberListener* listen)
     : participant_(p)
     , qos_(&qos == &SUBSCRIBER_QOS_DEFAULT ? participant_->get_default_subscriber_qos() : qos)
-    , att_(att)
     , listener_(listen)
     , subscriber_listener_(this)
     , user_subscriber_(nullptr)
@@ -143,28 +141,29 @@ DataReader* SubscriberImpl::create_datareader(
         return nullptr;
     }
 
+    //TODO: Fix once the SubscriberAttributes are included in DataReaderQos
     ReaderAttributes ratt;
     ratt.endpoint.durabilityKind = reader_qos.m_durability.durabilityKind();
     ratt.endpoint.endpointKind = READER;
-    ratt.endpoint.multicastLocatorList = att_.multicastLocatorList;
+    //ratt.endpoint.multicastLocatorList = qos_.subscriber_attr.multicastLocatorList;
     ratt.endpoint.reliabilityKind = reader_qos.m_reliability.kind == RELIABLE_RELIABILITY_QOS ? RELIABLE : BEST_EFFORT;
     ratt.endpoint.topicKind = topic_att.topicKind;
-    ratt.endpoint.unicastLocatorList = att_.unicastLocatorList;
-    ratt.endpoint.remoteLocatorList = att_.remoteLocatorList;
-    ratt.expectsInlineQos = att_.expectsInlineQos;
-    ratt.endpoint.properties = att_.properties;
+    //ratt.endpoint.unicastLocatorList = qos_.subscriber_attr.unicastLocatorList;
+    //ratt.endpoint.remoteLocatorList = qos_.subscriber_attr.remoteLocatorList;
+    //ratt.expectsInlineQos = qos_.subscriber_attr.expectsInlineQos;
+    //ratt.endpoint.properties = qos_.subscriber_attr.properties;
 
-    if (att_.getEntityID() > 0)
-    {
-        ratt.endpoint.setEntityID(static_cast<uint8_t>(att_.getEntityID()));
-    }
+    //if (qos_.subscriber_attr.getEntityID() > 0)
+    //{
+    //    ratt.endpoint.setEntityID(static_cast<uint8_t>(qos_.subscriber_attr.getEntityID()));
+    //}
 
-    if (att_.getUserDefinedID() > 0)
-    {
-        ratt.endpoint.setUserDefinedID(static_cast<uint8_t>(att_.getUserDefinedID()));
-    }
+    //if (qos_.subscriber_attr.getUserDefinedID() > 0)
+    //{
+    //    ratt.endpoint.setUserDefinedID(static_cast<uint8_t>(qos_.subscriber_attr.getUserDefinedID()));
+    //}
 
-    ratt.times = att_.times;
+    //ratt.times = qos_.subscriber_attr.times;
 
     // TODO(Ricardo) Remove in future
     // Insert topic_name and partitions
@@ -194,7 +193,8 @@ DataReader* SubscriberImpl::create_datareader(
         topic_att,
         ratt,
         reader_qos,
-        att_.historyMemoryPolicy,
+        //qos_.subscriber_attr.historyMemoryPolicy,
+        fastrtps::rtps::MemoryManagementPolicy_t(),
         listener);
 
     if (impl->reader_ == nullptr)
@@ -358,67 +358,6 @@ bool SubscriberImpl::contains_entity(
     return false;
    }
  */
-
-bool SubscriberImpl::set_attributes(
-        const fastrtps::SubscriberAttributes& att)
-{
-    bool updated = true;
-    bool missing = false;
-    if (att.unicastLocatorList.size() != att_.unicastLocatorList.size() ||
-            att.multicastLocatorList.size() != att_.multicastLocatorList.size())
-    {
-        logWarning(RTPS_READER, "Locator Lists cannot be changed or updated in this version");
-        updated &= false;
-    }
-    else
-    {
-        for (LocatorListConstIterator lit1 = att_.unicastLocatorList.begin();
-                lit1 != att_.unicastLocatorList.end(); ++lit1)
-        {
-            missing = true;
-            for (LocatorListConstIterator lit2 = att.unicastLocatorList.begin();
-                    lit2 != att.unicastLocatorList.end(); ++lit2)
-            {
-                if (*lit1 == *lit2)
-                {
-                    missing = false;
-                    break;
-                }
-            }
-            if (missing)
-            {
-                logWarning(RTPS_READER, "Locator: " << *lit1 << " not present in new list");
-                logWarning(RTPS_READER, "Locator Lists cannot be changed or updated in this version");
-            }
-        }
-        for (LocatorListConstIterator lit1 = att_.multicastLocatorList.begin();
-                lit1 != att_.multicastLocatorList.end(); ++lit1)
-        {
-            missing = true;
-            for (LocatorListConstIterator lit2 = att.multicastLocatorList.begin();
-                    lit2 != att.multicastLocatorList.end(); ++lit2)
-            {
-                if (*lit1 == *lit2)
-                {
-                    missing = false;
-                    break;
-                }
-            }
-            if (missing)
-            {
-                logWarning(RTPS_READER, "Locator: " << *lit1 << " not present in new list");
-                logWarning(RTPS_READER, "Locator Lists cannot be changed or updated in this version");
-            }
-        }
-    }
-
-    if (updated)
-    {
-        att_ = att;
-    }
-
-    return updated;
-}
 
 const DomainParticipant* SubscriberImpl::get_participant() const
 {

--- a/src/cpp/fastdds/subscriber/SubscriberImpl.hpp
+++ b/src/cpp/fastdds/subscriber/SubscriberImpl.hpp
@@ -70,7 +70,6 @@ class SubscriberImpl
     SubscriberImpl(
             DomainParticipantImpl* p,
             const SubscriberQos& qos,
-            const fastrtps::SubscriberAttributes& attr,
             SubscriberListener* listen = nullptr);
 
 public:
@@ -137,23 +136,6 @@ public:
             const fastrtps::TopicAttributes& topic_qos) const;
      */
 
-    /**
-     * Update the Attributes of the subscriber;
-     * @param att Reference to a SubscriberAttributes object to update the parameters;
-     * @return True if correctly updated, false if ANY of the updated parameters cannot be updated
-     */
-    bool set_attributes(
-            const fastrtps::SubscriberAttributes& att);
-
-    /**
-     * Get the Attributes of the Subscriber.
-     * @return Attributes of the Subscriber.
-     */
-    const fastrtps::SubscriberAttributes& get_attributes() const
-    {
-        return att_;
-    }
-
     const DomainParticipant* get_participant() const;
 
     const fastrtps::rtps::RTPSParticipant* rtps_participant() const
@@ -186,9 +168,6 @@ private:
     DomainParticipantImpl* participant_;
 
     SubscriberQos qos_;
-
-    //!Attributes of the Subscriber
-    fastrtps::SubscriberAttributes att_;
 
     //!Map of Pointer to associated DataReaders. Topic name is the key.
     std::map<std::string, std::vector<DataReaderImpl*> > readers_;

--- a/src/cpp/fastdds/subscriber/qos/SubscriberQos.cpp
+++ b/src/cpp/fastdds/subscriber/qos/SubscriberQos.cpp
@@ -26,11 +26,20 @@ namespace dds {
 
 RTPS_DllAPI const SubscriberQos SUBSCRIBER_QOS_DEFAULT;
 
+SubscriberQos::SubscriberQos()
+{
+}
+
+SubscriberQos::~SubscriberQos()
+{
+
+}
+
 void SubscriberQos::set_qos(
         const SubscriberQos& qos,
         bool first_time)
 {
-    if (first_time || !(presentation_== qos.presentation()))
+    if (first_time || !(presentation_ == qos.presentation()))
     {
         presentation_ = qos.presentation();
         presentation_.hasChanged = true;

--- a/src/cpp/fastdds/subscriber/qos/SubscriberQos.cpp
+++ b/src/cpp/fastdds/subscriber/qos/SubscriberQos.cpp
@@ -30,150 +30,38 @@ void SubscriberQos::set_qos(
         const SubscriberQos& qos,
         bool first_time)
 {
-    if (first_time)
+    if (first_time || !(presentation_== qos.presentation()))
     {
-        durability = qos.durability;
-        durability.hasChanged = true;
+        presentation_ = qos.presentation();
+        presentation_.hasChanged = true;
     }
-    if (first_time || deadline.period != qos.deadline.period)
+    if (qos.partition().names().size() > 0)
     {
-        deadline = qos.deadline;
-        deadline.hasChanged = true;
+        partition_ = qos.partition();
+        partition_.hasChanged = true;
     }
-    if (latency_budget.duration != qos.latency_budget.duration)
+    if (group_data_.getValue() != qos.group_data().getValue() )
     {
-        latency_budget = qos.latency_budget;
-        latency_budget.hasChanged = true;
+        group_data_ = qos.group_data();
+        group_data_.hasChanged = true;
     }
-    if (first_time)
+    if (entity_factory_.autoenable_created_entities != qos.entity_factory().autoenable_created_entities)
     {
-        liveliness = qos.liveliness;
-        liveliness.hasChanged = true;
-    }
-    if (first_time)
-    {
-        reliability = qos.reliability;
-        reliability.hasChanged = true;
-    }
-    if (first_time)
-    {
-        ownership = qos.ownership;
-        ownership.hasChanged = true;
-    }
-    if (destination_order.kind != qos.destination_order.kind)
-    {
-        destination_order = qos.destination_order;
-        destination_order.hasChanged = true;
-    }
-    if (user_data.data_vec() != qos.user_data.data_vec())
-    {
-        user_data = qos.user_data;
-        user_data.hasChanged = true;
-    }
-    if (time_based_filter.minimum_separation != qos.time_based_filter.minimum_separation )
-    {
-        time_based_filter = qos.time_based_filter;
-        time_based_filter.hasChanged = true;
-    }
-    if (first_time || presentation.access_scope != qos.presentation.access_scope ||
-            presentation.coherent_access != qos.presentation.coherent_access ||
-            presentation.ordered_access != qos.presentation.ordered_access)
-    {
-        presentation = qos.presentation;
-        presentation.hasChanged = true;
-    }
-    if (qos.partition.names().size() > 0)
-    {
-        partition = qos.partition;
-        partition.hasChanged = true;
-    }
-    if (topic_data.getValue() != qos.topic_data.getValue())
-    {
-        topic_data = qos.topic_data;
-        topic_data.hasChanged = true;
-    }
-    if (group_data.getValue() != qos.group_data.getValue() )
-    {
-        group_data = qos.group_data;
-        group_data.hasChanged = true;
-    }
-    if (first_time || durability_service.history_kind != qos.durability_service.history_kind ||
-            durability_service.history_depth != qos.durability_service.history_depth ||
-            durability_service.max_instances != qos.durability_service.max_instances ||
-            durability_service.max_samples != qos.durability_service.max_samples ||
-            durability_service.max_samples_per_instance != qos.durability_service.max_samples_per_instance ||
-            durability_service.service_cleanup_delay != qos.durability_service.service_cleanup_delay
-            )
-    {
-        durability_service = qos.durability_service;
-        durability_service.hasChanged = true;
-    }
-    if (lifespan.duration != qos.lifespan.duration )
-    {
-        lifespan = qos.lifespan;
-        lifespan.hasChanged = true;
-    }
-    if (first_time)
-    {
-        disable_positive_acks = qos.disable_positive_acks;
-        disable_positive_acks.hasChanged = true;
+        entity_factory_ = qos.entity_factory();
+        entity_factory_.hasChanged = true;
     }
 }
 
 bool SubscriberQos::check_qos() const
 {
-    using namespace fastrtps;
-    if (durability.kind == PERSISTENT_DURABILITY_QOS)
-    {
-        logError(RTPS_QOS_CHECK, "PERSISTENT Durability not supported");
-        return false;
-    }
-    if (destination_order.kind == BY_SOURCE_TIMESTAMP_DESTINATIONORDER_QOS)
-    {
-        logError(RTPS_QOS_CHECK, "BY SOURCE TIMESTAMP Destination_order not supported");
-        return false;
-    }
-    if (reliability.kind == BEST_EFFORT_RELIABILITY_QOS && ownership.kind == EXCLUSIVE_OWNERSHIP_QOS)
-    {
-        logError(RTPS_QOS_CHECK, "BEST_EFFORT incompatible with EXCLUSIVE ownership");
-        return false;
-    }
     return true;
 }
 
 bool SubscriberQos::can_qos_be_updated(
         const SubscriberQos& qos) const
 {
-    using namespace fastrtps;
-    bool updatable = true;
-    if (durability.kind != qos.durability.kind)
-    {
-        updatable = false;
-        logWarning(RTPS_QOS_CHECK, "Durability kind cannot be changed after the creation of a subscriber.");
-    }
-
-    if (liveliness.kind !=  qos.liveliness.kind)
-    {
-        updatable = false;
-        logWarning(RTPS_QOS_CHECK, "Liveliness Kind cannot be changed after the creation of a subscriber.");
-    }
-
-    if (reliability.kind != qos.reliability.kind)
-    {
-        updatable = false;
-        logWarning(RTPS_QOS_CHECK, "Reliability Kind cannot be changed after the creation of a subscriber.");
-    }
-    if (ownership.kind != qos.ownership.kind)
-    {
-        updatable = false;
-        logWarning(RTPS_QOS_CHECK, "Ownership Kind cannot be changed after the creation of a subscriber.");
-    }
-    if (destination_order.kind != qos.destination_order.kind)
-    {
-        updatable = false;
-        logWarning(RTPS_QOS_CHECK, "Destination order Kind cannot be changed after the creation of a subscriber.");
-    }
-    return updatable;
+    (void) qos;
+    return true;
 }
 
 } /* namespace dds */

--- a/test/dds/communication/Subscriber.cpp
+++ b/test/dds/communication/Subscriber.cpp
@@ -341,12 +341,12 @@ int main(
 
     //CREATE THE SUBSCRIBER
     //Domain::getDefaultSubscriberAttributes(subscriber_attributes);
-    g_subscriber_attributes.topic.topicKind = NO_KEY;
+    //g_subscriber_attributes.topic.topicKind = NO_KEY;
     //g_subscriber_attributes.topic.topicDataType = type.getName();
-    g_subscriber_attributes.topic.topicName = topic.str();
-    g_subscriber_attributes.qos.m_liveliness.lease_duration = 3;
-    g_subscriber_attributes.qos.m_liveliness.kind = eprosima::fastdds::dds::AUTOMATIC_LIVELINESS_QOS;
-    g_subscriber = participant->create_subscriber(SUBSCRIBER_QOS_DEFAULT, g_subscriber_attributes, &listener);
+    //g_subscriber_attributes.topic.topicName = topic.str();
+    //g_subscriber_attributes.qos.m_liveliness.lease_duration = 3;
+    //g_subscriber_attributes.qos.m_liveliness.kind = eprosima::fastdds::dds::AUTOMATIC_LIVELINESS_QOS;
+    g_subscriber = participant->create_subscriber(SUBSCRIBER_QOS_DEFAULT, &listener);
 
     if (g_subscriber == nullptr)
     {

--- a/test/unittest/dds/participant/ParticipantTests.cpp
+++ b/test/unittest/dds/participant/ParticipantTests.cpp
@@ -24,6 +24,7 @@
 #include <dds/domain/DomainParticipant.hpp>
 #include <dds/domain/qos/DomainParticipantQos.hpp>
 #include <dds/core/types.hpp>
+#include <dds/sub/Subscriber.hpp>
 
 namespace eprosima {
 namespace fastdds {
@@ -115,6 +116,15 @@ TEST(ParticipantTests, CreateSubscriber)
     Subscriber* subscriber = participant->create_subscriber(SUBSCRIBER_QOS_DEFAULT);
 
     ASSERT_NE(subscriber, nullptr);
+}
+
+TEST(ParticipantTests, CreatePSMSubscriber)
+{
+    ::dds::domain::DomainParticipant participant = ::dds::domain::DomainParticipant(0, PARTICIPANT_QOS_DEFAULT);
+    ::dds::sub::Subscriber subscriber = ::dds::core::null;
+    subscriber = ::dds::sub::Subscriber(participant);
+
+    ASSERT_NE(subscriber, ::dds::core::null);
 }
 
 } // namespace dds

--- a/test/unittest/dds/participant/ParticipantTests.cpp
+++ b/test/unittest/dds/participant/ParticipantTests.cpp
@@ -19,6 +19,8 @@
 #include <fastdds/dds/domain/qos/DomainParticipantQos.hpp>
 #include <fastdds/dds/publisher/Publisher.hpp>
 #include <fastdds/dds/publisher/qos/PublisherQos.hpp>
+#include <fastdds/dds/subscriber/Subscriber.hpp>
+#include <fastdds/dds/subscriber/qos/SubscriberQos.hpp>
 #include <dds/domain/DomainParticipant.hpp>
 #include <dds/domain/qos/DomainParticipantQos.hpp>
 #include <dds/core/types.hpp>
@@ -105,6 +107,14 @@ TEST(ParticipantTests, CreatePSMPublisher)
     publisher = ::dds::pub::Publisher(participant);
 
     ASSERT_NE(publisher, ::dds::core::null);
+}
+
+TEST(ParticipantTests, CreateSubscriber)
+{
+    DomainParticipant* participant = DomainParticipantFactory::get_instance()->create_participant(0);
+    Subscriber* subscriber = participant->create_subscriber(SUBSCRIBER_QOS_DEFAULT);
+
+    ASSERT_NE(subscriber, nullptr);
 }
 
 } // namespace dds

--- a/test/unittest/dds/participant/ParticipantTests.cpp
+++ b/test/unittest/dds/participant/ParticipantTests.cpp
@@ -25,6 +25,7 @@
 #include <dds/domain/qos/DomainParticipantQos.hpp>
 #include <dds/core/types.hpp>
 #include <dds/sub/Subscriber.hpp>
+#include <dds/pub/Publisher.hpp>
 
 namespace eprosima {
 namespace fastdds {

--- a/test/unittest/dds/participant/ParticipantTests.cpp
+++ b/test/unittest/dds/participant/ParticipantTests.cpp
@@ -122,7 +122,7 @@ TEST(ParticipantTests, CreatePSMSubscriber)
 {
     ::dds::domain::DomainParticipant participant = ::dds::domain::DomainParticipant(0, PARTICIPANT_QOS_DEFAULT);
     ::dds::sub::Subscriber subscriber = ::dds::core::null;
-    subscriber = ::dds::sub::Subscriber(participant);
+    subscriber = ::dds::sub::Subscriber(participant, SUBSCRIBER_QOS_DEFAULT);
 
     ASSERT_NE(subscriber, ::dds::core::null);
 }

--- a/test/xtypes/TestSubscriber.cpp
+++ b/test/xtypes/TestSubscriber.cpp
@@ -128,7 +128,7 @@ bool TestSubscriber::init(
     // Create sub and reader if topic was provided
     if (m_Type != nullptr)
     {
-        mp_subscriber = mp_participant->create_subscriber(SUBSCRIBER_QOS_DEFAULT, Rparam, nullptr);
+        mp_subscriber = mp_participant->create_subscriber(SUBSCRIBER_QOS_DEFAULT, nullptr);
 
         if (mp_subscriber == nullptr)
         {
@@ -303,7 +303,7 @@ DataReader* TestSubscriber::create_datareader()
         SubscriberAttributes Rparam;
         Rparam.topic = topic_att;
         Rparam.qos = reader_qos;
-        mp_subscriber = mp_participant->create_subscriber(SUBSCRIBER_QOS_DEFAULT, Rparam, nullptr);
+        mp_subscriber = mp_participant->create_subscriber(SUBSCRIBER_QOS_DEFAULT, nullptr);
 
         if (mp_subscriber == nullptr)
         {


### PR DESCRIPTION
- create_subscriber method following DDS standard
- unit test for create_subscriber
- link PSM Subscriber constructor to PIM implementation
- unit test for PSM Subscriber constructor

NOTE: This PR must be merged after #1073