### PR TITLE
dds type registration config

### DIFF
--- a/include/fastdds/dds/topic/TopicDataType.hpp
+++ b/include/fastdds/dds/topic/TopicDataType.hpp
@@ -56,6 +56,9 @@ class  TopicDataType
         RTPS_DllAPI TopicDataType()
             : m_typeSize(0)
             , m_isGetKeyDefined(false)
+            , type_id_(nullptr)
+            , auto_fill_type_object_(true)
+            , auto_fill_type_information_(true)
         {}
 
         RTPS_DllAPI virtual ~TopicDataType()
@@ -142,6 +145,40 @@ class  TopicDataType
             type_id_ = type_identifier;
         }
 
+        /**
+         * Get the type object auto-fill configuration
+         * @return true if the type object should be auto-filled
+         */
+        RTPS_DllAPI inline bool auto_fill_type_object() const
+        {
+            return auto_fill_type_object_;
+        }
+
+        /**
+         * Set the type object auto-fill configuration
+         */
+        RTPS_DllAPI inline void auto_fill_type_object(bool auto_fill_type_object)
+        {
+            auto_fill_type_object_ = auto_fill_type_object;
+        }
+
+        /**
+         * Get the type information auto-fill configuration
+         * @return true if the type information should be auto-filled
+         */
+        RTPS_DllAPI inline bool auto_fill_type_information() const
+        {
+            return auto_fill_type_information_;
+        }
+
+        /**
+         * Set type information auto-fill configuration
+         */
+        RTPS_DllAPI inline void auto_fill_type_information(bool auto_fill_type_information)
+        {
+            auto_fill_type_information_ = auto_fill_type_information;
+        }
+
         //! Maximum serialized size of the type in bytes.
         //! If the type has unbounded fields, and therefore cannot have a maximum size, use 0.
         uint32_t m_typeSize;
@@ -154,7 +191,11 @@ class  TopicDataType
         //! Type Identifier.
         const fastrtps::types::TypeIdentifier* type_id_;
 
+        bool auto_fill_type_object_;
+        bool auto_fill_type_information_;
+
         friend class fastdds::dds::TypeSupport;
+
 };
 
 } /* namespace dds */

--- a/include/fastdds/dds/topic/TopicDataType.hpp
+++ b/include/fastdds/dds/topic/TopicDataType.hpp
@@ -157,7 +157,8 @@ class  TopicDataType
         /**
          * Set the type object auto-fill configuration
          */
-        RTPS_DllAPI inline void auto_fill_type_object(bool auto_fill_type_object)
+        RTPS_DllAPI inline void auto_fill_type_object(
+                 bool auto_fill_type_object)
         {
             auto_fill_type_object_ = auto_fill_type_object;
         }
@@ -174,7 +175,8 @@ class  TopicDataType
         /**
          * Set type information auto-fill configuration
          */
-        RTPS_DllAPI inline void auto_fill_type_information(bool auto_fill_type_information)
+        RTPS_DllAPI inline void auto_fill_type_information(
+                bool auto_fill_type_information)
         {
             auto_fill_type_information_ = auto_fill_type_information;
         }

--- a/include/fastdds/dds/topic/qos/TopicQos.hpp
+++ b/include/fastdds/dds/topic/qos/TopicQos.hpp
@@ -424,6 +424,34 @@ public:
         ownership_ = ownership;
     }
 
+    /**
+     * Getter for DataRepresentationQosPolicy
+     * @return DataRepresentationQosPolicy reference
+     */
+    const DataRepresentationQosPolicy& representation() const
+    {
+        return representation_;
+    }
+
+    /**
+     * Getter for DataRepresentationQosPolicy
+     * @return DataRepresentationQosPolicy reference
+     */
+    DataRepresentationQosPolicy& representation()
+    {
+        return representation_;
+    }
+
+    /**
+     * Setter for DataRepresentationQosPolicy
+     * @param representation
+     */
+    void representation(
+            const DataRepresentationQosPolicy& representation)
+    {
+        representation_ = representation;
+    }
+
 private:
 
     //!Topic Data Qos, NOT implemented in the library.
@@ -464,6 +492,9 @@ private:
 
     //!Ownership Qos, NOT implemented in the library.
     OwnershipQosPolicy ownership_;
+
+    //!Data Representation Qos, (XTypes extension).
+    DataRepresentationQosPolicy representation_;
 };
 
 RTPS_DllAPI extern const TopicQos TOPIC_QOS_DEFAULT;

--- a/src/cpp/fastdds/domain/DomainParticipantImpl.cpp
+++ b/src/cpp/fastdds/domain/DomainParticipantImpl.cpp
@@ -143,7 +143,6 @@ DomainParticipantImpl::~DomainParticipantImpl()
             delete topic_it->second;
         }
         topics_.clear();
-        topics_by_name_.clear();
         topics_by_handle_.clear();
     }
 
@@ -614,7 +613,7 @@ Topic* DomainParticipantImpl::create_topic(
     std::lock_guard<std::mutex> lock(mtx_topics_);
 
     //Check there is no Topic with the same name
-    if (topics_by_name_.find(topic_name) != topics_by_name_.end())
+    if (topics_.find(topic_name) != topics_.end())
     {
         logError(PARTICIPANT, "Topic with name : " << topic_name << " already exists");
         return nullptr;
@@ -628,8 +627,7 @@ Topic* DomainParticipantImpl::create_topic(
 
     //SAVE THE TOPIC INTO MAPS
     topics_by_handle_[topic_handle] = topic;
-    topics_by_name_[topic_name] = topic;
-    topics_[topic] = topic_impl;
+    topics_[topic_name] = topic_impl;
 
     return topic;
 }
@@ -678,7 +676,7 @@ bool DomainParticipantImpl::register_type(
 
     if (type->auto_fill_type_object() || type->auto_fill_type_information())
     {
-        //register_dynamic_type_to_factories(type);
+        register_dynamic_type_to_factories(type);
     }
 
     return true;

--- a/src/cpp/fastdds/domain/DomainParticipantImpl.hpp
+++ b/src/cpp/fastdds/domain/DomainParticipantImpl.hpp
@@ -337,7 +337,9 @@ private:
     mutable std::mutex mtx_types_;
 
     //!Topic map
-    std::map<std::string, Topic*> topics_;
+    std::map<Topic*, TopicImpl*> topics_;
+    std::map<std::string, Topic*> topics_by_name_;
+    std::map<fastrtps::rtps::InstanceHandle_t, Topic*> topics_by_handle_;
     mutable std::mutex mtx_topics_;
 
     TopicQos default_topic_qos_;

--- a/src/cpp/fastdds/domain/DomainParticipantImpl.hpp
+++ b/src/cpp/fastdds/domain/DomainParticipantImpl.hpp
@@ -162,11 +162,11 @@ public:
     /**
      * @brief Registers into types Factories an already registered dynamic type
      * to ease its use through factories.
-     * @param type_name
+     * @param type
      * @return True if registered.
      */
     bool register_dynamic_type_to_factories(
-            const std::string& type_name) const;
+            const TypeSupport& type) const;
 
     /**
      * Unregister a type in this participant.

--- a/src/cpp/fastdds/domain/DomainParticipantImpl.hpp
+++ b/src/cpp/fastdds/domain/DomainParticipantImpl.hpp
@@ -337,8 +337,7 @@ private:
     mutable std::mutex mtx_types_;
 
     //!Topic map
-    std::map<Topic*, TopicImpl*> topics_;
-    std::map<std::string, Topic*> topics_by_name_;
+    std::map<std::string, TopicImpl*> topics_;
     std::map<fastrtps::rtps::InstanceHandle_t, Topic*> topics_by_handle_;
     mutable std::mutex mtx_topics_;
 

--- a/src/cpp/fastdds/domain/DomainParticipantImpl.hpp
+++ b/src/cpp/fastdds/domain/DomainParticipantImpl.hpp
@@ -160,15 +160,6 @@ public:
             const std::string& type_name);
 
     /**
-     * @brief Registers into types Factories an already registered dynamic type
-     * to ease its use through factories.
-     * @param type
-     * @return True if registered.
-     */
-    bool register_dynamic_type_to_factories(
-            const TypeSupport& type) const;
-
-    /**
      * Unregister a type in this participant.
      * @param typeName Name of the type
      * @return True if unregistered.
@@ -421,11 +412,15 @@ public:
 
     } rtps_listener_;
 
+
     bool exists_entity_id(
             const fastrtps::rtps::EntityId_t& entity_id) const;
 
     bool register_dynamic_type(
             fastrtps::types::DynamicType_ptr dyn_type);
+
+    bool register_dynamic_type_to_factories(
+            const TypeSupport& type) const;
 
     bool check_get_type_request(
             const fastrtps::rtps::SampleIdentity& requestId,

--- a/test/unittest/dds/participant/ParticipantTests.cpp
+++ b/test/unittest/dds/participant/ParticipantTests.cpp
@@ -293,8 +293,7 @@ TEST(ParticipantTests, CreateTopic)
 {
     DomainParticipant* participant = DomainParticipantFactory::get_instance()->create_participant(0);
 
-    TopicDataTypeMock data_type;
-    TypeSupport type_(&data_type);
+    TypeSupport type_(new TopicDataTypeMock());
     participant->register_type(type_, "footype");
 
     Topic* topic = participant->create_topic("footopic", "footype", TOPIC_QOS_DEFAULT);
@@ -305,8 +304,7 @@ TEST(ParticipantTests, PSMCreateTopic)
 {
     ::dds::domain::DomainParticipant participant = ::dds::domain::DomainParticipant(0);
 
-    TopicDataTypeMock data_type;
-    TypeSupport type_(&data_type);
+    TypeSupport type_(new TopicDataTypeMock());
     participant->register_type(type_, "footype");
 
     ::dds::topic::Topic topic = ::dds::core::null;


### PR DESCRIPTION
- Add `auto_fill_type_object` and `auto_fill_type_information` to `TopicDataType`
- Register the dynamic types to the factories when the data type is registered with `register_type`