### PR TITLE
DomainParticipant delete_subscriber

### DIFF
--- a/test/unittest/dds/participant/ParticipantTests.cpp
+++ b/test/unittest/dds/participant/ParticipantTests.cpp
@@ -144,6 +144,14 @@ TEST(ParticipantTests, DeletePublisher)
     ASSERT_TRUE(participant->delete_publisher(publisher) == ReturnCode_t::RETCODE_OK);
 }
 
+TEST(ParticipantTests, DeleteSubscriber)
+{
+    DomainParticipant* participant = DomainParticipantFactory::get_instance()->create_participant(0);
+    Subscriber* subscriber = participant->create_subscriber(SUBSCRIBER_QOS_DEFAULT);
+
+    ASSERT_TRUE(participant->delete_subscriber(subscriber) == ReturnCode_t::RETCODE_OK);
+}
+
 } // namespace dds
 } // namespace fastdds
 } // namespace eprosima


### PR DESCRIPTION
Just a unit test to check DomainParticipant::delete_subscriber

NOTE: This PR must be merged after #1117 