### PR TITLE
Fixed deserialization of WriterProxyData <1.10.x>

### DIFF
--- a/src/cpp/rtps/builtin/data/WriterProxyData.cpp
+++ b/src/cpp/rtps/builtin/data/WriterProxyData.cpp
@@ -737,7 +737,6 @@ bool WriterProxyData::readFromCDRMessage(
                             return false;
                         }
 
-                        m_guid = p.guid;
                         memcpy(m_RTPSParticipantKey.value, p.guid.guidPrefix.value, 12);
                         memcpy(m_RTPSParticipantKey.value + 12, p.guid.entityId.value, 4);
                         break;
@@ -750,6 +749,7 @@ bool WriterProxyData::readFromCDRMessage(
                             return false;
                         }
 
+                        m_guid = p.guid;
                         memcpy(m_key.value, p.guid.guidPrefix.value, 12);
                         memcpy(m_key.value + 12, p.guid.entityId.value, 4);
                         break;


### PR DESCRIPTION
This solves an interoperability regression introduced by #1004
Signed-off-by: Miguel Company <MiguelCompany@eprosima.com>