### PR TITLE
add freebsd support

### DIFF
--- a/src/cpp/fastrtps_deprecated/utils/IPFinder.cpp
+++ b/src/cpp/fastrtps_deprecated/utils/IPFinder.cpp
@@ -39,7 +39,7 @@
 #include <net/if.h>
 #endif
 
-#if __FreeBSD__
+#if defined(__FreeBSD__)
 #include <netinet/in.h>
 #endif
 

--- a/src/cpp/fastrtps_deprecated/utils/IPFinder.cpp
+++ b/src/cpp/fastrtps_deprecated/utils/IPFinder.cpp
@@ -39,6 +39,10 @@
 #include <net/if.h>
 #endif
 
+#if __FreeBSD__
+#include <netinet/in.h>
+#endif
+
 #include <cstddef>
 #include <cstring>
 


### PR DESCRIPTION
This header is necessary when compiling on FreeBSD.

I recognise this is deprecated, but ROS2 is still using v1.8.2 in the LTS Dashing branch, so I thought I would provide it for consideration.

The added header is necessary to avoid forward declarations of `struct sockaddr_in` and `struct sockaddr_in6`.

This doesn't appear to be an issue anywhere in the non-deprecated source files of the master branch. 