### PR TITLE
DomainParticipant get/set_default_subscriber_qos

### DIFF
--- a/include/fastdds/dds/core/policy/QosPolicies.hpp
+++ b/include/fastdds/dds/core/policy/QosPolicies.hpp
@@ -135,8 +135,7 @@ public:
             const EntityFactoryQosPolicy& b) const
     {
         return
-            (this->autoenable_created_entities == b.autoenable_created_entities) &&
-            QosPolicy::operator ==(b);
+            (this->autoenable_created_entities == b.autoenable_created_entities);
     }
 
     inline void clear() override

--- a/include/fastdds/dds/core/policy/QosPolicies.hpp
+++ b/include/fastdds/dds/core/policy/QosPolicies.hpp
@@ -108,7 +108,7 @@ protected:
     bool send_always_;
 };
 
-class EntityFactoryQosPolicy : public QosPolicy
+class EntityFactoryQosPolicy
 {
 public:
 
@@ -138,7 +138,7 @@ public:
             (this->autoenable_created_entities == b.autoenable_created_entities);
     }
 
-    inline void clear() override
+    inline void clear()
     {
         EntityFactoryQosPolicy reset = EntityFactoryQosPolicy();
         std::swap(*this, reset);

--- a/include/fastdds/dds/subscriber/qos/SubscriberQos.hpp
+++ b/include/fastdds/dds/subscriber/qos/SubscriberQos.hpp
@@ -38,9 +38,13 @@ class SubscriberQos
 {
 public:
 
-    RTPS_DllAPI SubscriberQos();
+    RTPS_DllAPI SubscriberQos()
+    {
+    }
 
-    RTPS_DllAPI virtual ~SubscriberQos();
+    RTPS_DllAPI virtual ~SubscriberQos()
+    {
+    }
 
     bool operator ==(
             const SubscriberQos& b) const
@@ -50,30 +54,6 @@ public:
                (group_data_ == b.group_data_) &&
                (entity_factory_ == b.entity_factory_);
     }
-
-    /**
-     * Set Qos from another class
-     * @param subscriberqos Reference from a SubscriberQos object.
-     * @param first_time Boolean indicating whether is the first time (If not some parameters cannot be set).
-     */
-    RTPS_DllAPI void set_qos(
-            const SubscriberQos& subscriberqos,
-            bool first_time);
-
-    /**
-     * Check if the Qos values are compatible between each other.
-     * @return True if correct.
-     */
-    RTPS_DllAPI bool check_qos() const;
-
-    /**
-     * Check if the Qos can be update with the values provided. This method DOES NOT update anything.
-     * @param qos Reference to the new qos.
-     * @return True if they can be updated.
-     */
-    RTPS_DllAPI bool can_qos_be_updated(
-            const SubscriberQos& qos) const;
-
 
     /**
      * Getter for PresentationQosPolicy

--- a/include/fastrtps/types/TypesBase.h
+++ b/include/fastrtps/types/TypesBase.h
@@ -218,7 +218,7 @@ public:
 
     explicit operator bool() = delete;
 
-    bool operator !()
+    bool operator !() const
     {
         return value_ != ReturnCode_t::RETCODE_OK.value_;
     }
@@ -231,18 +231,18 @@ public:
     }
 
     bool operator ==(
-            const ReturnCode_t& c)
+            const ReturnCode_t& c) const
     {
         return value_ == c.value_;
     }
 
     bool operator !=(
-            const ReturnCode_t& c)
+            const ReturnCode_t& c) const
     {
         return value_ != c.value_;
     }
 
-    uint32_t operator ()()
+    uint32_t operator ()() const
     {
         return value_;
     }

--- a/src/cpp/dds/domain/DomainParticipant.cpp
+++ b/src/cpp/dds/domain/DomainParticipant.cpp
@@ -133,17 +133,21 @@ DomainParticipant& DomainParticipant::default_publisher_qos(
     return *this;
 }
 
-//dds::sub::qos::SubscriberQos DomainParticipant::default_subscriber_qos() const
-//{
-//    return this->delegate()->get_default_subscriber_qos();
-//}
+dds::sub::qos::SubscriberQos DomainParticipant::default_subscriber_qos() const
+{
+    return this->delegate()->get_default_subscriber_qos();
+}
 
-//DomainParticipant& DomainParticipant::default_subscriber_qos(
-//        const ::dds::sub::qos::SubscriberQos& qos)
-//{
-//    this->delegate()->set_default_subscriber_qos(qos);
-//    return *this;
-//}
+DomainParticipant& DomainParticipant::default_subscriber_qos(
+        const ::dds::sub::qos::SubscriberQos& qos)
+{
+    if (this->delegate()->set_default_subscriber_qos(qos) ==
+            ReturnCode_t::RETCODE_INCONSISTENT_POLICY)
+    {
+        throw dds::core::InconsistentPolicyError("Inconsistent Qos");
+    }
+    return *this;
+}
 
 //dds::topic::qos::TopicQos DomainParticipant::default_topic_qos() const
 //{

--- a/src/cpp/dds/domain/DomainParticipant.cpp
+++ b/src/cpp/dds/domain/DomainParticipant.cpp
@@ -141,10 +141,14 @@ dds::sub::qos::SubscriberQos DomainParticipant::default_subscriber_qos() const
 DomainParticipant& DomainParticipant::default_subscriber_qos(
         const ::dds::sub::qos::SubscriberQos& qos)
 {
-    if (this->delegate()->set_default_subscriber_qos(qos) ==
-            ReturnCode_t::RETCODE_INCONSISTENT_POLICY)
+    ReturnCode_t result = delegate()->set_default_subscriber_qos(qos);
+    if (result == ReturnCode_t::RETCODE_INCONSISTENT_POLICY)
     {
         throw dds::core::InconsistentPolicyError("Inconsistent Qos");
+    }
+    if (result == ReturnCode_t::RETCODE_UNSUPPORTED)
+    {
+        throw dds::core::UnsupportedError("Unsupported Qos");
     }
     return *this;
 }

--- a/src/cpp/fastdds/domain/DomainParticipantImpl.cpp
+++ b/src/cpp/fastdds/domain/DomainParticipantImpl.cpp
@@ -348,12 +348,12 @@ ReturnCode_t DomainParticipantImpl::set_default_subscriber_qos(
 {
     if (&qos == &SUBSCRIBER_QOS_DEFAULT)
     {
-        default_sub_qos_.set_qos(SUBSCRIBER_QOS_DEFAULT, true);
+        SubscriberImpl::set_qos(default_sub_qos_, SUBSCRIBER_QOS_DEFAULT, true);
         return ReturnCode_t::RETCODE_OK;
     }
-    else if (qos.check_qos())
+    else if (SubscriberImpl::check_qos(qos))
     {
-        default_sub_qos_.set_qos(qos, false);
+        SubscriberImpl::set_qos(default_sub_qos_, qos, false);
         return ReturnCode_t::RETCODE_OK;
     }
     return ReturnCode_t::RETCODE_INCONSISTENT_POLICY;
@@ -471,7 +471,7 @@ Subscriber* DomainParticipantImpl::create_subscriber(
         SubscriberListener* listener,
         const StatusMask& mask)
 {
-    if (!qos.check_qos())
+    if (!SubscriberImpl::check_qos(qos))
     {
         return nullptr;
     }

--- a/src/cpp/fastdds/domain/DomainParticipantImpl.cpp
+++ b/src/cpp/fastdds/domain/DomainParticipantImpl.cpp
@@ -81,6 +81,7 @@ DomainParticipantImpl::DomainParticipantImpl(
     , rtps_participant_(nullptr)
     , participant_(dp)
     , listener_(listen)
+    , default_sub_qos_(SUBSCRIBER_QOS_DEFAULT)
 #pragma warning (disable : 4355 )
     , rtps_listener_(this)
 {
@@ -343,7 +344,7 @@ const fastdds::dds::PublisherQos& DomainParticipantImpl::get_default_publisher_q
 }
 
 ReturnCode_t DomainParticipantImpl::set_default_subscriber_qos(
-        const fastdds::dds::SubscriberQos& qos)
+        const SubscriberQos& qos)
 {
     if (&qos == &SUBSCRIBER_QOS_DEFAULT)
     {
@@ -358,7 +359,7 @@ ReturnCode_t DomainParticipantImpl::set_default_subscriber_qos(
     return ReturnCode_t::RETCODE_INCONSISTENT_POLICY;
 }
 
-const fastdds::dds::SubscriberQos& DomainParticipantImpl::get_default_subscriber_qos() const
+const SubscriberQos& DomainParticipantImpl::get_default_subscriber_qos() const
 {
     return default_sub_qos_;
 }

--- a/src/cpp/fastdds/domain/DomainParticipantImpl.cpp
+++ b/src/cpp/fastdds/domain/DomainParticipantImpl.cpp
@@ -351,12 +351,13 @@ ReturnCode_t DomainParticipantImpl::set_default_subscriber_qos(
         SubscriberImpl::set_qos(default_sub_qos_, SUBSCRIBER_QOS_DEFAULT, true);
         return ReturnCode_t::RETCODE_OK;
     }
-    else if (SubscriberImpl::check_qos(qos))
+    ReturnCode_t check_result = SubscriberImpl::check_qos(qos);
+    if (!check_result)
     {
-        SubscriberImpl::set_qos(default_sub_qos_, qos, false);
-        return ReturnCode_t::RETCODE_OK;
+        return check_result;
     }
-    return ReturnCode_t::RETCODE_INCONSISTENT_POLICY;
+    SubscriberImpl::set_qos(default_sub_qos_, qos, true);
+    return ReturnCode_t::RETCODE_OK;
 }
 
 const SubscriberQos& DomainParticipantImpl::get_default_subscriber_qos() const

--- a/src/cpp/fastdds/domain/DomainParticipantImpl.hpp
+++ b/src/cpp/fastdds/domain/DomainParticipantImpl.hpp
@@ -186,9 +186,9 @@ public:
     const fastdds::dds::PublisherQos& get_default_publisher_qos() const;
 
     ReturnCode_t set_default_subscriber_qos(
-            const fastdds::dds::SubscriberQos& qos);
+            const SubscriberQos& qos);
 
-    const fastdds::dds::SubscriberQos& get_default_subscriber_qos() const;
+    const SubscriberQos& get_default_subscriber_qos() const;
 
     // TODO Get/Set default Topic Qos
 

--- a/src/cpp/fastdds/subscriber/SubscriberImpl.cpp
+++ b/src/cpp/fastdds/subscriber/SubscriberImpl.cpp
@@ -90,13 +90,13 @@ const SubscriberQos& SubscriberImpl::get_qos() const
 ReturnCode_t SubscriberImpl::set_qos(
         const SubscriberQos& qos)
 {
-    if (!qos.check_qos())
+    if (!check_qos(qos))
     {
-        if (!qos_.can_qos_be_updated(qos))
+        if (!can_qos_be_updated(qos_, qos))
         {
             return ReturnCode_t::RETCODE_IMMUTABLE_POLICY;
         }
-        qos_.set_qos(qos, false);
+        set_qos(qos_, qos, false);
         return ReturnCode_t::RETCODE_OK;
     }
     return ReturnCode_t::RETCODE_INCONSISTENT_POLICY;
@@ -458,6 +458,50 @@ bool SubscriberImpl::type_in_use(
         }
     }
     return false;
+}
+
+
+void SubscriberImpl::set_qos(
+        SubscriberQos& to,
+        const SubscriberQos& from,
+        bool first_time)
+{
+    if (first_time || !(to.presentation() == from.presentation()))
+    {
+        to.presentation() = from.presentation();
+        to.presentation().hasChanged = true;
+    }
+    if (from.partition().names().size() > 0)
+    {
+        to.partition() = from.partition();
+        to.partition().hasChanged = true;
+    }
+    if (to.group_data().getValue() != from.group_data().getValue() )
+    {
+        to.group_data() = from.group_data();
+        to.group_data().hasChanged = true;
+    }
+    if (to.entity_factory().autoenable_created_entities != from.entity_factory().autoenable_created_entities)
+    {
+        to.entity_factory() = from.entity_factory();
+        to.entity_factory().hasChanged = true;
+    }
+}
+
+bool SubscriberImpl::check_qos(
+        const SubscriberQos& qos)
+{
+    (void) qos;
+    return true;
+}
+
+bool SubscriberImpl::can_qos_be_updated(
+        const SubscriberQos& to,
+        const SubscriberQos& from)
+{
+    (void) to;
+    (void) from;
+    return true;
 }
 
 } /* namespace dds */

--- a/src/cpp/fastdds/subscriber/SubscriberImpl.cpp
+++ b/src/cpp/fastdds/subscriber/SubscriberImpl.cpp
@@ -90,16 +90,17 @@ const SubscriberQos& SubscriberImpl::get_qos() const
 ReturnCode_t SubscriberImpl::set_qos(
         const SubscriberQos& qos)
 {
-    if (!check_qos(qos))
+    ReturnCode_t check_result = SubscriberImpl::check_qos(qos);
+    if (!check_result)
     {
-        if (!can_qos_be_updated(qos_, qos))
-        {
-            return ReturnCode_t::RETCODE_IMMUTABLE_POLICY;
-        }
-        set_qos(qos_, qos, false);
-        return ReturnCode_t::RETCODE_OK;
+        return check_result;
     }
-    return ReturnCode_t::RETCODE_INCONSISTENT_POLICY;
+    if (!can_qos_be_updated(qos_, qos))
+    {
+        return ReturnCode_t::RETCODE_IMMUTABLE_POLICY;
+    }
+    set_qos(qos_, qos, false);
+    return ReturnCode_t::RETCODE_OK;
 }
 
 const SubscriberListener* SubscriberImpl::get_listener() const
@@ -484,15 +485,14 @@ void SubscriberImpl::set_qos(
     if (to.entity_factory().autoenable_created_entities != from.entity_factory().autoenable_created_entities)
     {
         to.entity_factory() = from.entity_factory();
-        to.entity_factory().hasChanged = true;
     }
 }
 
-bool SubscriberImpl::check_qos(
+ReturnCode_t SubscriberImpl::check_qos(
         const SubscriberQos& qos)
 {
     (void) qos;
-    return true;
+    return ReturnCode_t::RETCODE_OK;
 }
 
 bool SubscriberImpl::can_qos_be_updated(

--- a/src/cpp/fastdds/subscriber/SubscriberImpl.hpp
+++ b/src/cpp/fastdds/subscriber/SubscriberImpl.hpp
@@ -162,6 +162,35 @@ public:
     bool type_in_use(
             const std::string& type_name) const;
 
+    /**
+     * Set Qos from another instance
+     * @param to Reference to the qos instance to be changed.
+     * @param from Reference to the qos instance with the new values.
+     * @param first_time Boolean indicating whether is the first time (If not some parameters cannot be set).
+     */
+    static void set_qos(
+            SubscriberQos& to,
+            const SubscriberQos& from,
+            bool first_time);
+
+    /**
+     * Check if the Qos values are compatible between each other.
+     * @param qos Reference to the qos instance to check.
+     * @return True if correct.
+     */
+    static bool check_qos(
+            const SubscriberQos& qos);
+
+    /**
+     * Check if the Qos can be update with the values provided. This method DOES NOT update anything.
+     * @param to Reference to the qos instance to be changed.
+     * @param from Reference to the qos instance with the new values.
+     * @return True if they can be updated.
+     */
+    static bool can_qos_be_updated(
+            const SubscriberQos& to,
+            const SubscriberQos& from);
+
 private:
 
     //!Participant

--- a/src/cpp/fastdds/subscriber/SubscriberImpl.hpp
+++ b/src/cpp/fastdds/subscriber/SubscriberImpl.hpp
@@ -178,7 +178,7 @@ public:
      * @param qos Reference to the qos instance to check.
      * @return True if correct.
      */
-    static bool check_qos(
+    static ReturnCode_t check_qos(
             const SubscriberQos& qos);
 
     /**

--- a/src/cpp/fastdds/subscriber/qos/SubscriberQos.cpp
+++ b/src/cpp/fastdds/subscriber/qos/SubscriberQos.cpp
@@ -26,53 +26,6 @@ namespace dds {
 
 RTPS_DllAPI const SubscriberQos SUBSCRIBER_QOS_DEFAULT;
 
-SubscriberQos::SubscriberQos()
-{
-}
-
-SubscriberQos::~SubscriberQos()
-{
-
-}
-
-void SubscriberQos::set_qos(
-        const SubscriberQos& qos,
-        bool first_time)
-{
-    if (first_time || !(presentation_ == qos.presentation()))
-    {
-        presentation_ = qos.presentation();
-        presentation_.hasChanged = true;
-    }
-    if (qos.partition().names().size() > 0)
-    {
-        partition_ = qos.partition();
-        partition_.hasChanged = true;
-    }
-    if (group_data_.getValue() != qos.group_data().getValue() )
-    {
-        group_data_ = qos.group_data();
-        group_data_.hasChanged = true;
-    }
-    if (entity_factory_.autoenable_created_entities != qos.entity_factory().autoenable_created_entities)
-    {
-        entity_factory_ = qos.entity_factory();
-        entity_factory_.hasChanged = true;
-    }
-}
-
-bool SubscriberQos::check_qos() const
-{
-    return true;
-}
-
-bool SubscriberQos::can_qos_be_updated(
-        const SubscriberQos& qos) const
-{
-    (void) qos;
-    return true;
-}
-
 } /* namespace dds */
 } /* namespace fastdds */
 } /* namespace eprosima */

--- a/test/unittest/dds/participant/ParticipantTests.cpp
+++ b/test/unittest/dds/participant/ParticipantTests.cpp
@@ -136,6 +136,26 @@ TEST(ParticipantTests, CreatePSMSubscriber)
     ASSERT_NE(subscriber, ::dds::core::null);
 }
 
+TEST(ParticipantTests, ChangeDefaultSubscriberQos)
+{
+    DomainParticipant* participant = DomainParticipantFactory::get_instance()->create_participant(0);
+
+    SubscriberQos qos;
+    ASSERT_EQ(participant->get_default_subscriber_qos(qos), ReturnCode_t::RETCODE_OK);
+
+    ASSERT_EQ(qos, SUBSCRIBER_QOS_DEFAULT);
+
+    qos.entity_factory.autoenable_created_entities = false;
+
+    ASSERT_EQ(participant->set_default_subscriber_qos(qos), ReturnCode_t::RETCODE_OK);
+
+    SubscriberQos pqos;
+    ASSERT_EQ(participant->get_default_subscriber_qos(pqos), ReturnCode_t::RETCODE_OK);
+
+    ASSERT_TRUE(pqos == qos);
+    ASSERT_EQ(pqos.entity_factory.autoenable_created_entities, false);
+}
+
 } // namespace dds
 } // namespace fastdds
 } // namespace eprosima

--- a/test/unittest/dds/participant/ParticipantTests.cpp
+++ b/test/unittest/dds/participant/ParticipantTests.cpp
@@ -146,7 +146,7 @@ TEST(ParticipantTests, ChangeDefaultSubscriberQos)
 
     ASSERT_EQ(qos, SUBSCRIBER_QOS_DEFAULT);
 
-    qos.entity_factory.autoenable_created_entities = false;
+    qos.entity_factory().autoenable_created_entities = false;
 
     ASSERT_EQ(participant->set_default_subscriber_qos(qos), ReturnCode_t::RETCODE_OK);
 
@@ -154,7 +154,7 @@ TEST(ParticipantTests, ChangeDefaultSubscriberQos)
     ASSERT_EQ(participant->get_default_subscriber_qos(pqos), ReturnCode_t::RETCODE_OK);
 
     ASSERT_TRUE(pqos == qos);
-    ASSERT_EQ(pqos.entity_factory.autoenable_created_entities, false);
+    ASSERT_EQ(pqos.entity_factory().autoenable_created_entities, false);
 }
 
 TEST(ParticipantTests, ChangePSMDefaultSubscriberQos)
@@ -163,14 +163,14 @@ TEST(ParticipantTests, ChangePSMDefaultSubscriberQos)
     ::dds::sub::qos::SubscriberQos qos = participant.default_subscriber_qos();
     ASSERT_EQ(qos, SUBSCRIBER_QOS_DEFAULT);
 
-    qos.entity_factory.autoenable_created_entities = false;
+    qos.entity_factory().autoenable_created_entities = false;
 
     ASSERT_NO_THROW(participant.default_subscriber_qos(qos));
 
     ::dds::sub::qos::SubscriberQos pqos = participant.default_subscriber_qos();
 
     ASSERT_TRUE(qos == pqos);
-    ASSERT_EQ(pqos.entity_factory.autoenable_created_entities, false);
+    ASSERT_EQ(pqos.entity_factory().autoenable_created_entities, false);
 }
 
 } // namespace dds

--- a/test/unittest/dds/participant/ParticipantTests.cpp
+++ b/test/unittest/dds/participant/ParticipantTests.cpp
@@ -23,6 +23,7 @@
 #include <fastdds/dds/subscriber/qos/SubscriberQos.hpp>
 #include <dds/domain/DomainParticipant.hpp>
 #include <dds/domain/qos/DomainParticipantQos.hpp>
+#include <dds/sub/qos/SubscriberQos.hpp>
 #include <dds/core/types.hpp>
 #include <dds/sub/Subscriber.hpp>
 #include <dds/pub/Publisher.hpp>
@@ -153,6 +154,22 @@ TEST(ParticipantTests, ChangeDefaultSubscriberQos)
     ASSERT_EQ(participant->get_default_subscriber_qos(pqos), ReturnCode_t::RETCODE_OK);
 
     ASSERT_TRUE(pqos == qos);
+    ASSERT_EQ(pqos.entity_factory.autoenable_created_entities, false);
+}
+
+TEST(ParticipantTests, ChangePSMDefaultSubscriberQos)
+{
+    ::dds::domain::DomainParticipant participant = ::dds::domain::DomainParticipant(0, PARTICIPANT_QOS_DEFAULT);
+    ::dds::sub::qos::SubscriberQos qos = participant.default_subscriber_qos();
+    ASSERT_EQ(qos, SUBSCRIBER_QOS_DEFAULT);
+
+    qos.entity_factory.autoenable_created_entities = false;
+
+    ASSERT_NO_THROW(participant.default_subscriber_qos(qos));
+
+    ::dds::sub::qos::SubscriberQos pqos = participant.default_subscriber_qos();
+
+    ASSERT_TRUE(qos == pqos);
     ASSERT_EQ(pqos.entity_factory.autoenable_created_entities, false);
 }
 


### PR DESCRIPTION
- Implementation of get/set_default_subscriber_qos on PIM
- Unit test for get/set_default_subscriber_qos on PIM
- link PSM get/set_default_subscriber_qos methods to PIM
- Unit test for get/set_default_subscriber_qos on PSM

NOTE: This PR must be merged after #1073