### PR TITLE
Disable SHM transport as built-in <1.10.x> [8134]

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -282,6 +282,11 @@ if(COMPILE_EXAMPLES)
 endif()
 
 ###############################################################################
+# SHM as Default transport
+###############################################################################
+option(SHM_TRANSPORT_DEFAULT "Adds SHM transport to the default transports" OFF)
+
+###############################################################################
 # Documentation
 ###############################################################################
 # Add an option to toggle the generation of the API documentation.

--- a/src/cpp/CMakeLists.txt
+++ b/src/cpp/CMakeLists.txt
@@ -351,6 +351,7 @@ elseif(NOT EPROSIMA_INSTALLER)
         $<$<AND:$<BOOL:${ANDROID}>,$<NOT:$<BOOL:${HAVE_CXX14}>>,$<NOT:$<BOOL:${HAVE_CXX1Y}>>>:ASIO_DISABLE_STD_STRING_VIEW>
         $<$<BOOL:${WIN32}>:_ENABLE_ATOMIC_ALIGNMENT_FIX>
         $<$<NOT:$<BOOL:${IS_THIRDPARTY_BOOST_SUPPORTED}>>:FASTDDS_SHM_TRANSPORT_DISABLED> # Do not compile SHM Transport
+        $<$<BOOL:${SHM_TRANSPORT_DEFAULT}>:SHM_TRANSPORT_BUILTIN> # Enable SHM as built-in transport
         )
 
     # Define public headers

--- a/src/cpp/rtps/participant/RTPSParticipantImpl.cpp
+++ b/src/cpp/rtps/participant/RTPSParticipantImpl.cpp
@@ -124,6 +124,7 @@ RTPSParticipantImpl::RTPSParticipantImpl(
         descriptor.receiveBufferSize = m_att.listenSocketBufferSize;
         m_network_Factory.RegisterTransport(&descriptor);
 
+#ifdef SHM_TRANSPORT_BUILTIN
         SharedMemTransportDescriptor shm_transport;
         // We assume (Linux) UDP doubles the user socket buffer size in kernel, so
         // the equivalent segment size in SHM would be socket buffer size x 2
@@ -133,6 +134,7 @@ RTPSParticipantImpl::RTPSParticipantImpl(
         // Use same default max_message_size on both UDP and SHM
         shm_transport.max_message_size(descriptor.max_message_size());
         has_shm_transport_ |= m_network_Factory.RegisterTransport(&shm_transport);
+#endif
     }
 
     // BACKUP servers guid is its persistence one


### PR DESCRIPTION
In FastRTPS 1.10.0 SHM is, by default, built-in transport.

This PR:

* Enable / disable SHM transport as built-in, on compilation time.
* Adds a cmake option SHM_TRANSPORT_DEFAULT (OFF by default) to enable SHM built-in compilation.