### PR TITLE
Segfault when no network interfaces. <1.10.x> [8138]

### DIFF
--- a/src/cpp/utils/Host.hpp
+++ b/src/cpp/utils/Host.hpp
@@ -50,8 +50,8 @@ public:
             }
             else
             {
-                reinterpret_cast<uint8_t*>(id_)[0] = 127;
-                reinterpret_cast<uint8_t*>(id_)[1] = 1;
+                reinterpret_cast<uint8_t*>(&id_)[0] = 127;
+                reinterpret_cast<uint8_t*>(&id_)[1] = 1;
             }
         }
     }


### PR DESCRIPTION
FastRTPS 1.10.0 crash by segfault when no network interfaces are detected in the machine.