### PR TITLE
DDS Visibility of reference API from TopicDescription

### DIFF
--- a/include/fastdds/dds/topic/Topic.hpp
+++ b/include/fastdds/dds/topic/Topic.hpp
@@ -122,6 +122,8 @@ public:
             TopicListener* listener,
             const StatusMask& mask = StatusMask::all());
 
+    TopicDescriptionImpl* get_impl() const override;
+
 private:
 
     TopicImpl* impl_;

--- a/include/fastdds/dds/topic/TopicDescription.hpp
+++ b/include/fastdds/dds/topic/TopicDescription.hpp
@@ -28,7 +28,6 @@ namespace dds {
 class DomainParticipant;
 class TopicDescriptionImpl;
 
-
 /**
  * Class TopicDescription, represents the fact that both publications
  * and subscriptions are tied to a single data-type

--- a/include/fastdds/dds/topic/TopicDescription.hpp
+++ b/include/fastdds/dds/topic/TopicDescription.hpp
@@ -26,6 +26,8 @@ namespace fastdds {
 namespace dds {
 
 class DomainParticipant;
+class TopicDescriptionImpl;
+
 
 /**
  * Class TopicDescription, represents the fact that both publications
@@ -58,6 +60,8 @@ public:
     {
         return type_name_;
     }
+
+    virtual TopicDescriptionImpl* get_impl() const = 0;
 
 protected:
 

--- a/src/cpp/fastdds/topic/Topic.cpp
+++ b/src/cpp/fastdds/topic/Topic.cpp
@@ -105,6 +105,12 @@ ReturnCode_t Topic::get_inconsistent_topic_status(
     return ReturnCode_t::RETCODE_UNSUPPORTED;
 }
 
+TopicDescriptionImpl* Topic::get_impl() const
+{
+    return impl_;
+}
+
+
 } /* namespace dds */
 } /* namespace fastdds */
 } /* namespace eprosima */

--- a/src/cpp/fastdds/topic/Topic.cpp
+++ b/src/cpp/fastdds/topic/Topic.cpp
@@ -110,7 +110,6 @@ TopicDescriptionImpl* Topic::get_impl() const
     return impl_;
 }
 
-
 } /* namespace dds */
 } /* namespace fastdds */
 } /* namespace eprosima */

--- a/src/cpp/fastdds/topic/TopicDescriptionImpl.hpp
+++ b/src/cpp/fastdds/topic/TopicDescriptionImpl.hpp
@@ -33,7 +33,7 @@ class TopicDescriptionImpl
 public:
 
     TopicDescriptionImpl()
-    : num_refs_(0u)
+        : num_refs_(0u)
     {
     }
 

--- a/src/cpp/fastdds/topic/TopicDescriptionImpl.hpp
+++ b/src/cpp/fastdds/topic/TopicDescriptionImpl.hpp
@@ -1,0 +1,70 @@
+// Copyright 2019 Proyectos y Sistemas de Mantenimiento SL (eProsima).
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+/**
+ * @file TopicDescriptionImpl.hpp
+ *
+ */
+
+#ifndef _FASTDDS_TOPICDESCRIPTIONIMPL_HPP_
+#define _FASTDDS_TOPICDESCRIPTIONIMPL_HPP_
+#ifndef DOXYGEN_SHOULD_SKIP_THIS_PUBLIC
+
+namespace eprosima {
+namespace fastdds {
+namespace dds {
+
+class Topic;
+
+class TopicDescriptionImpl
+{
+
+public:
+
+    TopicDescriptionImpl()
+    : num_refs_(0u)
+    {
+    }
+
+    virtual ~TopicDescriptionImpl()
+    {
+    }
+
+
+    bool is_referenced() const
+    {
+        return num_refs_ != 0u;
+    }
+
+    void reference()
+    {
+        ++num_refs_;
+    }
+
+    void dereference()
+    {
+        --num_refs_;
+    }
+
+private:
+    std::atomic_size_t num_refs_;
+
+};
+
+} /* namespace dds */
+} /* namespace fastdds */
+} /* namespace eprosima */
+
+#endif /* DOXYGEN_SHOULD_SKIP_THIS_PUBLIC */
+#endif /* _FASTDDS_TOPICDESCRIPTIONIMPL_HPP_ */

--- a/src/cpp/fastdds/topic/TopicImpl.cpp
+++ b/src/cpp/fastdds/topic/TopicImpl.cpp
@@ -41,7 +41,6 @@ TopicImpl::TopicImpl(
     , qos_(&qos == &TOPIC_QOS_DEFAULT ? participant_->get_default_topic_qos() : qos)
     , listener_(listen)
     , user_topic_(nullptr)
-    , num_refs_(0u)
 {
 }
 
@@ -163,21 +162,6 @@ const Topic* TopicImpl::get_topic() const
 const TypeSupport& TopicImpl::get_type() const
 {
     return type_support_;
-}
-
-bool TopicImpl::is_referenced() const
-{
-    return num_refs_ != 0u;
-}
-
-void TopicImpl::reference()
-{
-    ++num_refs_;
-}
-
-void TopicImpl::dereference()
-{
-    --num_refs_;
 }
 
 } // dds

--- a/src/cpp/fastdds/topic/TopicImpl.hpp
+++ b/src/cpp/fastdds/topic/TopicImpl.hpp
@@ -24,6 +24,7 @@
 // #include <fastdds/dds/topic/TopicListener.hpp>
 #include <fastdds/dds/topic/qos/TopicQos.hpp>
 #include <fastdds/dds/topic/TypeSupport.hpp>
+#include <fastdds/topic/TopicDescriptionImpl.hpp>
 #include <fastrtps/types/TypesBase.h>
 
 #include <atomic>
@@ -39,7 +40,7 @@ class DomainParticipant;
 class TopicListener;
 class Topic;
 
-class TopicImpl
+class TopicImpl : public TopicDescriptionImpl
 {
     friend class DomainParticipantImpl;
 
@@ -81,12 +82,6 @@ public:
 
     const TypeSupport& get_type() const;
 
-    bool is_referenced() const;
-
-    void reference();
-
-    void dereference();
-
 private:
 
     DomainParticipantImpl* participant_;
@@ -94,8 +89,6 @@ private:
     TopicQos qos_;
     TopicListener* listener_;
     Topic* user_topic_;
-    std::atomic_size_t num_refs_;
-
 };
 
 } // dds


### PR DESCRIPTION
Make the reference count API accessible from TopicDescription but hide it from the user on an implementation class