### PR TITLE
RobustInterprocessCondition implementation <1.10.x> [8213]

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -257,6 +257,11 @@ endif()
 option(SQLITE3_SUPPORT "Activate SQLITE3 support" ON)
 
 ###############################################################################
+# SHM as Default transport
+###############################################################################
+option(SHM_TRANSPORT_DEFAULT "Adds SHM transport to the default transports" OFF)
+
+###############################################################################
 # Compile library.
 ###############################################################################
 add_subdirectory(src/cpp)
@@ -280,11 +285,6 @@ endif()
 if(COMPILE_EXAMPLES)
     add_subdirectory(examples)
 endif()
-
-###############################################################################
-# SHM as Default transport
-###############################################################################
-option(SHM_TRANSPORT_DEFAULT "Adds SHM transport to the default transports" OFF)
 
 ###############################################################################
 # Documentation

--- a/src/cpp/rtps/transport/shared_mem/RobustInterprocessCondition.hpp
+++ b/src/cpp/rtps/transport/shared_mem/RobustInterprocessCondition.hpp
@@ -1,0 +1,341 @@
+// Copyright 2020 Proyectos y Sistemas de Mantenimiento SL (eProsima).
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef _FASTDDS_SHAREDMEM_ROBUST_INTERPROCESS_CONDITION_
+#define _FASTDDS_SHAREDMEM_ROBUST_INTERPROCESS_CONDITION_
+
+#include <boost/interprocess/sync/detail/locks.hpp>
+#include <boost/interprocess/sync/interprocess_mutex.hpp>
+#include <boost/interprocess/sync/interprocess_semaphore.hpp>
+#include <boost/interprocess/sync/scoped_lock.hpp>
+
+namespace eprosima {
+namespace fastdds {
+namespace rtps {
+
+namespace bi = boost::interprocess;
+
+class RobustInterprocessCondition
+{
+public:
+
+    RobustInterprocessCondition()
+        : list_listening_(SemaphoreList::LIST_NULL)
+        , list_free_(MAX_LISTENERS-1)
+    {
+        init_sem_list();
+    }
+
+    ~RobustInterprocessCondition()
+    {
+    }
+
+    /**
+     * If there is a thread waiting on *this, change that
+     * thread's state to ready. Otherwise there is no effect.
+     * @throw boost::interprocess::interprocess_exception on error.
+     */
+    void notify_one()
+    {
+        bi::scoped_lock<bi::interprocess_mutex> lock(semaphore_lists_mutex_);
+
+        auto sem_index = list_listening_.tail();
+
+        if (sem_index != SemaphoreList::LIST_NULL)
+        {
+            semaphores_pool_[sem_index].sem.post();
+        }
+    }
+
+    /**
+     * Change the state of all threads waiting on *this to ready.
+     * If there are no waiting threads, notify_all() has no effect.
+     * @throw boost::interprocess::interprocess_exception on error.
+     */
+    void notify_all()
+    {
+        bi::scoped_lock<bi::interprocess_mutex> lock(semaphore_lists_mutex_);
+
+        auto sem_index = list_listening_.tail();
+
+        while (sem_index != SemaphoreList::LIST_NULL)
+        {
+            semaphores_pool_[sem_index].sem.post();
+            sem_index = semaphores_pool_[sem_index].prev;
+        }
+    }
+
+    /**
+     * Releases the lock on the interprocess_mutex object associated with lock, blocks
+     * the current thread of execution until readied by a call to
+     * this->notify_one() or this->notify_all(), and then reacquires the lock.
+     * @throw boost::interprocess::interprocess_exception on error.
+     */
+    template <typename L>
+    void wait(
+            L& lock)
+    {
+        do_wait(*lock.mutex());
+    }
+
+    /**
+     * The same as:
+     * while (!pred()) wait(lock)
+     * @throw boost::interprocess::interprocess_exception on error.
+     */
+    template <typename L, typename Pr>
+    void wait(
+            L& lock,
+            Pr pred)
+    {
+        while (!pred())
+            do_wait(*lock.mutex());
+    }
+
+    /**
+     * Releases the lock on the interprocess_mutex object associated with lock, blocks
+     * the current thread of execution until readied by a call to
+     * this->notify_one() or this->notify_all(), or until time abs_time is reached,
+     * and then reacquires the lock.
+     * @return false if time abs_time is reached, otherwise true.
+     * @throw boost::interprocess::interprocess_exception on error.
+     */
+    template <typename L>
+    bool timed_wait(
+            L& lock,
+            const boost::posix_time::ptime& abs_time)
+    {
+        //Handle infinity absolute time here to avoid complications in do_timed_wait
+        if (abs_time == boost::posix_time::pos_infin)
+        {
+            this->wait(lock);
+            return true;
+        }
+        return this->do_timed_wait(abs_time, *lock.mutex());
+    }
+
+    /**
+     * The same as:
+     * while (!pred())
+     * {
+     *     if (!timed_wait(lock, abs_time)) return pred();
+     * }
+     * return true;
+     */
+    template <typename L, typename Pr>
+    bool timed_wait(
+            L& lock,
+            const boost::posix_time::ptime& abs_time,
+            Pr pred)
+    {
+        // Posix does not support infinity absolute time so handle it here
+        if (abs_time == boost::posix_time::pos_infin)
+        {
+            wait(lock, pred);
+            return true;
+        }
+        while (!pred()){
+            if (!do_timed_wait(abs_time, *lock.mutex()))
+            {
+                return pred();
+            }
+        }
+        return true;
+    }
+
+private:
+
+    struct SemaphoreNode
+    {
+        bi::interprocess_semaphore sem;
+        uint32_t next;
+        uint32_t prev;
+    };
+
+    static constexpr uint32_t MAX_LISTENERS = 512;
+    SemaphoreNode semaphores_pool_[MAX_LISTENERS];
+
+    class SemaphoreList
+    {
+    private:
+
+        uint32_t tail_;
+
+    public:
+
+        static constexpr uint32_t LIST_NULL = static_cast<uint32_t>(-1);
+
+        SemaphoreList(
+                uint32_t tail)
+            : tail_(tail)
+        {
+        }
+
+        inline void push(
+                uint32_t sem_index,
+                SemaphoreNode* sem_pool)
+        {
+            if (tail_ != LIST_NULL)
+            {
+                sem_pool[tail_].next = sem_index;
+            }
+
+            sem_pool[sem_index].prev = tail_;
+            sem_pool[sem_index].next = LIST_NULL;
+
+            tail_ = sem_index;
+        }
+
+        inline uint32_t pop(
+                SemaphoreNode* sem_pool)
+        {
+            if (tail_ == LIST_NULL)
+            {
+                throw bi::interprocess_exception("RobustInterprocessCondition: pop() on empty list!");
+            }
+
+            uint32_t sem_index = tail_;
+            tail_ = sem_pool[tail_].prev;
+
+            if (tail_ != LIST_NULL)
+            {
+                sem_pool[tail_].next = LIST_NULL;
+            }
+            return sem_index;
+        }
+
+        inline uint32_t tail() const
+        {
+            return tail_;
+        }
+
+        inline void remove(
+                uint32_t sem_index,
+                SemaphoreNode* sem_pool)
+        {
+            assert(sem_index != LIST_NULL);
+
+            auto prev = sem_pool[sem_index].prev;
+            auto next = sem_pool[sem_index].next;
+
+            if (prev != LIST_NULL)
+            {
+                sem_pool[prev].next = next;
+            }
+
+            if (next != LIST_NULL)
+            {
+                sem_pool[next].prev = prev;
+            }
+
+            if (tail_ == sem_index)
+            {
+                tail_ = prev;
+            }
+        }
+    };
+
+    SemaphoreList list_listening_;
+    SemaphoreList list_free_;
+    bi::interprocess_mutex semaphore_lists_mutex_;
+
+    void init_sem_list()
+    {
+        semaphores_pool_[0].prev = SemaphoreList::LIST_NULL;
+        semaphores_pool_[0].next = 1;
+
+        for (uint32_t i = 1; i < MAX_LISTENERS-1; i++)
+        {
+            semaphores_pool_[i].next = i+1;
+            semaphores_pool_[i].prev = i-1;
+        }
+
+        semaphores_pool_[MAX_LISTENERS-1].prev = MAX_LISTENERS-2;
+        semaphores_pool_[MAX_LISTENERS-1].next = SemaphoreList::LIST_NULL;
+    }
+
+    inline uint32_t enqueue_listener()
+    {
+        auto sem_index = list_free_.pop(semaphores_pool_);
+        list_listening_.push(sem_index, semaphores_pool_);
+        return sem_index;
+    }
+
+    inline void dequeue_listener(
+            uint32_t sem_index)
+    {
+        list_listening_.remove(sem_index, semaphores_pool_);
+        list_free_.push(sem_index, semaphores_pool_);
+    }
+
+    inline void do_wait(
+            bi::interprocess_mutex& mut)
+    {
+        uint32_t sem_index;
+
+        {
+            bi::scoped_lock<bi::interprocess_mutex> lock_enqueue(semaphore_lists_mutex_);
+            sem_index = enqueue_listener();
+        }
+
+        {
+            // Release caller's lock
+            bi::ipcdetail::lock_inverter<bi::interprocess_mutex> inverted_lock(mut);
+            bi::scoped_lock<bi::ipcdetail::lock_inverter<bi::interprocess_mutex> > unlock(inverted_lock);
+
+            // timed_wait (infin) is used, instead wait, because wait on semaphores could throw when
+            // BOOST_INTERPROCESS_ENABLE_TIMEOUT_WHEN_LOCKING is set. We don't want that for our condition_variables
+            semaphores_pool_[sem_index].sem.timed_wait(boost::posix_time::pos_infin);
+        }
+
+        {
+            bi::scoped_lock<bi::interprocess_mutex> lock_dequeue(semaphore_lists_mutex_);
+            dequeue_listener(sem_index);
+        }
+    }
+
+    inline bool do_timed_wait(
+            const boost::posix_time::ptime& abs_time,
+            bi::interprocess_mutex& mut)
+    {
+        bool ret;
+        uint32_t sem_index;
+
+        {
+            bi::scoped_lock<bi::interprocess_mutex> lock_enqueue(semaphore_lists_mutex_);
+            sem_index = enqueue_listener();
+        }
+
+        {
+            // Release caller's lock
+            bi::ipcdetail::lock_inverter<bi::interprocess_mutex> inverted_lock(mut);
+            bi::scoped_lock<bi::ipcdetail::lock_inverter<bi::interprocess_mutex> > unlock(inverted_lock);
+
+            ret = semaphores_pool_[sem_index].sem.timed_wait(abs_time);
+        }
+
+        {
+            bi::scoped_lock<bi::interprocess_mutex> lock_dequeue(semaphore_lists_mutex_);
+            dequeue_listener(sem_index);
+        }
+
+        return ret;
+    }
+};
+
+} // namespace rtps
+} // namespace fastdds
+} // namespace eprosima
+
+#endif // _FASTDDS_SHAREDMEM_ROBUST_INTERPROCESS_CONDITION_

--- a/src/cpp/rtps/transport/shared_mem/SharedMemGlobal.hpp
+++ b/src/cpp/rtps/transport/shared_mem/SharedMemGlobal.hpp
@@ -72,6 +72,8 @@ public:
      */
     struct BufferDescriptor
     {
+        alignas(8) uint32_t flags;
+        uint64_t enqueue_tick;
         SharedMemSegment::Id source_segment_id;
         SharedMemSegment::Offset buffer_node_offset;
     };
@@ -79,7 +81,7 @@ public:
     typedef MultiProducerConsumerRingBuffer<BufferDescriptor>::Listener Listener;
     typedef MultiProducerConsumerRingBuffer<BufferDescriptor>::Cell PortCell;
 
-    static const uint32_t CURRENT_ABI_VERSION = 2;
+    static const uint32_t CURRENT_ABI_VERSION = 3;
 
     struct PortNode
     {

--- a/src/cpp/rtps/transport/shared_mem/SharedMemManager.hpp
+++ b/src/cpp/rtps/transport/shared_mem/SharedMemManager.hpp
@@ -659,6 +659,12 @@ public:
             , segment_id_(segment_id)
         {
             segment_node_ = segment_->get().find<SegmentNode>("segment_node").first;
+
+            if(!segment_node_)
+            {
+                throw std::runtime_error("segment_node not found");
+            }
+
             segment_node_->ref_count.fetch_add(1);
         }
 

--- a/src/cpp/rtps/transport/shared_mem/SharedMemManager.hpp
+++ b/src/cpp/rtps/transport/shared_mem/SharedMemManager.hpp
@@ -130,7 +130,7 @@ public:
             return buffer_node_->header.data_size;
         }
 
-        SharedMemSegment::offset node_offset()
+        SharedMemSegment::Offset node_offset()
         {
             return segment_->get_offset_from_address(buffer_node_);
         }

--- a/src/cpp/rtps/transport/shared_mem/SharedMemManager.hpp
+++ b/src/cpp/rtps/transport/shared_mem/SharedMemManager.hpp
@@ -545,7 +545,7 @@ public:
 
             try
             {
-                ret = global_port_->try_push({shared_mem_buffer->segment_id(), shared_mem_buffer->node_offset()},
+                ret = global_port_->try_push({0,0, shared_mem_buffer->segment_id(), shared_mem_buffer->node_offset()},
                                 &are_listeners_active);
 
                 if (!are_listeners_active)

--- a/src/cpp/rtps/transport/shared_mem/SharedMemSegment.hpp
+++ b/src/cpp/rtps/transport/shared_mem/SharedMemSegment.hpp
@@ -37,7 +37,7 @@
 #include <boost/interprocess/offset_ptr.hpp>
 #include <boost/thread/thread_time.hpp>
 
-
+#include "RobustInterprocessCondition.hpp"
 #include "SharedMemUUID.hpp"
 
 namespace eprosima {
@@ -55,7 +55,7 @@ class SharedMemSegment
 public:
 
     typedef std::ptrdiff_t offset;
-    typedef boost::interprocess::interprocess_condition condition_variable;
+    typedef RobustInterprocessCondition condition_variable;
     typedef boost::interprocess::interprocess_mutex mutex;
     typedef boost::interprocess::named_mutex named_mutex;
     typedef boost::interprocess::spin_wait spin_wait;

--- a/src/cpp/rtps/transport/shared_mem/SharedMemSegment.hpp
+++ b/src/cpp/rtps/transport/shared_mem/SharedMemSegment.hpp
@@ -53,12 +53,20 @@ using Log = fastdds::dds::Log;
 class SharedMemSegment
 {
 public:
-
-    typedef std::ptrdiff_t offset;
+    
     typedef RobustInterprocessCondition condition_variable;
     typedef boost::interprocess::interprocess_mutex mutex;
     typedef boost::interprocess::named_mutex named_mutex;
     typedef boost::interprocess::spin_wait spin_wait;
+
+    // Offset must be the same size for 32/64-bit versions, so no size_t used here.
+    typedef std::uint32_t Offset;
+    typedef boost::interprocess::offset_ptr<void, Offset, std::uint64_t> VoidPointerT;
+	typedef boost::interprocess::basic_managed_shared_memory<
+        char, 
+        boost::interprocess::rbtree_best_fit<boost::interprocess::mutex_family, 
+        VoidPointerT>, 
+        boost::interprocess::iset_index> managed_shared_memory_type;
 
     static constexpr boost::interprocess::open_only_t open_only = boost::interprocess::open_only_t();
     static constexpr boost::interprocess::create_only_t create_only = boost::interprocess::create_only_t();
@@ -73,7 +81,7 @@ public:
             boost::interprocess::create_only_t,
             const std::string& name,
             size_t size)
-        : segment_(boost::interprocess::create_only, name.c_str(), size + EXTRA_SEGMENT_SIZE)
+        : segment_(boost::interprocess::create_only, name.c_str(), static_cast<Offset>(size + EXTRA_SEGMENT_SIZE))
         , name_(name)
     {
     }
@@ -90,24 +98,24 @@ public:
             boost::interprocess::open_or_create_t,
             const std::string& name,
             size_t size)
-        : segment_(boost::interprocess::create_only, name.c_str(), size)
+        : segment_(boost::interprocess::create_only, name.c_str(), static_cast<Offset>(size))
         , name_(name)
     {
     }
 
     void* get_address_from_offset(
-            SharedMemSegment::offset offset) const
+            SharedMemSegment::Offset offset) const
     {
         return segment_.get_address_from_handle(offset);
     }
 
-    SharedMemSegment::offset get_offset_from_address(
+    SharedMemSegment::Offset get_offset_from_address(
             void* address) const
     {
         return segment_.get_handle_from_address(address);
     }
 
-    boost::interprocess::managed_shared_memory& get() { return segment_;}
+    managed_shared_memory_type& get() { return segment_;}
 
     static void remove(
             const std::string& name)
@@ -276,7 +284,7 @@ private:
 
     class EnvironmentInitializer
     {
-public:
+    public:
 
         EnvironmentInitializer()
         {
@@ -284,7 +292,7 @@ public:
         }
     } shared_mem_environment_initializer_;
 
-    boost::interprocess::managed_shared_memory segment_;
+    managed_shared_memory_type segment_;
 
     std::string name_;
 };

--- a/test/communication/liveliness_assertion.360.xml
+++ b/test/communication/liveliness_assertion.360.xml
@@ -3,13 +3,7 @@
     <profiles>
         <library_settings>
             <intraprocess_delivery>FULL</intraprocess_delivery>
-        </library_settings>
-        <transport_descriptors>
-            <transport_descriptor>
-                <transport_id>disable_shm</transport_id>
-                <type>UDPv4</type>
-            </transport_descriptor>
-        </transport_descriptors>
+        </library_settings>        
         <participant profile_name="simple_participant_profile" is_default_profile="true">
             <rtps>
                 <builtin>
@@ -18,11 +12,7 @@
                             <sec>360</sec>
                         </leaseDuration>
                     </discovery_config>
-                </builtin>
-                <userTransports>
-                    <transport_id>disable_shm</transport_id>
-                </userTransports>
-                <useBuiltinTransports>false</useBuiltinTransports>
+                </builtin>                
             </rtps>
         </participant>
     </profiles>

--- a/test/communication/liveliness_assertion.xml
+++ b/test/communication/liveliness_assertion.xml
@@ -3,13 +3,7 @@
     <profiles>
         <library_settings>
             <intraprocess_delivery>FULL</intraprocess_delivery>
-        </library_settings>
-        <transport_descriptors>
-            <transport_descriptor>
-                <transport_id>disable_shm</transport_id>
-                <type>UDPv4</type>
-            </transport_descriptor>
-        </transport_descriptors>
+        </library_settings>        
         <participant profile_name="simple_participant_profile" is_default_profile="true">
             <rtps>
                 <builtin>
@@ -21,11 +15,7 @@
                             <sec>1</sec>
                         </leaseAnnouncement>
                     </discovery_config>
-                </builtin>
-                <userTransports>
-                    <transport_id>disable_shm</transport_id>
-                </userTransports>
-                <useBuiltinTransports>false</useBuiltinTransports>
+                </builtin>                
             </rtps>
         </participant>
     </profiles>

--- a/test/unittest/transport/SharedMemTests.cpp
+++ b/test/unittest/transport/SharedMemTests.cpp
@@ -1069,7 +1069,9 @@ TEST_F(SHMTransportTests, empty_cv_mutex_deadlocked_try_push)
     ASSERT_FALSE(port_mocker.lock_empty_cv_mutex(*global_port));
 
     bool listerner_active;
-    SharedMemGlobal::BufferDescriptor foo;
+    SharedMemSegment::Id random_id;
+    random_id.generate();
+    SharedMemGlobal::BufferDescriptor foo = {0, 0, random_id, 0};
     ASSERT_THROW(global_port->try_push(foo, &listerner_active), std::exception);
 
     ASSERT_THROW(global_port->healthy_check(), std::exception);
@@ -1108,7 +1110,7 @@ TEST_F(SHMTransportTests, dead_listener_port_recover)
     bool listerners_active;
     SharedMemSegment::Id random_id;
     random_id.generate();
-    SharedMemGlobal::BufferDescriptor foo = {random_id, 0};
+    SharedMemGlobal::BufferDescriptor foo = {0,0,random_id, 0};
     ASSERT_TRUE(port->try_push(foo, &listerners_active));
     ASSERT_TRUE(listerners_active);
     ASSERT_TRUE(listener->head() != nullptr);

--- a/thirdparty/boost/include/boost/interprocess/sync/interprocess_semaphore.hpp
+++ b/thirdparty/boost/include/boost/interprocess/sync/interprocess_semaphore.hpp
@@ -1,0 +1,149 @@
+//////////////////////////////////////////////////////////////////////////////
+//
+// (C) Copyright Ion Gaztanaga 2005-2012. Distributed under the Boost
+// Software License, Version 1.0. (See accompanying file
+// LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+//
+// See http://www.boost.org/libs/interprocess for documentation.
+//
+//////////////////////////////////////////////////////////////////////////////
+
+#ifndef BOOST_INTERPROCESS_SEMAPHORE_HPP
+#define BOOST_INTERPROCESS_SEMAPHORE_HPP
+
+#if !defined(BOOST_INTERPROCESS_DOXYGEN_INVOKED)
+
+#ifndef BOOST_CONFIG_HPP
+#  include <boost/config.hpp>
+#endif
+#
+#if defined(BOOST_HAS_PRAGMA_ONCE)
+#  pragma once
+#endif
+
+#include <boost/interprocess/detail/config_begin.hpp>
+#include <boost/interprocess/detail/workaround.hpp>
+
+#include <boost/interprocess/creation_tags.hpp>
+#include <boost/interprocess/exceptions.hpp>
+#include <boost/interprocess/detail/posix_time_types_wrk.hpp>
+
+#if !defined(BOOST_INTERPROCESS_FORCE_GENERIC_EMULATION) && \
+   (defined(BOOST_INTERPROCESS_POSIX_PROCESS_SHARED) && defined(BOOST_INTERPROCESS_POSIX_UNNAMED_SEMAPHORES))
+   #include <boost/interprocess/sync/posix/semaphore.hpp>
+   #define BOOST_INTERPROCESS_USE_POSIX
+//Experimental...
+#elif !defined(BOOST_INTERPROCESS_FORCE_GENERIC_EMULATION) && defined (BOOST_INTERPROCESS_WINDOWS)
+   #include <boost/interprocess/sync/windows/semaphore.hpp>
+   #define BOOST_INTERPROCESS_USE_WINDOWS
+#elif !defined(BOOST_INTERPROCESS_DOXYGEN_INVOKED)
+   #include <boost/interprocess/sync/spin/semaphore.hpp>
+   #define BOOST_INTERPROCESS_USE_GENERIC_EMULATION
+#endif
+
+#endif   //#ifndef BOOST_INTERPROCESS_DOXYGEN_INVOKED
+
+//!\file
+//!Describes a interprocess_semaphore class for inter-process synchronization
+
+namespace boost {
+namespace interprocess {
+
+//!Wraps a interprocess_semaphore that can be placed in shared memory and can be
+//!shared between processes. Allows timed lock tries
+class interprocess_semaphore
+{
+   #if !defined(BOOST_INTERPROCESS_DOXYGEN_INVOKED)
+   //Non-copyable
+   interprocess_semaphore(const interprocess_semaphore &);
+   interprocess_semaphore &operator=(const interprocess_semaphore &);
+   #endif   //#ifndef BOOST_INTERPROCESS_DOXYGEN_INVOKED
+   public:
+   //!Creates a interprocess_semaphore with the given initial count.
+   //!interprocess_exception if there is an error.*/
+   interprocess_semaphore(unsigned int initialCount = 0);
+
+   //!Destroys the interprocess_semaphore.
+   //!Does not throw
+   ~interprocess_semaphore();
+
+   //!Increments the interprocess_semaphore count. If there are processes/threads blocked waiting
+   //!for the interprocess_semaphore, then one of these processes will return successfully from
+   //!its wait function. If there is an error an interprocess_exception exception is thrown.
+   void post();
+
+   //!Decrements the interprocess_semaphore. If the interprocess_semaphore value is not greater than zero,
+   //!then the calling process/thread blocks until it can decrement the counter.
+   //!If there is an error an interprocess_exception exception is thrown.
+   void wait();
+
+   //!Decrements the interprocess_semaphore if the interprocess_semaphore's value is greater than zero
+   //!and returns true. If the value is not greater than zero returns false.
+   //!If there is an error an interprocess_exception exception is thrown.
+   bool try_wait();
+
+   //!Decrements the interprocess_semaphore if the interprocess_semaphore's value is greater
+   //!than zero and returns true. Otherwise, waits for the interprocess_semaphore
+   //!to the posted or the timeout expires. If the timeout expires, the
+   //!function returns false. If the interprocess_semaphore is posted the function
+   //!returns true. If there is an error throws sem_exception
+   bool timed_wait(const boost::posix_time::ptime &abs_time);
+
+   //!Returns the interprocess_semaphore count
+//   int get_count() const;
+   #if !defined(BOOST_INTERPROCESS_DOXYGEN_INVOKED)
+   private:
+   #if defined(BOOST_INTERPROCESS_USE_GENERIC_EMULATION)
+      #undef BOOST_INTERPROCESS_USE_GENERIC_EMULATION
+      ipcdetail::spin_semaphore m_sem;
+   #elif defined(BOOST_INTERPROCESS_USE_WINDOWS)
+      #undef BOOST_INTERPROCESS_USE_WINDOWS
+      ipcdetail::windows_semaphore m_sem;
+   #else
+      #undef BOOST_INTERPROCESS_USE_POSIX
+      ipcdetail::posix_semaphore m_sem;
+   #endif   //#if defined(BOOST_INTERPROCESS_USE_GENERIC_EMULATION)
+   #endif   //#ifndef BOOST_INTERPROCESS_DOXYGEN_INVOKED
+};
+
+}  //namespace interprocess {
+}  //namespace boost {
+
+namespace boost {
+namespace interprocess {
+
+inline interprocess_semaphore::interprocess_semaphore(unsigned int initialCount)
+   : m_sem(initialCount)
+{}
+
+inline interprocess_semaphore::~interprocess_semaphore(){}
+
+inline void interprocess_semaphore::wait()
+{
+   #ifdef BOOST_INTERPROCESS_ENABLE_TIMEOUT_WHEN_LOCKING
+      boost::posix_time::ptime wait_time
+         = microsec_clock::universal_time()
+         + boost::posix_time::milliseconds(BOOST_INTERPROCESS_TIMEOUT_WHEN_LOCKING_DURATION_MS);
+      if (!m_sem.timed_wait(wait_time))
+      {
+         throw interprocess_exception(timeout_when_waiting_error, "Interprocess semaphore timeout when waiting. Possible deadlock: owner died without posting?");
+      }
+   #else
+      m_sem.wait();
+   #endif
+}
+inline bool interprocess_semaphore::try_wait()
+{ return m_sem.try_wait(); }
+
+inline bool interprocess_semaphore::timed_wait(const boost::posix_time::ptime &abs_time)
+{ return m_sem.timed_wait(abs_time); }
+
+inline void interprocess_semaphore::post()
+{ m_sem.post(); }
+
+}  //namespace interprocess {
+}  //namespace boost {
+
+#include <boost/interprocess/detail/config_end.hpp>
+
+#endif   //BOOST_INTERPROCESS_SEMAPHORE_HPP

--- a/thirdparty/boost/include/boost/interprocess/sync/posix/semaphore.hpp
+++ b/thirdparty/boost/include/boost/interprocess/sync/posix/semaphore.hpp
@@ -1,0 +1,67 @@
+//////////////////////////////////////////////////////////////////////////////
+//
+// (C) Copyright Ion Gaztanaga 2005-2012. Distributed under the Boost
+// Software License, Version 1.0. (See accompanying file
+// LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+//
+// See http://www.boost.org/libs/interprocess for documentation.
+//
+//////////////////////////////////////////////////////////////////////////////
+
+#ifndef BOOST_INTERPROCESS_POSIX_SEMAPHORE_HPP
+#define BOOST_INTERPROCESS_POSIX_SEMAPHORE_HPP
+
+#ifndef BOOST_CONFIG_HPP
+#  include <boost/config.hpp>
+#endif
+#
+#if defined(BOOST_HAS_PRAGMA_ONCE)
+#  pragma once
+#endif
+
+#include <boost/interprocess/detail/config_begin.hpp>
+#include <boost/interprocess/detail/workaround.hpp>
+
+#include <boost/interprocess/detail/posix_time_types_wrk.hpp>
+#include <boost/interprocess/sync/posix/semaphore_wrapper.hpp>
+
+namespace boost {
+namespace interprocess {
+namespace ipcdetail {
+
+class posix_semaphore
+{
+   posix_semaphore();
+   posix_semaphore(const posix_semaphore&);
+   posix_semaphore &operator= (const posix_semaphore &);
+
+   public:
+   posix_semaphore(unsigned int initialCount)
+   {  semaphore_init(&m_sem, initialCount);  }
+
+   ~posix_semaphore()
+   {  semaphore_destroy(&m_sem);  }
+
+   void post()
+   {  semaphore_post(&m_sem); }
+
+   void wait()
+   {  semaphore_wait(&m_sem); }
+
+   bool try_wait()
+   {  return semaphore_try_wait(&m_sem); }
+
+   bool timed_wait(const boost::posix_time::ptime &abs_time)
+   {  return semaphore_timed_wait(&m_sem, abs_time); }
+
+   private:
+   sem_t       m_sem;
+};
+
+}  //namespace ipcdetail {
+}  //namespace interprocess {
+}  //namespace boost {
+
+#include <boost/interprocess/detail/config_end.hpp>
+
+#endif   //#ifndef BOOST_INTERPROCESS_POSIX_SEMAPHORE_HPP

--- a/thirdparty/boost/include/boost/interprocess/sync/spin/semaphore.hpp
+++ b/thirdparty/boost/include/boost/interprocess/sync/spin/semaphore.hpp
@@ -1,0 +1,94 @@
+//////////////////////////////////////////////////////////////////////////////
+//
+// (C) Copyright Ion Gaztanaga 2005-2012. Distributed under the Boost
+// Software License, Version 1.0. (See accompanying file
+// LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+//
+// See http://www.boost.org/libs/interprocess for documentation.
+//
+//////////////////////////////////////////////////////////////////////////////
+
+#ifndef BOOST_INTERPROCESS_DETAIL_SPIN_SEMAPHORE_HPP
+#define BOOST_INTERPROCESS_DETAIL_SPIN_SEMAPHORE_HPP
+
+#ifndef BOOST_CONFIG_HPP
+#  include <boost/config.hpp>
+#endif
+#
+#if defined(BOOST_HAS_PRAGMA_ONCE)
+#  pragma once
+#endif
+
+#include <boost/interprocess/detail/config_begin.hpp>
+#include <boost/interprocess/detail/workaround.hpp>
+#include <boost/interprocess/detail/atomic.hpp>
+#include <boost/interprocess/detail/os_thread_functions.hpp>
+#include <boost/interprocess/detail/posix_time_types_wrk.hpp>
+#include <boost/interprocess/sync/detail/common_algorithms.hpp>
+#include <boost/interprocess/sync/detail/locks.hpp>
+#include <boost/cstdint.hpp>
+
+namespace boost {
+namespace interprocess {
+namespace ipcdetail {
+
+class spin_semaphore
+{
+   spin_semaphore(const spin_semaphore &);
+   spin_semaphore &operator=(const spin_semaphore &);
+
+   public:
+   spin_semaphore(unsigned int initialCount);
+   ~spin_semaphore();
+
+   void post();
+   void wait();
+   bool try_wait();
+   bool timed_wait(const boost::posix_time::ptime &abs_time);
+
+//   int get_count() const;
+   private:
+   volatile boost::uint32_t m_count;
+};
+
+
+inline spin_semaphore::~spin_semaphore()
+{}
+
+inline spin_semaphore::spin_semaphore(unsigned int initialCount)
+{  ipcdetail::atomic_write32(&this->m_count, boost::uint32_t(initialCount));  }
+
+inline void spin_semaphore::post()
+{
+   ipcdetail::atomic_inc32(&m_count);
+}
+
+inline void spin_semaphore::wait()
+{
+   ipcdetail::lock_to_wait<spin_semaphore> lw(*this);
+   return ipcdetail::try_based_lock(lw);
+}
+
+inline bool spin_semaphore::try_wait()
+{
+   return ipcdetail::atomic_add_unless32(&m_count, boost::uint32_t(-1), boost::uint32_t(0));
+}
+
+inline bool spin_semaphore::timed_wait(const boost::posix_time::ptime &abs_time)
+{
+   ipcdetail::lock_to_wait<spin_semaphore> lw(*this);
+   return ipcdetail::try_based_timed_lock(lw, abs_time);
+}
+
+//inline int spin_semaphore::get_count() const
+//{
+   //return (int)ipcdetail::atomic_read32(&m_count);
+//}
+
+}  //namespace ipcdetail {
+}  //namespace interprocess {
+}  //namespace boost {
+
+#include <boost/interprocess/detail/config_end.hpp>
+
+#endif   //BOOST_INTERPROCESS_DETAIL_SPIN_SEMAPHORE_HPP


### PR DESCRIPTION
This PR solves several SHM issues of v1.10.0 
* POSIX condition_variables are not robust for interprocess comunication. [glibc issue](https://sourceware.org/bugzilla/show_bug.cgi?id=21422)
A robust interprocess_condition is implemented based on semaphores.
This should fix FastRTPS issue #1144 

* SHM structures alignment is bad for some platforms provoking bus exceptions accesing atomics in shared memory. Also processes running in the same host compiled for different architectures (32/64-bit) failed to communicate.
This should fix issue FastRTPS #1133

Signed-off-by: AdolfoMartinez <adolfomartinez@eprosima.com>