### PR TITLE
SHM fault tolerance <1.10.x> [8118]

### DIFF
--- a/examples/C++/HelloWorldExampleSharedMem/HelloWorld_main.cpp
+++ b/examples/C++/HelloWorldExampleSharedMem/HelloWorld_main.cpp
@@ -31,7 +31,7 @@ int main(
         char** argv)
 {
     Log::SetVerbosity(Log::Warning);
-    //Log::SetCategoryFilter(std::regex("RTPS_EDP_MATCH|RTPS_PDP_DISCOVERY|RTPS_PARTICIPANT_LISTEN|SHM"));
+    //Log::SetCategoryFilter(std::regex("RTPS_TRANSPORT_SHM"));
 
 
     std::cout << "Starting "<< std::endl;

--- a/src/cpp/rtps/transport/shared_mem/MultiProducerConsumerRingBuffer.hpp
+++ b/src/cpp/rtps/transport/shared_mem/MultiProducerConsumerRingBuffer.hpp
@@ -296,9 +296,9 @@ public:
      * Copies the currenty enqueued cells to a vector
      * @param [out] enqueued_cells pointers vector to where cells will be copied.
      * @remark This is an unsafe operation, that means the caller must assure
-     * that no write operations are perform on the buffer while executing the copy.
+     * that no write operations are performed on the buffer while executing the copy.
      */
-        void copy(
+    void copy(
             std::vector<const T*>* enqueued_cells)
     {
         if (node_->registered_listeners_ > 0)
@@ -352,7 +352,7 @@ private:
         return (loop_flag << 31) | value;
     }
 
-        uint32_t pointer_to_head(
+    uint32_t pointer_to_head(
             const Pointer& pointer) const
     {
         // Init the head as write pointer in previous loop
@@ -367,7 +367,7 @@ private:
         }
 
         // Skip the free cells
-        value = value + pointer.free_cells % node_->total_cells_;
+        value = (value + pointer.free_cells) % node_->total_cells_;
 
         // Bit 31 is loop_flag, 0-30 are value
         return (loop_flag << 31) | value;

--- a/src/cpp/rtps/transport/shared_mem/MultiProducerConsumerRingBuffer.hpp
+++ b/src/cpp/rtps/transport/shared_mem/MultiProducerConsumerRingBuffer.hpp
@@ -103,7 +103,7 @@ public:
          * if the counter reaches 0 the cell becomes dirty
          * and free_cells are incremented
          * @return true if the cell ref_counter is 0 after pop
-         * @throw int if buffer is empty
+         * @throw std::exception if buffer is empty
          */
         bool pop()
         {
@@ -292,6 +292,36 @@ public:
         node->pointer_.store({0,total_cells}, std::memory_order_relaxed);
     }
 
+    /**
+     * Copies the currenty enqueued cells to a vector
+     * @param [out] enqueued_cells pointers vector to where cells will be copied.
+     * @remark This is an unsafe operation, that means the caller must assure
+     * that no write operations are perform on the buffer while executing the copy.
+     */
+        void copy(
+            std::vector<const T*>* enqueued_cells)
+    {
+        if (node_->registered_listeners_ > 0)
+        {
+            auto pointer = node_->pointer_.load(std::memory_order_relaxed);
+
+            uint32_t p = pointer_to_head(pointer);
+
+            while (p != pointer.write_p)
+            {
+                auto cell = &cells_[get_pointer_value(p)];
+
+                // If the cell has not been read by any listener
+                if (cell->ref_counter() > 0)
+                {
+                    enqueued_cells->push_back(&cell->data());
+                }
+
+                p = inc_pointer(p);
+            }
+        }
+    }
+
 private:
 
     Node* node_;
@@ -306,7 +336,7 @@ private:
     }
 
     uint32_t inc_pointer(
-            const uint32_t pointer)
+            const uint32_t pointer) const
     {
         uint32_t value = pointer & 0x7FFFFFFF;
         uint32_t loop_flag = pointer >> 31;
@@ -317,6 +347,27 @@ private:
         {
             loop_flag ^= 1;
         }
+
+        // Bit 31 is loop_flag, 0-30 are value
+        return (loop_flag << 31) | value;
+    }
+
+        uint32_t pointer_to_head(
+            const Pointer& pointer) const
+    {
+        // Init the head as write pointer in previous loop
+        uint32_t head = pointer.write_p ^ 0x80000000;
+
+        uint32_t value = head & 0x7FFFFFFF;
+        uint32_t loop_flag = head >> 31;
+
+        if (value +  pointer.free_cells >= node_->total_cells_)
+        {
+            loop_flag ^= 1;
+        }
+
+        // Skip the free cells
+        value = value + pointer.free_cells % node_->total_cells_;
 
         // Bit 31 is loop_flag, 0-30 are value
         return (loop_flag << 31) | value;

--- a/src/cpp/rtps/transport/shared_mem/SharedMemGlobal.hpp
+++ b/src/cpp/rtps/transport/shared_mem/SharedMemGlobal.hpp
@@ -578,7 +578,7 @@ public:
                 status.is_waiting = 0;
 
             }
-            catch (const std::exception& e)
+            catch (const std::exception&)
             {
                 node_->is_port_ok = false;
                 throw;
@@ -884,7 +884,12 @@ private:
             port_node->port_wait_timeout_ms = healthy_check_timeout_ms / 3;
             port_node->max_buffer_descriptors = max_buffer_descriptors;
             memset(port_node->listeners_status, 0, sizeof(port_node->listeners_status));
+#ifdef _MSC_VER
+            strncpy_s(port_node->domain_name, sizeof(port_node->domain_name), 
+                domain_name_.c_str(), sizeof(port_node->domain_name)-1); 
+#else
             strncpy(port_node->domain_name, domain_name_.c_str(), sizeof(port_node->domain_name)-1); 
+#endif
             port_node->domain_name[sizeof(port_node->domain_name)-1] = 0;
 
             // Buffer cells allocation

--- a/src/cpp/rtps/transport/shared_mem/SharedMemGlobal.hpp
+++ b/src/cpp/rtps/transport/shared_mem/SharedMemGlobal.hpp
@@ -39,7 +39,7 @@ public:
     // Long names for SHM files could cause problems on some platforms
     static constexpr uint32_t MAX_DOMAIN_NAME_LENGTH = 16; 
 
-        SharedMemGlobal(
+    SharedMemGlobal(
         const std::string& domain_name)
         : domain_name_(domain_name)
     {
@@ -223,8 +223,12 @@ public:
              */
             void wake_up()
             {
-                std::lock_guard<std::mutex> lock(wake_run_mutex_);
-                wake_run_ = true;
+                {
+                    std::lock_guard<std::mutex> lock(wake_run_mutex_);
+                    wake_run_ = true;
+                }
+                
+                wake_run_cv_.notify_one();
             }
 
         private:

--- a/src/cpp/rtps/transport/shared_mem/SharedMemGlobal.hpp
+++ b/src/cpp/rtps/transport/shared_mem/SharedMemGlobal.hpp
@@ -36,11 +36,17 @@ class SharedMemGlobal
 {
 public:
 
+    struct BufferDescriptor;
+    typedef std::function<void(const std::vector<
+                const SharedMemGlobal::BufferDescriptor*>&,
+                const std::string& domain_name)> PortFailureHandler;
+
     // Long names for SHM files could cause problems on some platforms
     static constexpr uint32_t MAX_DOMAIN_NAME_LENGTH = 16; 
 
     SharedMemGlobal(
-        const std::string& domain_name)
+        const std::string& domain_name,
+        PortFailureHandler failure_handler)
         : domain_name_(domain_name)
     {
         if (domain_name.length() > MAX_DOMAIN_NAME_LENGTH)
@@ -51,6 +57,8 @@ public:
                     std::to_string(MAX_DOMAIN_NAME_LENGTH) +
                     " characters");
         }
+
+        Port::on_failure_buffer_descriptors_handler(failure_handler);
     }
 
     ~SharedMemGlobal()
@@ -227,7 +235,7 @@ public:
                     std::lock_guard<std::mutex> lock(wake_run_mutex_);
                     wake_run_ = true;
                 }
-                
+
                 wake_run_cv_.notify_one();
             }
 

--- a/src/cpp/rtps/transport/shared_mem/SharedMemManager.hpp
+++ b/src/cpp/rtps/transport/shared_mem/SharedMemManager.hpp
@@ -57,7 +57,13 @@ public:
 
     SharedMemManager(
             const std::string& domain_name)
-        : global_segment_(domain_name)
+        : global_segment_(
+            domain_name,
+            []( const std::vector<const SharedMemGlobal::BufferDescriptor*>& buffer_descriptors,
+                    const std::string& domain_name) 
+                    {
+                        on_failure_buffer_descriptor_handler(buffer_descriptors, domain_name);
+                    })
     {
         if (domain_name.length() > SharedMemGlobal::MAX_DOMAIN_NAME_LENGTH)
         {
@@ -621,6 +627,15 @@ public:
         return std::make_shared<Port>(this,
                        global_segment_.open_port(port_id, max_descriptors, healthy_check_timeout_ms, open_mode),
                        open_mode);
+    }
+
+    /**
+     * @return Pointer to the underlying global segment. The pointer is only valid
+     * while this SharedMemManager is alive. 
+     */
+    SharedMemGlobal* global_segment()
+    {
+        return &global_segment_;
     }
 
     private:

--- a/src/cpp/rtps/transport/shared_mem/SharedMemManager.hpp
+++ b/src/cpp/rtps/transport/shared_mem/SharedMemManager.hpp
@@ -41,7 +41,7 @@ private:
     {
         struct
         {
-            std::atomic<uint32_t> ref_count;
+            std::atomic<int> ref_count;
             uint32_t data_size;
         }header;
         uint8_t data[1];
@@ -59,6 +59,23 @@ public:
             const std::string& domain_name)
         : global_segment_(domain_name)
     {
+        if (domain_name.length() > SharedMemGlobal::MAX_DOMAIN_NAME_LENGTH)
+        {
+            throw std::runtime_error(
+                    domain_name +
+                    " too long for domain name (max " +
+                    std::to_string(SharedMemGlobal::MAX_DOMAIN_NAME_LENGTH) +
+                    " characters");
+        }
+
+        SharedMemGlobal::Port::on_failure_buffer_descriptors_handler(
+            []( const std::vector<const SharedMemGlobal::BufferDescriptor*>& buffer_descriptors,
+                const std::string& domain_name) 
+                {
+                    on_failure_buffer_descriptor_handler(buffer_descriptors, domain_name);
+                }
+        );
+            
         per_allocation_extra_size_ =
                 SharedMemSegment::compute_per_allocation_extra_size(std::alignment_of<BufferNode>::value);
     }
@@ -280,7 +297,9 @@ public:
             auto node_it = allocated_nodes_.begin();
             while (node_it != allocated_nodes_.end())
             {
-                if ((*node_it)->header.ref_count.load() == 0)
+                // This shouldn't normally be negative, but when processes crashes
+                // due to fault-tolerance mecanishms it could happen.
+                if ((*node_it)->header.ref_count.load() <= 0)
                 {
                     release_buffer(*node_it);
 
@@ -337,59 +356,120 @@ public:
     public:
 
         Listener(
-                SharedMemManager& shared_mem_manager,
+                SharedMemManager* shared_mem_manager,
                 std::shared_ptr<SharedMemGlobal::Port> port)
             : global_port_(port)
             , shared_mem_manager_(shared_mem_manager)
             , is_closed_(false)
         {
-            global_listener_ = global_port_->create_listener();
+            global_listener_ = global_port_->create_listener(&listener_index_);
         }
 
+        ~Listener()
+        {
+            global_listener_.reset();
+            if (global_port_)
+            {
+                global_port_->unregister_listener();
+            }
+        }
+
+        Listener& operator = (
+                Listener&& other)
+        {
+            global_listener_ = other.global_listener_;
+            other.global_listener_.reset();
+            global_port_ = other.global_port_;
+            other.global_port_.reset();
+            shared_mem_manager_ = other.shared_mem_manager_;
+            is_closed_.exchange(other.is_closed_);
+
+            return *this;
+        }
+                
         /**
          * Extract the first buffer enqued in the port.
          * If the queue is empty, blocks until a buffer is pushed
          * to the port.
+         * @return A shared_ptr to the buffer, this shared_ptr can be nullptr if the 
+         * wait was interrupted because errors or close operations.
          * @remark Multithread not supported.
          */
         std::shared_ptr<Buffer> pop()
         {
-            bool was_cell_freed;
             std::shared_ptr<Buffer> buffer_ref;
 
-            SharedMemGlobal::PortCell* head_cell = nullptr;
-
-            while ( !is_closed_.load() && nullptr == (head_cell = global_listener_->head()) )
+            try
             {
-                // Wait until threre's data to pop
-                global_port_->wait_pop(*global_listener_, is_closed_);
+                bool was_cell_freed;
+                
+                SharedMemGlobal::PortCell* head_cell = nullptr;
+
+                while ( !is_closed_.load() && nullptr == (head_cell = global_listener_->head()) )
+                {
+                    // Wait until there's data to pop
+                    global_port_->wait_pop(*global_listener_, is_closed_, listener_index_);
+                }
+
+                if (!head_cell)
+                {
+                    return nullptr;
+                }
+
+                if (!global_port_->is_port_ok())
+                {
+                    throw std::runtime_error("");
+                }
+
+                SharedMemGlobal::BufferDescriptor buffer_descriptor = head_cell->data();
+
+                SegmentNode* segment_node;
+                auto segment = shared_mem_manager_->find_segment(buffer_descriptor.source_segment_id, &segment_node);
+                auto buffer_node =
+                        static_cast<BufferNode*>(segment->get_address_from_offset(buffer_descriptor.buffer_node_offset));
+
+                // TODO(Adolfo) : Dynamic allocation. Use foonathan to convert it to static allocation
+                buffer_ref = std::make_shared<SharedMemBuffer>(segment, buffer_descriptor.source_segment_id, buffer_node,
+                                segment_node);
+
+                // If the cell has been read by all listeners
+                global_port_->pop(*global_listener_, was_cell_freed);
+
+                if (was_cell_freed)
+                {
+                    buffer_node->header.ref_count.fetch_sub(1);
+                }
             }
+            catch(const std::exception& e)
+            {   
+                if (global_port_->is_port_ok())
+                {
+                    throw;
+                }
+                else
+                {
+                    logWarning(RTPS_TRANSPORT_SHM, "SHM Listener on port " << global_port_->port_id() << " failure: "
+                        << e.what());
 
-            if (!head_cell)
-            {
-                return nullptr;
-            }
-
-            SharedMemGlobal::BufferDescriptor buffer_descriptor = head_cell->data();
-
-            SegmentNode* segment_node;
-            auto segment = shared_mem_manager_.find_segment(buffer_descriptor.source_segment_id, &segment_node);
-            auto buffer_node =
-                    static_cast<BufferNode*>(segment->get_address_from_offset(buffer_descriptor.buffer_node_offset));
-
-            // TODO(Adolfo) : Dynamic allocation. Use foonathan to convert it to static allocation
-            buffer_ref = std::make_shared<SharedMemBuffer>(segment, buffer_descriptor.source_segment_id, buffer_node,
-                            segment_node);
-
-            // If the cell has been read by all listeners
-            global_port_->pop(*global_listener_, was_cell_freed);
-
-            if (was_cell_freed)
-            {
-                buffer_node->header.ref_count.fetch_sub(1);
+                    regenerate_port();
+                }
             }
 
             return buffer_ref;
+        }
+
+        void regenerate_port()
+        {
+            auto new_port = shared_mem_manager_->open_port(
+                global_port_->port_id(), 
+                global_port_->max_buffer_descriptors(),
+                global_port_->healthy_check_timeout_ms(),
+                global_port_->open_mode()
+                );
+
+            auto new_listener = new_port->create_listener();
+
+            *this = std::move(*new_listener);
         }
 
         /**
@@ -406,10 +486,12 @@ public:
         std::shared_ptr<SharedMemGlobal::Port> global_port_;
 
         std::shared_ptr<SharedMemGlobal::Listener> global_listener_;
+        uint32_t listener_index_;
 
-        SharedMemManager& shared_mem_manager_;
+        SharedMemManager* shared_mem_manager_;
 
         std::atomic<bool> is_closed_;
+        
     }; // Listener
 
     /**
@@ -420,11 +502,24 @@ public:
     public:
 
         Port(
-                SharedMemManager& shared_mem_manager,
-                std::shared_ptr<SharedMemGlobal::Port> port)
+                SharedMemManager* shared_mem_manager,
+                std::shared_ptr<SharedMemGlobal::Port> port,
+                SharedMemGlobal::Port::OpenMode open_mode)
             : shared_mem_manager_(shared_mem_manager)
             , global_port_(port)
+            , open_mode_(open_mode)
         {
+        }
+
+        Port& operator = (
+                Port&& other)
+        {
+            shared_mem_manager_ = other.shared_mem_manager_;
+            open_mode_ = other.open_mode_;
+            global_port_ = other.global_port_;
+            other.global_port_.reset();
+
+            return *this;
         }
 
         /**
@@ -452,10 +547,22 @@ public:
                     shared_mem_buffer->decrease_ref();
                 }
             }
-            catch (std::exception&)
+            catch (std::exception& e)
             {
                 shared_mem_buffer->decrease_ref();
-                throw;
+
+                if (!global_port_->is_port_ok())
+                {
+                    logWarning(RTPS_TRANSPORT_SHM, "SHM Port " << global_port_->port_id() << " failure: "
+                        << e.what());
+
+                    regenerate_port();
+                    ret = false;
+                }
+                else
+                {
+                    throw;
+                }
             }
 
             return ret;
@@ -468,9 +575,22 @@ public:
 
     private:
 
-        SharedMemManager& shared_mem_manager_;
+        void regenerate_port()
+        {
+            auto new_port = shared_mem_manager_->open_port(
+                global_port_->port_id(),
+                global_port_->max_buffer_descriptors(),
+                global_port_->healthy_check_timeout_ms(),
+                open_mode_);
+
+            *this = std::move(*new_port);
+        }
+
+        SharedMemManager* shared_mem_manager_;
 
         std::shared_ptr<SharedMemGlobal::Port> global_port_;
+
+        SharedMemGlobal::Port::OpenMode open_mode_;
 
     }; // Port
 
@@ -498,8 +618,9 @@ public:
             uint32_t healthy_check_timeout_ms,
             SharedMemGlobal::Port::OpenMode open_mode = SharedMemGlobal::Port::OpenMode::ReadShared)
     {
-        return std::make_shared<Port>(*this,
-                       global_segment_.open_port(port_id, max_descriptors, healthy_check_timeout_ms, open_mode));
+        return std::make_shared<Port>(this,
+                       global_segment_.open_port(port_id, max_descriptors, healthy_check_timeout_ms, open_mode),
+                       open_mode);
     }
 
     private:
@@ -591,6 +712,43 @@ public:
         }
 
         return segment;
+    }
+
+    /**
+     * Called by PortWatchdog when a dead listener has been detected.
+     * At this point the port is marked as not OK, and a vector of
+     * the recovered descriptors, from the port, are passed to
+     * this function that performs their release.
+     */     
+    static void on_failure_buffer_descriptor_handler(
+            const std::vector<const SharedMemGlobal::BufferDescriptor*>& buffer_descriptors,
+            const std::string& domain_name)
+    {
+        try
+        {
+            SharedMemManager shared_mem_manager(domain_name);
+
+            for (auto buffer_descriptor : buffer_descriptors)
+            {
+                SegmentNode* segment_node;
+                auto segment = shared_mem_manager.find_segment(buffer_descriptor->source_segment_id, &segment_node);
+                auto buffer_node =
+                        static_cast<BufferNode*>(segment->get_address_from_offset(buffer_descriptor->buffer_node_offset));
+
+                int32_t buffer_size = buffer_node->header.data_size;
+
+                // Last reference to the buffer
+                if (buffer_node->header.ref_count.fetch_sub(1) == 1)
+                {
+                    // Anotate the new free space
+                    segment_node->free_bytes.fetch_add(buffer_size);
+                }
+            }
+        }
+        catch (const std::exception& e)
+        {
+            logError(RTPS_TRANSPORT_SHM, e.what());
+        }
     }
 };
 

--- a/test/unittest/transport/SharedMemTests.cpp
+++ b/test/unittest/transport/SharedMemTests.cpp
@@ -210,49 +210,49 @@ TEST_F(SHMRingBuffer, copy)
     std::vector<const MyData*> enqueued_data;
 
     ring_buffer->copy(&enqueued_data);
-    ASSERT_EQ(0, enqueued_data.size());
+    ASSERT_EQ(0u, enqueued_data.size());
 
     ring_buffer->push({ 0,0 });
     ring_buffer->copy(&enqueued_data);
-    ASSERT_EQ(1, enqueued_data.size());
+    ASSERT_EQ(1u, enqueued_data.size());
     enqueued_data.clear();
 
     ring_buffer->push({ 0,1 });
     ring_buffer->copy(&enqueued_data);
-    ASSERT_EQ(2, enqueued_data.size());
+    ASSERT_EQ(2u, enqueued_data.size());
 
-    ASSERT_EQ(0, enqueued_data[0]->counter);
-    ASSERT_EQ(1, enqueued_data[1]->counter);
+    ASSERT_EQ(0u, enqueued_data[0]->counter);
+    ASSERT_EQ(1u, enqueued_data[1]->counter);
 
     listener->pop();
 
     enqueued_data.clear();
     ring_buffer->push({ 0,2 });
     ring_buffer->copy(&enqueued_data);
-    ASSERT_EQ(2, enqueued_data.size());
+    ASSERT_EQ(2u, enqueued_data.size());
 
-    ASSERT_EQ(1, enqueued_data[0]->counter);
-    ASSERT_EQ(2, enqueued_data[1]->counter);
+    ASSERT_EQ(1u, enqueued_data[0]->counter);
+    ASSERT_EQ(2u, enqueued_data[1]->counter);
 
     listener->pop();
 
     enqueued_data.clear();
     ring_buffer->push({ 0,3 });
     ring_buffer->copy(&enqueued_data);
-    ASSERT_EQ(2, enqueued_data.size());
+    ASSERT_EQ(2u, enqueued_data.size());
 
-    ASSERT_EQ(2, enqueued_data[0]->counter);
-    ASSERT_EQ(3, enqueued_data[1]->counter);
-
-    listener->pop();
-    enqueued_data.clear();
-    ring_buffer->copy(&enqueued_data);
-    ASSERT_EQ(1, enqueued_data.size());
+    ASSERT_EQ(2u, enqueued_data[0]->counter);
+    ASSERT_EQ(3u, enqueued_data[1]->counter);
 
     listener->pop();
     enqueued_data.clear();
     ring_buffer->copy(&enqueued_data);
-    ASSERT_EQ(0, enqueued_data.size());
+    ASSERT_EQ(1u, enqueued_data.size());
+
+    listener->pop();
+    enqueued_data.clear();
+    ring_buffer->copy(&enqueued_data);
+    ASSERT_EQ(0u, enqueued_data.size());
 }
 
 TEST_F(SHMRingBuffer, listeners_register_unregister)


### PR DESCRIPTION
This patch helps colaborating applications using SHM transport to recover when one of the applications is broken by ctrl-c or crash.

Before the patch, SHM ports opened for reading by the crashed application could be left inoperative for the rest of applications.

This is specially a problem for multicast ports opened by several processes.