### PR TITLE
DDS create_datareader

### DIFF
--- a/examples/C++/DDS/DynamicHelloWorldExample/HelloWorldSubscriber.h
+++ b/examples/C++/DDS/DynamicHelloWorldExample/HelloWorldSubscriber.h
@@ -61,6 +61,8 @@ private:
 
     eprosima::fastdds::dds::Subscriber* mp_subscriber;
 
+    std::map<eprosima::fastdds::dds::DataReader*, eprosima::fastdds::dds::Topic*> topics_;
+
     std::map<eprosima::fastdds::dds::DataReader*, eprosima::fastrtps::types::DynamicType_ptr> readers_;
 
     std::map<eprosima::fastdds::dds::DataReader*, eprosima::fastrtps::types::DynamicData_ptr> datas_;
@@ -68,8 +70,6 @@ private:
     eprosima::fastrtps::SubscriberAttributes att_;
 
     eprosima::fastdds::dds::DataReaderQos qos_;
-
-    eprosima::fastrtps::TopicAttributes topic_;
 
     std::mutex mutex_;
 

--- a/examples/C++/DDS/HelloWorldExample/HelloWorldSubscriber.cpp
+++ b/examples/C++/DDS/HelloWorldExample/HelloWorldSubscriber.cpp
@@ -30,6 +30,8 @@ using namespace eprosima::fastdds::dds;
 HelloWorldSubscriber::HelloWorldSubscriber()
     : participant_(nullptr)
     , subscriber_(nullptr)
+    , topic_(nullptr)
+    , reader_(nullptr)
     , type_(new HelloWorldPubSubType())
 {
 }
@@ -56,13 +58,21 @@ bool HelloWorldSubscriber::init()
         return false;
     }
 
+    //CREATE THE TOPIC
+    topic_ = participant_->create_topic(
+            "HelloWorldTopic",
+            "HelloWorld",
+            TOPIC_QOS_DEFAULT);
+
+    if (topic_ == nullptr)
+    {
+        return false;
+    }
+
     // CREATE THE READER
-    DataReaderQos rqos;
+    DataReaderQos rqos = DATAREADER_QOS_DEFAULT;
     rqos.reliability().kind = RELIABLE_RELIABILITY_QOS;
-    eprosima::fastrtps::TopicAttributes topic_att;
-    topic_att.topicDataType = "HelloWorld";
-    topic_att.topicName = "HelloWorldTopic";
-    reader_ = subscriber_->create_datareader(topic_att, rqos, &listener_);
+    reader_ = subscriber_->create_datareader(topic_, rqos, &listener_);
 
     if (reader_ == nullptr)
     {
@@ -74,6 +84,18 @@ bool HelloWorldSubscriber::init()
 
 HelloWorldSubscriber::~HelloWorldSubscriber()
 {
+    if (reader_ != nullptr)
+    {
+        subscriber_->delete_datareader(reader_);
+    }
+    if (topic_ != nullptr)
+    {
+        participant_->delete_topic(topic_);
+    }
+    if (subscriber_ != nullptr)
+    {
+        participant_->delete_subscriber(subscriber_);
+    }
     DomainParticipantFactory::get_instance()->delete_participant(participant_);
 }
 

--- a/examples/C++/DDS/HelloWorldExample/HelloWorldSubscriber.h
+++ b/examples/C++/DDS/HelloWorldExample/HelloWorldSubscriber.h
@@ -51,6 +51,8 @@ private:
 
     eprosima::fastdds::dds::Subscriber* subscriber_;
 
+    eprosima::fastdds::dds::Topic* topic_;
+
     eprosima::fastdds::dds::DataReader* reader_;
 
     eprosima::fastdds::dds::TypeSupport type_;

--- a/examples/C++/DDS/TypeLookupService/TypeLookupSubscriber.h
+++ b/examples/C++/DDS/TypeLookupService/TypeLookupSubscriber.h
@@ -61,6 +61,8 @@ private:
 
     eprosima::fastdds::dds::Subscriber* mp_subscriber;
 
+    std::map<eprosima::fastdds::dds::DataReader*, eprosima::fastdds::dds::Topic*> topics_;
+
     std::map<eprosima::fastdds::dds::DataReader*, eprosima::fastrtps::types::DynamicType_ptr> readers_;
 
     std::map<eprosima::fastdds::dds::DataReader*, eprosima::fastrtps::types::DynamicData_ptr> datas_;
@@ -68,8 +70,6 @@ private:
     eprosima::fastrtps::SubscriberAttributes att_;
 
     eprosima::fastdds::dds::DataReaderQos qos_;
-
-    eprosima::fastrtps::TopicAttributes topic_;
 
     std::mutex mutex_;
 

--- a/include/dds/sub/DataReader.hpp
+++ b/include/dds/sub/DataReader.hpp
@@ -1,0 +1,215 @@
+/*
+ * Copyright 2020, Proyectos y Sistemas de Mantenimiento SL (eProsima).
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef OMG_DDS_SUB_DATAREADER_HPP_
+#define OMG_DDS_SUB_DATAREADER_HPP_
+
+#include <dds/sub/detail/DataReader.hpp>
+
+#include <dds/core/Entity.hpp>
+#include <dds/sub/qos/DataReaderQos.hpp>
+#include <dds/sub/Subscriber.hpp>
+
+namespace dds {
+namespace sub {
+
+class DataReaderListener;
+
+/**
+ * @brief
+ * A DataReader allows the application to declare the data it wishes to receive.
+ *
+ * @see @ref DCPS_Modules_Datareader "Datareader"
+ */
+class DataReader : public dds::core::TEntity<detail::DataReader>
+{
+public:
+
+    /**
+     * Local convenience typedef for dds::pub::DataReaderListener.
+     */
+    typedef DataReaderListener Listener;
+
+    OMG_DDS_REF_TYPE_PROTECTED_DC(
+        DataReader,
+        dds::core::TEntity,
+        detail::DataReader)
+
+    OMG_DDS_IMPLICIT_REF_BASE(
+        DataReader)
+
+    /**
+     * Create a new DataReader.
+     *
+     * The DataReader will be created with the QoS values specified on the last
+     * successful call to @link dds::sub::Subscriber::default_DataReader_qos(const ::dds::sub::qos::DataReaderQos& qos)
+     * sub.default_DataReader_qos(qos) @endlink or, if the call was never made, the
+     * @ref anchor_dds_sub_DataReader_qos_defaults "default" values.
+     *
+     * @param sub the subscriber
+     * @param topic the topic the DataReader will be listening.
+     * @throws dds::core::Error
+     *                  An internal error has occurred.
+     * @throws dds::core::OutOfResourcesError
+     *                  The Data Distribution Service ran out of resources to
+     *                  complete this operation.
+     */
+    OMG_DDS_API DataReader(
+            const dds::sub::Subscriber& sub,
+            const dds::topic::Topic& topic);
+
+    /**
+     * Create a new DataReader.
+     *
+     * The DataReader will be created with the given QosPolicy settings and if
+     * applicable, attaches the optionally specified DataReaderListener to it.
+     *
+     * See @ref DCPS_Modules_Infrastructure_Listener "listener" for more information
+     * about listeners and possible status propagation to other entities.
+     *
+     * @param sub the subscriber to create the DataReader with.
+     * @param topic the topic the DataReader will be listening.
+     * @param qos a collection of QosPolicy settings for the new DataReader. In case
+     *            these settings are not self consistent, no DataReader is created.
+     * @param listener the DataReader listener
+     * @param mask the mask of events notified to the listener
+     * @throws dds::core::Error
+     *                  An internal error has occurred.
+     * @throws dds::core::OutOfResourcesError
+     *                  The Data Distribution Service ran out of resources to
+     *                  complete this operation.
+     * @throws dds::core::InconsistentPolicyError
+     *                  The parameter qos contains conflicting QosPolicy settings.
+     */
+    OMG_DDS_API DataReader(
+            const dds::sub::Subscriber& sub,
+            const dds::topic::Topic& topic,
+            const qos::DataReaderQos& qos,
+            DataReaderListener* listener = NULL,
+            const dds::core::status::StatusMask& mask = dds::core::status::StatusMask::none());
+
+    /** @cond */
+    virtual OMG_DDS_API ~DataReader();
+    /** @endcond */
+
+    //==========================================================================
+
+    /**
+     * Gets the DataReaderQos setting for this instance.
+     *
+     * @return the qos
+     * @throws dds::core::Error
+     *                  An internal error has occurred.
+     * @throws dds::core::NullReferenceError
+     *                  The entity was not properly created and references to dds::core::null.
+     * @throws dds::core::AlreadyClosedError
+     *                  The entity has already been closed.
+     * @throws dds::core::OutOfResourcesError
+     *                  The Data Distribution Service ran out of resources to
+     *                  complete this operation.
+     */
+    OMG_DDS_API const qos::DataReaderQos& qos() const;
+
+
+    /**
+     * Sets the DataReaderQos setting for this instance.
+     *
+     * @param qos the qos
+     * @throws dds::core::Error
+     *                  An internal error has occurred.
+     * @throws dds::core::NullReferenceError
+     *                  The entity was not properly created and references to dds::core::null.
+     * @throws dds::core::AlreadyClosedError
+     *                  The entity has already been closed.
+     * @throws dds::core::OutOfResourcesError
+     *                  The Data Distribution Service ran out of resources to
+     *                  complete this operation.
+     */
+    OMG_DDS_API void qos(
+            const qos::DataReaderQos& qos);
+
+    /** @copydoc dds::pub::DataReader::qos(const dds::pub::qos::DataReaderQos& qos) */
+    OMG_DDS_API DataReader& operator <<(
+            const qos::DataReaderQos& qos);
+
+    /** @copydoc dds::pub::DataReader::qos() */
+    OMG_DDS_API DataReader& operator >>(
+            qos::DataReaderQos& qos);
+
+    //==========================================================================
+
+    /**
+     * Register a listener with the DataReader.
+     *
+     * The notifications received by the listener depend on the
+     * status mask with which it was registered.
+     *
+     * Listener un-registration is performed by setting the listener to NULL.
+     *
+     * See also @ref DCPS_Modules_Infrastructure_Listener "listener information".
+     *
+     * @param plistener the listener
+     * @param mask      the mask defining the events for which the listener
+     *                  will be notified.
+     * @throws dds::core::Error
+     *                  An internal error has occurred.
+     * @throws dds::core::NullReferenceError
+     *                  The entity was not properly created and references to dds::core::null.
+     * @throws dds::core::AlreadyClosedError
+     *                  The entity has already been closed.
+     * @throws dds::core::UnsupportedError
+     *                  A status was selected that cannot be supported because
+     *                  the infrastructure does not maintain the required connectivity information.
+     * @throws dds::core::OutOfResourcesError
+     *                  The Data Distribution Service ran out of resources to
+     *                  complete this operation.
+     */
+    OMG_DDS_API void listener(
+            Listener* plistener,
+            const dds::core::status::StatusMask& mask);
+
+    /**
+     * Get the listener of this DataReader.
+     *
+     * See also @ref DCPS_Modules_Infrastructure_Listener "listener information".
+     *
+     * @return the listener
+     * @throws dds::core::NullReferenceError
+     *                  The entity was not properly created and references to dds::core::null.
+     */
+    OMG_DDS_API Listener* listener() const;
+
+    /**
+     * Return the Subscriber that owns this DataReader.
+     *
+     * @return the Subscriber
+     * @throws dds::core::Error
+     *                  An internal error has occurred.
+     * @throws dds::core::NullReferenceError
+     *                  The entity was not properly created and references to dds::core::null.
+     * @throws dds::core::AlreadyClosedError
+     *                  The entity has already been closed.
+     */
+    OMG_DDS_API const dds::sub::Subscriber& subscriber() const;
+
+    dds::sub::Subscriber* subscriber_;
+
+};
+
+} //namespace sub
+} //namespace dds
+
+#endif //OMG_DDS_SUB_DATAREADER_HPP_

--- a/include/dds/sub/DataReader.hpp
+++ b/include/dds/sub/DataReader.hpp
@@ -28,6 +28,8 @@ namespace sub {
 
 class DataReaderListener;
 
+//TODO: [ILG] Decide if we need to templatize the DataReader and derive from a AnyDataReader
+
 /**
  * @brief
  * A DataReader allows the application to declare the data it wishes to receive.

--- a/include/dds/sub/DataReaderListener.hpp
+++ b/include/dds/sub/DataReaderListener.hpp
@@ -1,0 +1,107 @@
+/*
+ * Copyright 2020, Proyectos y Sistemas de Mantenimiento SL (eProsima).
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef OMG_DDS_SUB_DATAREADER_LISTENER_HPP_
+#define OMG_DDS_SUB_DATAREADER_LISTENER_HPP_
+
+// TODO Remove when PSM DDS Listeners are ready to be used.
+#include <fastdds/dds/subscriber/DataReaderListener.hpp>
+
+// TODO uncomment when PSM DDS Listeners are ready to be used.
+//#include <dds/sub/AnyDataReaderListener.hpp>
+
+namespace dds {
+namespace sub {
+
+class SubscriberListener;
+class NoOpSubscriberListener;
+
+/**
+ * @brief
+ * DataReader events Listener
+ *
+ * Since a DataReader is an Entity, it has the ability to have a Listener
+ * associated with it. In this case, the associated Listener should be of type
+ * DataReaderListener. This interface must be implemented by the
+ * application. A user-defined class must be provided by the application which must
+ * extend from the DataReaderListener class.
+ *
+ * <b><i>
+ * All operations for this interface must be implemented in the user-defined class, it is
+ * up to the application whether an operation is empty or contains some functionality.
+ * </i></b>
+ *
+ * The DataReaderListener provides a generic mechanism (actually a
+ * callback function) for the Data Distribution Service to notify the application of
+ * relevant asynchronous status change events, such as a missed deadline, violation of
+ * a QosPolicy setting, etc. The DataReaderListener is related to
+ * changes in communication status StatusConditions.
+ */
+// TODO Uncomment when PSM listeners are implemented.
+//class OMG_DDS_API DataReaderListener : public virtual AnyDataReaderListener
+// TODO Remove the PSM listeners are implemented.
+class DataReaderListener : public eprosima::fastdds::dds::DataReaderListener
+{
+public:
+
+    /** @cond */
+    virtual ~DataReaderListener()
+    {
+    }
+
+    /** @endcond */
+};
+
+/**
+ * @brief
+ * DataReader events Listener
+ *
+ * This listener is just like DataReaderListener, except
+ * that the application doesn't have to implement all operations.
+ *
+ * @code{.cpp}
+ * class ExampleListener : public virtual dds::sub::NoOpDataReaderListener
+ * {
+ *    // Not necessary to implement any Listener operations.
+ * };
+ * @endcode
+ *
+ * @see dds::pub::DataReaderListener
+ */
+
+// TODO Uncomment when PSM DDS listeners are ready to be used
+/*
+   class OMG_DDS_API NoOpDataReaderListener :
+        public virtual DataReaderListener,
+        public virtual NoOpAnyDataReaderListener
+ */
+// TODO Remove the PSM listeners are implemented.
+class NoOpDataReaderListener : public virtual DataReaderListener
+{
+public:
+
+    /** @cond */
+    virtual ~NoOpDataReaderListener()
+    {
+    }
+
+    /** @endcond */
+};
+
+} //namespace sub
+} //namespace dds
+
+#endif //OMG_DDS_SUB_DATAREADER_LISTENER_HPP_

--- a/include/dds/sub/SubscriberListener.hpp
+++ b/include/dds/sub/SubscriberListener.hpp
@@ -98,7 +98,7 @@ class NoOpSubscriberListener;
  * @see @ref DCPS_Modules_Infrastructure_Listener "Listener information"
  */
 // TODO Uncomment when PSM listeners are implemented.
-//class OMG_DDS_API SubscriberListener : public virtual AnySubscriberListener
+//class OMG_DDS_API SubscriberListener : public virtual AnyDataReaderListener
 // TODO Remove the PSM listeners are implemented.
 class SubscriberListener : public eprosima::fastdds::dds::SubscriberListener
 {

--- a/include/dds/sub/SubscriberListener.hpp
+++ b/include/dds/sub/SubscriberListener.hpp
@@ -53,7 +53,7 @@ class NoOpSubscriberListener;
  * @code{.cpp}
  * // Application example listener
  * class ExampleListener :
- *                public virtual dds::pub::SubscriberListener
+ *                public virtual dds::sub::SubscriberListener
  * {
  * public:
  *     virtual void on_new_data_message (
@@ -98,7 +98,7 @@ class NoOpSubscriberListener;
  * @see @ref DCPS_Modules_Infrastructure_Listener "Listener information"
  */
 // TODO Uncomment when PSM listeners are implemented.
-//class OMG_DDS_API SubscriberListener : public virtual AnyDataReaderListener
+//class OMG_DDS_API SubscriberListener : public virtual AnySubscriberListener
 // TODO Remove the PSM listeners are implemented.
 class SubscriberListener : public eprosima::fastdds::dds::SubscriberListener
 {
@@ -120,7 +120,7 @@ public:
  * that the application doesn't have to implement all operations.
  *
  * @code{.cpp}
- * class ExampleListener : public virtual dds::pub::NoOpSubscriberListener
+ * class ExampleListener : public virtual dds::sub::NoOpSubscriberListener
  * {
  *    // Not necessary to implement any Listener operations.
  * };
@@ -133,7 +133,7 @@ public:
 /*
    class OMG_DDS_API NoOpSubscriberListener :
         public virtual SubscriberListener,
-        public virtual NoOpAnyDataReaderListener
+        public virtual NoOpAnySubscriberListener
  */
 // TODO Remove the PSM listeners are implemented.
 class NoOpSubscriberListener : public virtual SubscriberListener

--- a/include/dds/sub/detail/DataReader.hpp
+++ b/include/dds/sub/detail/DataReader.hpp
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2020, Proyectos y Sistemas de Mantenimiento SL (eProsima).
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+#ifndef EPROSIMA_DDS_SUB_DETAIL_DATAREADER_HPP_
+#define EPROSIMA_DDS_SUB_DETAIL_DATAREADER_HPP_
+
+#include <fastdds/dds/subscriber/DataReader.hpp>
+
+/**
+ * @cond
+ * Ignore this file in the API
+ */
+
+namespace dds {
+namespace sub {
+namespace detail {
+
+using DataReader = eprosima::fastdds::dds::DataReader;
+
+} //namespace detail
+} //namespace sub
+} //namespace dds
+
+/** @endcond */
+
+#endif //EPROSIMA_DDS_SUB_DETAIL_DATAREADER_HPP_

--- a/include/fastdds/dds/core/policy/QosPolicies.hpp
+++ b/include/fastdds/dds/core/policy/QosPolicies.hpp
@@ -1665,6 +1665,14 @@ public:
     }
 
     RTPS_DllAPI TypeIdV1(
+            const fastrtps::types::TypeIdentifier& identifier)
+        : Parameter_t(PID_TYPE_IDV1, 0)
+        , QosPolicy(false)
+        , m_type_identifier(identifier)
+    {
+    }
+
+    RTPS_DllAPI TypeIdV1(
             TypeIdV1&& type)
         : Parameter_t(type.Pid, type.length)
         , QosPolicy(type.send_always_)
@@ -1738,6 +1746,14 @@ public:
         : Parameter_t(type.Pid, type.length)
         , QosPolicy(type.send_always_)
         , m_type_object(type.m_type_object)
+    {
+    }
+
+    RTPS_DllAPI TypeObjectV1(
+            const fastrtps::types::TypeObject& type)
+        : Parameter_t(PID_TYPE_OBJECTV1, 0)
+        , QosPolicy(false)
+        , m_type_object(type)
     {
     }
 
@@ -1819,6 +1835,15 @@ public:
         , QosPolicy(type.send_always_)
         , type_information(type.type_information)
         , assigned_(type.assigned_)
+    {
+    }
+
+    RTPS_DllAPI TypeInformation(
+            const fastrtps::types::TypeInformation& info)
+        : Parameter_t(PID_TYPE_INFORMATION, 0)
+        , QosPolicy(false)
+        , type_information(info)
+        , assigned_(true)
     {
     }
 

--- a/include/fastdds/dds/subscriber/DataReader.hpp
+++ b/include/fastdds/dds/subscriber/DataReader.hpp
@@ -32,6 +32,14 @@
 
 using eprosima::fastrtps::types::ReturnCode_t;
 
+namespace dds {
+namespace sub {
+
+class DataReader;
+
+} // namespace sub
+} // namespace dds
+
 namespace eprosima {
 namespace fastrtps {
 
@@ -56,6 +64,7 @@ class DataReaderImpl;
 class DataReaderListener;
 class TypeSupport;
 class DataReaderQos;
+class TopicDescription;
 struct LivelinessChangedStatus;
 
 /**
@@ -64,6 +73,7 @@ struct LivelinessChangedStatus;
  */
 class RTPS_DllAPI DataReader : public DomainEntity
 {
+    friend class DataReaderImpl;
     friend class SubscriberImpl;
 
     /**
@@ -71,6 +81,13 @@ class RTPS_DllAPI DataReader : public DomainEntity
      */
     DataReader(
             DataReaderImpl* impl,
+            const StatusMask& mask = StatusMask::all());
+
+    DataReader(
+            Subscriber* s,
+            const TopicDescription* topic,
+            const DataReaderQos& qos,
+            DataReaderListener* listener = nullptr,
             const StatusMask& mask = StatusMask::all());
 
 public:
@@ -200,6 +217,9 @@ public:
 private:
 
     DataReaderImpl* impl_;
+
+    friend class ::dds::sub::DataReader;
+
 };
 
 } /* namespace dds */

--- a/include/fastdds/dds/subscriber/DataReader.hpp
+++ b/include/fastdds/dds/subscriber/DataReader.hpp
@@ -85,7 +85,7 @@ class RTPS_DllAPI DataReader : public DomainEntity
 
     DataReader(
             Subscriber* s,
-            const TopicDescription* topic,
+            TopicDescription* topic,
             const DataReaderQos& qos,
             DataReaderListener* listener = nullptr,
             const StatusMask& mask = StatusMask::all());
@@ -154,16 +154,17 @@ public:
     TypeSupport type();
 
     /**
+     * Get TopicDescription
+     * @return TopicDescription
+     */
+    const TopicDescription* topic() const;
+
+    /**
      * @brief Get the requested deadline missed status
      * @return The deadline missed status
      */
     ReturnCode_t get_requested_deadline_missed_status(
             fastrtps::RequestedDeadlineMissedStatus& status);
-
-    bool set_attributes(
-            const fastrtps::rtps::ReaderAttributes& att);
-
-    const fastrtps::rtps::ReaderAttributes& get_attributes() const;
 
     ReturnCode_t set_qos(
             const DataReaderQos& qos);
@@ -172,11 +173,6 @@ public:
 
     ReturnCode_t get_qos(
             DataReaderQos& qos) const;
-
-    bool set_topic(
-            const fastrtps::TopicAttributes& att);
-
-    const fastrtps::TopicAttributes& get_topic() const;
 
     ReturnCode_t set_listener(
             DataReaderListener* listener);

--- a/include/fastdds/dds/subscriber/DataReader.hpp
+++ b/include/fastdds/dds/subscriber/DataReader.hpp
@@ -71,7 +71,7 @@ struct LivelinessChangedStatus;
  * Class DataReader, contains the actual implementation of the behaviour of the Subscriber.
  *  @ingroup FASTDDS_MODULE
  */
-class RTPS_DllAPI DataReader : public DomainEntity
+class DataReader : public DomainEntity
 {
     friend class DataReaderImpl;
     friend class SubscriberImpl;
@@ -79,11 +79,11 @@ class RTPS_DllAPI DataReader : public DomainEntity
     /**
      * Creates a DataReader. Don't use it directly, but through Subscriber.
      */
-    DataReader(
+    RTPS_DllAPI DataReader(
             DataReaderImpl* impl,
             const StatusMask& mask = StatusMask::all());
 
-    DataReader(
+    RTPS_DllAPI DataReader(
             Subscriber* s,
             TopicDescription* topic,
             const DataReaderQos& qos,
@@ -92,12 +92,12 @@ class RTPS_DllAPI DataReader : public DomainEntity
 
 public:
 
-    virtual ~DataReader();
+    RTPS_DllAPI virtual ~DataReader();
 
     /**
      * Method to block the current thread until an unread message is available
      */
-    bool wait_for_unread_message(
+    RTPS_DllAPI bool wait_for_unread_message(
             const fastrtps::Duration_t& timeout);
 
 
@@ -108,24 +108,24 @@ public:
     ///@{
 
     /* TODO
-       bool read(
+       RTPS_DllAPI bool read(
             std::vector<void*>& data_values,
             std::vector<fastrtps::SampleInfo_t>& sample_infos,
             uint32_t max_samples);
      */
 
-    ReturnCode_t read_next_sample(
+    RTPS_DllAPI ReturnCode_t read_next_sample(
             void* data,
             fastrtps::SampleInfo_t* info);
 
     /* TODO
-       bool take(
+       RTPS_DllAPI bool take(
             std::vector<void*>& data_values,
             std::vector<fastrtps::SampleInfo_t>& sample_infos,
             uint32_t max_samples);
      */
 
-    ReturnCode_t take_next_sample(
+    RTPS_DllAPI ReturnCode_t take_next_sample(
             void* data,
             fastrtps::SampleInfo_t* info);
 
@@ -136,16 +136,16 @@ public:
      * @param [out] info Pointer to a SampleInfo_t structure to store first untaken sample information.
      * @return RETCODE_OK if sample info was returned. RETCODE_NO_DATA if there is no sample to take.
      */
-    ReturnCode_t get_first_untaken_info(
+    RTPS_DllAPI ReturnCode_t get_first_untaken_info(
             fastrtps::SampleInfo_t* info);
 
     /**
      * Get associated GUID
      * @return Associated GUID
      */
-    const fastrtps::rtps::GUID_t& guid();
+    RTPS_DllAPI const fastrtps::rtps::GUID_t& guid();
 
-    fastrtps::rtps::InstanceHandle_t get_instance_handle() const;
+    RTPS_DllAPI fastrtps::rtps::InstanceHandle_t get_instance_handle() const;
 
     /**
      * Get topic data type
@@ -163,50 +163,50 @@ public:
      * @brief Get the requested deadline missed status
      * @return The deadline missed status
      */
-    ReturnCode_t get_requested_deadline_missed_status(
+    RTPS_DllAPI ReturnCode_t get_requested_deadline_missed_status(
             fastrtps::RequestedDeadlineMissedStatus& status);
 
-    ReturnCode_t set_qos(
+    RTPS_DllAPI ReturnCode_t set_qos(
             const DataReaderQos& qos);
 
-    const DataReaderQos& get_qos() const;
+    RTPS_DllAPI const DataReaderQos& get_qos() const;
 
-    ReturnCode_t get_qos(
+    RTPS_DllAPI ReturnCode_t get_qos(
             DataReaderQos& qos) const;
 
-    ReturnCode_t set_listener(
+    RTPS_DllAPI ReturnCode_t set_listener(
             DataReaderListener* listener);
 
-    const DataReaderListener* get_listener() const;
+    RTPS_DllAPI const DataReaderListener* get_listener() const;
 
     /* TODO
-       bool get_key_value(
+       RTPS_DllAPI bool get_key_value(
             void* data,
             const fastrtps::rtps::InstanceHandle_t& handle);
      */
 
-    ReturnCode_t get_liveliness_changed_status(
+    RTPS_DllAPI ReturnCode_t get_liveliness_changed_status(
             LivelinessChangedStatus& status) const;
 
     /* TODO
-       bool get_requested_incompatible_qos_status(
+       RTPS_DllAPI bool get_requested_incompatible_qos_status(
             fastrtps::RequestedIncompatibleQosStatus& status) const;
      */
 
     /* TODO
-       bool get_sample_lost_status(
+       RTPS_DllAPI bool get_sample_lost_status(
             fastrtps::SampleLostStatus& status) const;
      */
 
     /* TODO
-       bool get_sample_rejected_status(
+       RTPS_DllAPI bool get_sample_rejected_status(
             fastrtps::SampleRejectedStatus& status) const;
      */
 
-    const Subscriber* get_subscriber() const;
+    RTPS_DllAPI const Subscriber* get_subscriber() const;
 
     /* TODO
-       bool wait_for_historical_data(
+       RTPS_DllAPI bool wait_for_historical_data(
             const fastrtps::Duration_t& max_wait) const;
      */
 

--- a/include/fastdds/dds/subscriber/DataReader.hpp
+++ b/include/fastdds/dds/subscriber/DataReader.hpp
@@ -157,7 +157,7 @@ public:
      * Get TopicDescription
      * @return TopicDescription
      */
-    const TopicDescription* topic() const;
+    const TopicDescription* get_topicdescription() const;
 
     /**
      * @brief Get the requested deadline missed status

--- a/include/fastdds/dds/subscriber/DataReader.hpp
+++ b/include/fastdds/dds/subscriber/DataReader.hpp
@@ -23,6 +23,8 @@
 
 #include <fastrtps/qos/DeadlineMissedStatus.h>
 #include <fastdds/rtps/common/Time_t.h>
+#include <fastdds/dds/core/status/StatusMask.hpp>
+#include <fastdds/dds/core/Entity.hpp>
 #include <fastrtps/types/TypesBase.h>
 
 #include <vector>
@@ -60,7 +62,7 @@ struct LivelinessChangedStatus;
  * Class DataReader, contains the actual implementation of the behaviour of the Subscriber.
  *  @ingroup FASTDDS_MODULE
  */
-class RTPS_DllAPI DataReader
+class RTPS_DllAPI DataReader : public DomainEntity
 {
     friend class SubscriberImpl;
 
@@ -68,7 +70,8 @@ class RTPS_DllAPI DataReader
      * Creates a DataReader. Don't use it directly, but through Subscriber.
      */
     DataReader(
-            DataReaderImpl* impl);
+            DataReaderImpl* impl,
+            const StatusMask& mask = StatusMask::all());
 
 public:
 

--- a/include/fastdds/dds/subscriber/Subscriber.hpp
+++ b/include/fastdds/dds/subscriber/Subscriber.hpp
@@ -127,7 +127,7 @@ public:
      * @return Pointer to the created DataReader. nullptr if failed.
      */
     RTPS_DllAPI DataReader* create_datareader(
-            const TopicDescription* topic,
+            TopicDescription* topic,
             const DataReaderQos& reader_qos,
             DataReaderListener* listener = nullptr,
             const StatusMask& mask = StatusMask::all());

--- a/include/fastdds/dds/subscriber/Subscriber.hpp
+++ b/include/fastdds/dds/subscriber/Subscriber.hpp
@@ -53,7 +53,7 @@ class SubscriberImpl;
 class DataReader;
 class DataReaderListener;
 class DataReaderQos;
-
+class TopicDescription;
 /**
  * Class Subscriber, contains the public API that allows the user to control the reception of messages.
  * This class should not be instantiated directly.
@@ -127,9 +127,10 @@ public:
      * @return Pointer to the created DataReader. nullptr if failed.
      */
     RTPS_DllAPI DataReader* create_datareader(
-            const fastrtps::TopicAttributes& topic_attr,
+            const TopicDescription* topic,
             const DataReaderQos& reader_qos,
-            DataReaderListener* listener);
+            DataReaderListener* listener = nullptr,
+            const StatusMask& mask = StatusMask::all());
 
     /**
      * This operation deletes a DataReader that belongs to the Subscriber.

--- a/src/cpp/CMakeLists.txt
+++ b/src/cpp/CMakeLists.txt
@@ -102,6 +102,8 @@ set(${PROJECT_NAME}_source_files
     fastdds/subscriber/SubscriberImpl.cpp
     fastdds/subscriber/qos/SubscriberQos.cpp
     fastdds/subscriber/Subscriber.cpp
+    fastdds/subscriber/DataReader.cpp
+    fastdds/subscriber/DataReaderImpl.cpp
     fastdds/domain/DomainParticipantFactory.cpp
     fastdds/domain/DomainParticipantImpl.cpp
     fastdds/domain/DomainParticipant.cpp
@@ -205,6 +207,7 @@ set(${PROJECT_NAME}_source_files
     dds/pub/AnyDataWriter.cpp
     dds/pub/DataWriter.cpp
     dds/sub/Subscriber.cpp
+    dds/sub/DataReader.cpp
     dds/topic/Topic.cpp
     )
 

--- a/src/cpp/dds/sub/DataReader.cpp
+++ b/src/cpp/dds/sub/DataReader.cpp
@@ -1,0 +1,111 @@
+/*
+ * Copyright 2020, Proyectos y Sistemas de Mantenimiento SL (eProsima).
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+/**
+ * @file
+ */
+
+/*
+ * OMG PSM class declaration
+ */
+#include <dds/sub/DataReader.hpp>
+#include <dds/sub/DataReaderListener.hpp>
+#include <dds/topic/Topic.hpp>
+
+namespace dds {
+namespace sub {
+
+DataReader::DataReader(
+        const Subscriber& sub,
+        const dds::topic::Topic& topic)
+    : ::dds::core::Reference<detail::DataReader>(
+        new detail::DataReader(
+            sub.delegate().get(),
+            topic.delegate().get(),
+            sub.default_datareader_qos(),
+            nullptr,
+            dds::core::status::StatusMask::all()))
+    , subscriber_(nullptr)
+{
+}
+
+DataReader::DataReader(
+        const Subscriber& sub,
+        const dds::topic::Topic& topic,
+        const qos::DataReaderQos& qos,
+        DataReaderListener* listener,
+        const dds::core::status::StatusMask& mask)
+    : ::dds::core::Reference<detail::DataReader>(
+        new detail::DataReader(
+            sub.delegate().get(), topic.delegate().get(), qos, listener, mask))
+    , subscriber_(nullptr)
+{
+}
+
+DataReader::~DataReader()
+{
+}
+
+//const qos::DataReaderQos& DataReader::qos() const
+//{
+//    return delegate()->get_qos();
+//}
+
+//void DataReader::qos(
+//        const qos::DataReaderQos& pqos)
+//{
+//    delegate()->set_qos(pqos);
+//}
+
+//DataReader& DataReader::operator <<(
+//        const qos::DataReaderQos& qos)
+//{
+//    this->qos(qos);
+//    return *this;
+//}
+
+//DataReader& DataReader::operator >>(
+//        qos::DataReaderQos& qos)
+//{
+//    qos = this->qos();
+//    return *this;
+//}
+
+//void DataReader::listener(
+//        Listener* plistener,
+//        const dds::core::status::StatusMask& /*event_mask*/)
+//{
+//    delegate()->set_listener(plistener /*, event_mask*/);
+//}
+
+//typename DataReader::Listener* DataReader::listener() const
+//{
+//    return dynamic_cast<Listener*>(delegate()->get_listener());
+//}
+
+//const dds::sub::Subscriber& DataReader::subscriber() const
+//{
+//    eprosima::fastdds::dds::Subscriber s = delegate()->get_subscriber();
+//    std::shared_ptr<eprosima::fastdds::dds::Subscriber> ptr(&s);
+//    subscriber_->delegate().swap(ptr);
+
+//    return *subscriber;
+//}
+
+} //namespace sub
+} //namespace dds
+

--- a/src/cpp/fastdds/subscriber/DataReader.cpp
+++ b/src/cpp/fastdds/subscriber/DataReader.cpp
@@ -200,9 +200,9 @@ TypeSupport DataReader::type()
 }
 
 
-const TopicDescription* DataReader::topic() const
+const TopicDescription* DataReader::get_topicdescription() const
 {
-    return impl_->topic();
+    return impl_->get_topicdescription();
 }
 
 } /* namespace dds */

--- a/src/cpp/fastdds/subscriber/DataReader.cpp
+++ b/src/cpp/fastdds/subscriber/DataReader.cpp
@@ -30,8 +30,10 @@ namespace fastdds {
 namespace dds {
 
 DataReader::DataReader(
-        DataReaderImpl* impl)
-    : impl_(impl)
+        DataReaderImpl* impl,
+        const StatusMask& mask)
+    : DomainEntity(mask)
+    , impl_(impl)
 {
 }
 

--- a/src/cpp/fastdds/subscriber/DataReader.cpp
+++ b/src/cpp/fastdds/subscriber/DataReader.cpp
@@ -19,6 +19,7 @@
 
 #include <fastdds/dds/subscriber/DataReader.hpp>
 #include <fastdds/subscriber/DataReaderImpl.hpp>
+#include <fastdds/dds/subscriber/Subscriber.hpp>
 
 
 namespace eprosima {
@@ -34,6 +35,17 @@ DataReader::DataReader(
         const StatusMask& mask)
     : DomainEntity(mask)
     , impl_(impl)
+{
+}
+
+DataReader::DataReader(
+        Subscriber* s,
+        const TopicDescription* topic,
+        const DataReaderQos& qos,
+        DataReaderListener* listener,
+        const StatusMask& mask)
+    : DomainEntity(mask)
+    , impl_(s->create_datareader(topic, qos, listener, mask)->impl_)
 {
 }
 

--- a/src/cpp/fastdds/subscriber/DataReader.cpp
+++ b/src/cpp/fastdds/subscriber/DataReader.cpp
@@ -40,7 +40,7 @@ DataReader::DataReader(
 
 DataReader::DataReader(
         Subscriber* s,
-        const TopicDescription* topic,
+        TopicDescription* topic,
         const DataReaderQos& qos,
         DataReaderListener* listener,
         const StatusMask& mask)
@@ -95,12 +95,6 @@ ReturnCode_t DataReader::set_qos(
     return impl_->set_qos(qos);
 }
 
-bool DataReader::set_topic(
-        const TopicAttributes& topic_att)
-{
-    return impl_->set_topic(topic_att);
-}
-
 const DataReaderQos& DataReader::get_qos() const
 {
     return impl_->get_qos();
@@ -111,22 +105,6 @@ ReturnCode_t DataReader::get_qos(
 {
     qos = impl_->get_qos();
     return ReturnCode_t::RETCODE_OK;
-}
-
-const TopicAttributes& DataReader::get_topic() const
-{
-    return impl_->get_topic();
-}
-
-bool DataReader::set_attributes(
-        const fastrtps::rtps::ReaderAttributes& att)
-{
-    return impl_->set_attributes(att);
-}
-
-const ReaderAttributes& DataReader::get_attributes() const
-{
-    return impl_->get_attributes();
 }
 
 ReturnCode_t DataReader::get_requested_deadline_missed_status(
@@ -219,6 +197,12 @@ const Subscriber* DataReader::get_subscriber() const
 TypeSupport DataReader::type()
 {
     return impl_->type();
+}
+
+
+const TopicDescription* DataReader::topic() const
+{
+    return impl_->topic();
 }
 
 } /* namespace dds */

--- a/src/cpp/fastdds/subscriber/DataReaderImpl.cpp
+++ b/src/cpp/fastdds/subscriber/DataReaderImpl.cpp
@@ -45,17 +45,16 @@ namespace dds {
 DataReaderImpl::DataReaderImpl(
         SubscriberImpl* s,
         TypeSupport& type,
-        const TopicDescription* topic,
+        TopicDescription* topic,
         const DataReaderQos& qos,
         DataReaderListener* listener)
     : subscriber_(s)
     , reader_(nullptr)
     , type_(type)
-    , topic_att_()
-    , att_()
+    , topic_(topic)
     , qos_(&qos == &DATAREADER_QOS_DEFAULT ? subscriber_->get_default_datareader_qos() : qos)
 #pragma warning (disable : 4355 )
-    , history_(topic_att_,
+    , history_(topic_attributes(),
             type_.get(),
             qos_.get_readerqos(subscriber_->get_qos()),
             type_->m_typeSize + 3,    /* Possible alignment */
@@ -81,54 +80,36 @@ DataReaderImpl::DataReaderImpl(
                 },
                     qos_.lifespan().duration.to_ns() * 1e-6);
 
-    topic_att_.topicKind = type->m_isGetKeyDefined ? WITH_KEY : NO_KEY;
-    topic_att_.topicName = topic->get_name();
-    topic_att_.topicDataType = topic->get_type_name();
-    topic_att_.historyQos = qos.history();
-    topic_att_.resourceLimitsQos = qos.resource_limits();
-    if (type->type_object())
-    {
-        topic_att_.type = *type->type_object();
-    }
-    if (type->type_identifier())
-    {
-        topic_att_.type_id = *type->type_identifier();
-    }
-    if (type->type_information())
-    {
-        topic_att_.type_information = *type->type_information();
-    }
-    topic_att_.auto_fill_type_object = type->auto_fill_type_object();
-    topic_att_.auto_fill_type_information = type->auto_fill_type_information();
+    fastrtps::rtps::ReaderAttributes att;
 
-    att_.endpoint.durabilityKind = qos.durability().durabilityKind();
-    att_.endpoint.endpointKind = READER;
-    att_.endpoint.multicastLocatorList = qos.endpoint().multicast_locator_list;
-    att_.endpoint.reliabilityKind = qos.reliability().kind == RELIABLE_RELIABILITY_QOS ? RELIABLE : BEST_EFFORT;
-    att_.endpoint.topicKind = topic_att_.topicKind;
-    att_.endpoint.unicastLocatorList = qos.endpoint().unicast_locator_list;
-    att_.endpoint.remoteLocatorList = qos.endpoint().remote_locator_list;
-    att_.expectsInlineQos = qos.expects_inline_qos();
-    att_.endpoint.properties = qos.properties();
+    att.endpoint.durabilityKind = qos.durability().durabilityKind();
+    att.endpoint.endpointKind = READER;
+    att.endpoint.multicastLocatorList = qos.endpoint().multicast_locator_list;
+    att.endpoint.reliabilityKind = qos.reliability().kind == RELIABLE_RELIABILITY_QOS ? RELIABLE : BEST_EFFORT;
+    att.endpoint.topicKind = type->m_isGetKeyDefined ? WITH_KEY : NO_KEY;
+    att.endpoint.unicastLocatorList = qos.endpoint().unicast_locator_list;
+    att.endpoint.remoteLocatorList = qos.endpoint().remote_locator_list;
+    att.expectsInlineQos = qos.expects_inline_qos();
+    att.endpoint.properties = qos.properties();
 
     if (qos.endpoint().entity_id > 0)
     {
-        att_.endpoint.setEntityID(static_cast<uint8_t>(qos.endpoint().entity_id));
+        att.endpoint.setEntityID(static_cast<uint8_t>(qos.endpoint().entity_id));
     }
 
     if (qos.endpoint().user_defined_id > 0)
     {
-        att_.endpoint.setUserDefinedID(static_cast<uint8_t>(qos.endpoint().user_defined_id));
+        att.endpoint.setUserDefinedID(static_cast<uint8_t>(qos.endpoint().user_defined_id));
     }
 
-    att_.times = qos.reliable_reader_qos().reader_times;
+    att.times = qos.reliable_reader_qos().reader_times;
 
     // TODO(Ricardo) Remove in future
     // Insert topic_name and partitions
     Property property;
     property.name("topic_name");
     property.value(topic->get_name().c_str());
-    att_.endpoint.properties.properties().push_back(std::move(property));
+    att.endpoint.properties.properties().push_back(std::move(property));
     if (s->get_qos().partition().names().size() > 0)
     {
         property.name("partitions");
@@ -138,16 +119,16 @@ DataReaderImpl::DataReaderImpl(
             partitions += partition + ";";
         }
         property.value(std::move(partitions));
-        att_.endpoint.properties.properties().push_back(std::move(property));
+        att.endpoint.properties.properties().push_back(std::move(property));
     }
     if (qos.reliable_reader_qos().disable_positive_ACKs.enabled)
     {
-        att_.disable_positive_acks = true;
+        att.disable_positive_acks = true;
     }
 
     RTPSReader* reader = RTPSDomain::createRTPSReader(
         subscriber_->rtps_participant(),
-        att_,
+        att,
         static_cast<ReaderHistory*>(&history_),
         static_cast<ReaderListener*>(&reader_listener_));
 
@@ -175,7 +156,7 @@ DataReaderImpl::~DataReaderImpl()
 
     if (reader_ != nullptr)
     {
-        logInfo(DATA_READER, guid().entityId << " in topic: " << topic_att_.topicName);
+        logInfo(DATA_READER, guid().entityId << " in topic: " << topic_->get_name());
     }
 
     RTPSDomain::removeRTPSReader(reader_);
@@ -268,7 +249,7 @@ ReturnCode_t DataReaderImpl::set_qos(
 
     //NOTIFY THE BUILTIN PROTOCOLS THAT THE READER HAS CHANGED
     ReaderQos rqos = qos.get_readerqos(get_subscriber()->get_qos());
-    subscriber_->rtps_participant()->updateReader(reader_, topic_att_, rqos);
+    subscriber_->rtps_participant()->updateReader(reader_, topic_attributes(), rqos);
 
     // Deadline
     if (qos_.deadline().period != c_TimeInfinite)
@@ -300,92 +281,6 @@ ReturnCode_t DataReaderImpl::set_qos(
 const DataReaderQos& DataReaderImpl::get_qos() const
 {
     return qos_;
-}
-
-bool DataReaderImpl::set_topic(
-        const TopicAttributes& topic_att)
-{
-    //TOPIC ATTRIBUTES
-    if (topic_att_ != topic_att)
-    {
-        logWarning(RTPS_READER, "Topic Attributes cannot be updated");
-        return false;
-    }
-    //NOTIFY THE BUILTIN PROTOCOLS THAT THE READER HAS CHANGED
-    //subscriber_->update_reader(this, topic_att_, qos_);
-    //subscriber_->rtps_participant()->updateReader(reader_, topic_att_, qos_);
-    return true;
-}
-
-const TopicAttributes& DataReaderImpl::get_topic() const
-{
-    return topic_att_;
-}
-
-bool DataReaderImpl::set_attributes(
-        const fastrtps::rtps::ReaderAttributes& att)
-{
-    bool updated = true;
-    bool missing = false;
-    if (att.endpoint.unicastLocatorList.size() != att_.endpoint.unicastLocatorList.size() ||
-            att.endpoint.multicastLocatorList.size() != att_.endpoint.multicastLocatorList.size())
-    {
-        logWarning(RTPS_READER, "Locator Lists cannot be changed or updated in this version");
-        updated &= false;
-    }
-    else
-    {
-        for (LocatorListConstIterator lit1 = att_.endpoint.unicastLocatorList.begin();
-                lit1 != att_.endpoint.unicastLocatorList.end(); ++lit1)
-        {
-            missing = true;
-            for (LocatorListConstIterator lit2 = att.endpoint.unicastLocatorList.begin();
-                    lit2 != att.endpoint.unicastLocatorList.end(); ++lit2)
-            {
-                if (*lit1 == *lit2)
-                {
-                    missing = false;
-                    break;
-                }
-            }
-            if (missing)
-            {
-                logWarning(RTPS_READER, "Locator: " << *lit1 << " not present in new list");
-                logWarning(RTPS_READER, "Locator Lists cannot be changed or updated in this version");
-            }
-        }
-        for (LocatorListConstIterator lit1 = att_.endpoint.multicastLocatorList.begin();
-                lit1 != att_.endpoint.multicastLocatorList.end(); ++lit1)
-        {
-            missing = true;
-            for (LocatorListConstIterator lit2 = att.endpoint.multicastLocatorList.begin();
-                    lit2 != att.endpoint.multicastLocatorList.end(); ++lit2)
-            {
-                if (*lit1 == *lit2)
-                {
-                    missing = false;
-                    break;
-                }
-            }
-            if (missing)
-            {
-                logWarning(RTPS_READER, "Locator: " << *lit1 << " not present in new list");
-                logWarning(RTPS_READER, "Locator Lists cannot be changed or updated in this version");
-            }
-        }
-    }
-
-    if (updated)
-    {
-        att_.expectsInlineQos = att.expectsInlineQos;
-    }
-
-    return updated;
-}
-
-const ReaderAttributes& DataReaderImpl::get_attributes() const
-{
-    return att_;
 }
 
 void DataReaderImpl::InnerDataReaderListener::onNewCacheChangeAdded(
@@ -697,6 +592,11 @@ const Subscriber* DataReaderImpl::get_subscriber() const
    }
  */
 
+const TopicDescription* DataReaderImpl::topic() const
+{
+    return topic_;
+}
+
 TypeSupport DataReaderImpl::type()
 {
     return type_;
@@ -874,6 +774,33 @@ void DataReaderImpl::set_qos(
         to.reader_resource_limits() = from.reader_resource_limits();
     }
 }
+
+fastrtps::TopicAttributes DataReaderImpl::topic_attributes() const
+{
+    fastrtps::TopicAttributes topic_att;
+    topic_att.topicKind = type_->m_isGetKeyDefined ? WITH_KEY : NO_KEY;
+    topic_att.topicName = topic_->get_name();
+    topic_att.topicDataType = topic_->get_type_name();
+    topic_att.historyQos = qos_.history();
+    topic_att.resourceLimitsQos = qos_.resource_limits();
+    if (type_->type_object())
+    {
+        topic_att.type = *type_->type_object();
+    }
+    if (type_->type_identifier())
+    {
+        topic_att.type_id = *type_->type_identifier();
+    }
+    if (type_->type_information())
+    {
+        topic_att.type_information = *type_->type_information();
+    }
+    topic_att.auto_fill_type_object = type_->auto_fill_type_object();
+    topic_att.auto_fill_type_information = type_->auto_fill_type_information();
+
+    return topic_att;
+}
+
 
 
 } /* namespace dds */

--- a/src/cpp/fastdds/subscriber/DataReaderImpl.cpp
+++ b/src/cpp/fastdds/subscriber/DataReaderImpl.cpp
@@ -592,7 +592,7 @@ const Subscriber* DataReaderImpl::get_subscriber() const
    }
  */
 
-const TopicDescription* DataReaderImpl::topic() const
+const TopicDescription* DataReaderImpl::get_topicdescription() const
 {
     return topic_;
 }

--- a/src/cpp/fastdds/subscriber/DataReaderImpl.hpp
+++ b/src/cpp/fastdds/subscriber/DataReaderImpl.hpp
@@ -71,7 +71,7 @@ class DataReaderImpl
     DataReaderImpl(
             SubscriberImpl* s,
             TypeSupport& type,
-            const TopicDescription* topic,
+            TopicDescription* topic,
             const DataReaderQos& qos,
             DataReaderListener* listener = nullptr);
 
@@ -139,26 +139,22 @@ public:
     TypeSupport type();
 
     /**
+     * Get TopicDescription
+     * @return TopicDescription
+     */
+    const TopicDescription* topic() const;
+
+    /**
      * @brief Get the requested deadline missed status
      * @return The deadline missed status
      */
     ReturnCode_t get_requested_deadline_missed_status(
             fastrtps::RequestedDeadlineMissedStatus& status);
 
-    bool set_attributes(
-            const fastrtps::rtps::ReaderAttributes& att);
-
-    const fastrtps::rtps::ReaderAttributes& get_attributes() const;
-
     ReturnCode_t set_qos(
             const DataReaderQos& qos);
 
     const DataReaderQos& get_qos() const;
-
-    bool set_topic(
-            const fastrtps::TopicAttributes& att);
-
-    const fastrtps::TopicAttributes& get_topic() const;
 
     ReturnCode_t set_listener(
             DataReaderListener* listener);
@@ -236,10 +232,7 @@ private:
     //! Pointer to the TopicDataType object.
     TypeSupport type_;
 
-    fastrtps::TopicAttributes topic_att_;
-
-    //!Attributes of the Subscriber
-    fastrtps::rtps::ReaderAttributes att_;
+    TopicDescription* topic_;
 
     DataReaderQos qos_;
 
@@ -320,6 +313,8 @@ public:
      * @brief A method called when the lifespan timer expires
      */
     bool lifespan_expired();
+
+    fastrtps::TopicAttributes topic_attributes() const;
 
 };
 

--- a/src/cpp/fastdds/subscriber/DataReaderImpl.hpp
+++ b/src/cpp/fastdds/subscriber/DataReaderImpl.hpp
@@ -55,6 +55,7 @@ namespace dds {
 
 class Subscriber;
 class SubscriberImpl;
+class TopicDescription;
 
 /**
  * Class DataReader, contains the actual implementation of the behaviour of the Subscriber.
@@ -69,11 +70,9 @@ class DataReaderImpl
      */
     DataReaderImpl(
             SubscriberImpl* s,
-            TypeSupport type,
-            const fastrtps::TopicAttributes& topic_att,
-            const fastrtps::rtps::ReaderAttributes& att,
+            TypeSupport& type,
+            const TopicDescription* topic,
             const DataReaderQos& qos,
-            const fastrtps::rtps::MemoryManagementPolicy_t memory_policy,
             DataReaderListener* listener = nullptr);
 
 public:

--- a/src/cpp/fastdds/subscriber/DataReaderImpl.hpp
+++ b/src/cpp/fastdds/subscriber/DataReaderImpl.hpp
@@ -142,7 +142,7 @@ public:
      * Get TopicDescription
      * @return TopicDescription
      */
-    const TopicDescription* topic() const;
+    const TopicDescription* get_topicdescription() const;
 
     /**
      * @brief Get the requested deadline missed status

--- a/src/cpp/fastdds/subscriber/Subscriber.cpp
+++ b/src/cpp/fastdds/subscriber/Subscriber.cpp
@@ -72,11 +72,12 @@ ReturnCode_t Subscriber::set_listener(
 }
 
 DataReader* Subscriber::create_datareader(
-        const fastrtps::TopicAttributes& topic_attr,
+        const TopicDescription* topic,
         const DataReaderQos& reader_qos,
-        DataReaderListener* listener)
+        DataReaderListener* listener,
+        const StatusMask& mask)
 {
-    return impl_->create_datareader(topic_attr, reader_qos, listener);
+    return impl_->create_datareader(topic, reader_qos, listener, mask);
 }
 
 ReturnCode_t Subscriber::delete_datareader(

--- a/src/cpp/fastdds/subscriber/Subscriber.cpp
+++ b/src/cpp/fastdds/subscriber/Subscriber.cpp
@@ -72,7 +72,7 @@ ReturnCode_t Subscriber::set_listener(
 }
 
 DataReader* Subscriber::create_datareader(
-        const TopicDescription* topic,
+        TopicDescription* topic,
         const DataReaderQos& reader_qos,
         DataReaderListener* listener,
         const StatusMask& mask)

--- a/src/cpp/fastdds/subscriber/SubscriberImpl.cpp
+++ b/src/cpp/fastdds/subscriber/SubscriberImpl.cpp
@@ -19,6 +19,7 @@
 
 #include <fastdds/subscriber/SubscriberImpl.hpp>
 #include <fastdds/subscriber/DataReaderImpl.hpp>
+#include <fastdds/topic/TopicDescriptionImpl.hpp>
 #include <fastdds/domain/DomainParticipantImpl.hpp>
 
 #include <fastdds/dds/subscriber/Subscriber.hpp>
@@ -151,6 +152,8 @@ DataReader* SubscriberImpl::create_datareader(
         return nullptr;
     }
 
+    topic->get_impl()->reference();
+
     DataReaderImpl* impl = new DataReaderImpl(
         this,
         type_support,
@@ -162,6 +165,7 @@ DataReader* SubscriberImpl::create_datareader(
     {
         logError(SUBSCRIBER, "Problem creating associated Reader");
         delete impl;
+        topic->get_impl()->dereference();
         return nullptr;
     }
 
@@ -194,6 +198,7 @@ ReturnCode_t SubscriberImpl::delete_datareader(
         if (dr_it != it->second.end())
         {
             (*dr_it)->set_listener(nullptr);
+            (*dr_it)->topic()->get_impl()->dereference();
             delete (*dr_it);
             it->second.erase(dr_it);
             if (it->second.empty())

--- a/src/cpp/fastdds/subscriber/SubscriberImpl.cpp
+++ b/src/cpp/fastdds/subscriber/SubscriberImpl.cpp
@@ -191,14 +191,14 @@ ReturnCode_t SubscriberImpl::delete_datareader(
         return ReturnCode_t::RETCODE_PRECONDITION_NOT_MET;
     }
     std::lock_guard<std::mutex> lock(mtx_readers_);
-    auto it = readers_.find(reader->impl_->topic()->get_name());
+    auto it = readers_.find(reader->impl_->get_topicdescription()->get_name());
     if (it != readers_.end())
     {
         auto dr_it = std::find(it->second.begin(), it->second.end(), reader->impl_);
         if (dr_it != it->second.end())
         {
             (*dr_it)->set_listener(nullptr);
-            (*dr_it)->topic()->get_impl()->dereference();
+            (*dr_it)->get_topicdescription()->get_impl()->dereference();
             delete (*dr_it);
             it->second.erase(dr_it);
             if (it->second.empty())

--- a/src/cpp/fastdds/subscriber/SubscriberImpl.cpp
+++ b/src/cpp/fastdds/subscriber/SubscriberImpl.cpp
@@ -129,7 +129,7 @@ ReturnCode_t SubscriberImpl::set_listener(
 }
 
 DataReader* SubscriberImpl::create_datareader(
-        const TopicDescription* topic,
+        TopicDescription* topic,
         const DataReaderQos& qos,
         DataReaderListener* listener,
         const StatusMask& mask)
@@ -169,7 +169,7 @@ DataReader* SubscriberImpl::create_datareader(
     impl->user_datareader_ = reader;
 
     ReaderQos rqos = qos.get_readerqos(qos_);
-    rtps_participant_->registerReader(impl->reader_, impl->get_topic(), rqos);
+    rtps_participant_->registerReader(impl->reader_, impl->topic_attributes(), rqos);
 
     {
         std::lock_guard<std::mutex> lock(mtx_readers_);
@@ -187,7 +187,7 @@ ReturnCode_t SubscriberImpl::delete_datareader(
         return ReturnCode_t::RETCODE_PRECONDITION_NOT_MET;
     }
     std::lock_guard<std::mutex> lock(mtx_readers_);
-    auto it = readers_.find(reader->get_topic().getTopicName().to_string());
+    auto it = readers_.find(reader->impl_->topic()->get_name());
     if (it != readers_.end())
     {
         auto dr_it = std::find(it->second.begin(), it->second.end(), reader->impl_);
@@ -426,7 +426,7 @@ bool SubscriberImpl::type_in_use(
     {
         for (DataReaderImpl* reader : it.second)
         {
-            if (reader->get_topic().getTopicDataType() == type_name)
+            if (reader->topic_attributes().getTopicDataType() == type_name)
             {
                 return true; // Is in use
             }

--- a/src/cpp/fastdds/subscriber/SubscriberImpl.hpp
+++ b/src/cpp/fastdds/subscriber/SubscriberImpl.hpp
@@ -26,6 +26,7 @@
 #include <fastdds/dds/subscriber/DataReaderListener.hpp>
 #include <fastdds/dds/subscriber/qos/DataReaderQos.hpp>
 #include <fastdds/dds/subscriber/qos/SubscriberQos.hpp>
+#include <fastdds/dds/core/status/StatusMask.hpp>
 #include <fastrtps/types/TypesBase.h>
 
 #include <mutex>
@@ -53,6 +54,7 @@ class DomainParticipant;
 class DomainParticipantImpl;
 class Subscriber;
 class DataReaderImpl;
+class TopicDescription;
 
 /**
  * Class SubscriberImpl, contains the actual implementation of the behaviour of the Subscriber.
@@ -87,9 +89,10 @@ public:
             SubscriberListener* listener);
 
     DataReader* create_datareader(
-            const fastrtps::TopicAttributes& topic_attr,
+            const TopicDescription* topic,
             const DataReaderQos& reader_qos,
-            DataReaderListener* listener);
+            DataReaderListener* listener = nullptr,
+            const StatusMask& mask = StatusMask::all());
 
     ReturnCode_t delete_datareader(
             DataReader* reader);

--- a/src/cpp/fastdds/subscriber/SubscriberImpl.hpp
+++ b/src/cpp/fastdds/subscriber/SubscriberImpl.hpp
@@ -89,7 +89,7 @@ public:
             SubscriberListener* listener);
 
     DataReader* create_datareader(
-            const TopicDescription* topic,
+            TopicDescription* topic,
             const DataReaderQos& reader_qos,
             DataReaderListener* listener = nullptr,
             const StatusMask& mask = StatusMask::all());

--- a/test/unittest/dds/participant/ParticipantTests.cpp
+++ b/test/unittest/dds/participant/ParticipantTests.cpp
@@ -38,6 +38,13 @@ namespace dds {
 // Mocked TopicDataType for Topic creation tests
 class TopicDataTypeMock : public TopicDataType
 {
+public:
+    TopicDataTypeMock()
+        : TopicDataType()
+    {
+        setName("footype");
+    }
+
     bool serialize(
             void* /*data*/,
             fastrtps::rtps::SerializedPayload_t* /*payload*/) override
@@ -128,6 +135,39 @@ TEST(ParticipantTests, DeleteDomainParticipant)
 
     ASSERT_TRUE(DomainParticipantFactory::get_instance()->delete_participant(participant) == ReturnCode_t::RETCODE_OK);
 
+}
+
+TEST(ParticipantTests, DeleteDomainParticipantWithEntities)
+{
+    DomainParticipant* participant = DomainParticipantFactory::get_instance()->create_participant(0);
+
+    Subscriber* subscriber = participant->create_subscriber(SUBSCRIBER_QOS_DEFAULT);
+    ASSERT_NE(subscriber, nullptr);
+
+    ASSERT_EQ(DomainParticipantFactory::get_instance()->delete_participant(participant), ReturnCode_t::RETCODE_PRECONDITION_NOT_MET);
+    ASSERT_EQ(participant->delete_subscriber(subscriber), ReturnCode_t::RETCODE_OK);
+    ASSERT_EQ(DomainParticipantFactory::get_instance()->delete_participant(participant), ReturnCode_t::RETCODE_OK);
+
+    participant = DomainParticipantFactory::get_instance()->create_participant(0);
+
+    Publisher* publisher = participant->create_publisher(PUBLISHER_QOS_DEFAULT);
+    ASSERT_NE(publisher, nullptr);
+
+    ASSERT_EQ(DomainParticipantFactory::get_instance()->delete_participant(participant), ReturnCode_t::RETCODE_PRECONDITION_NOT_MET);
+    ASSERT_EQ(participant->delete_publisher(publisher), ReturnCode_t::RETCODE_OK);
+    ASSERT_EQ(DomainParticipantFactory::get_instance()->delete_participant(participant), ReturnCode_t::RETCODE_OK);
+
+    participant = DomainParticipantFactory::get_instance()->create_participant(0);
+
+    TypeSupport type_(new TopicDataTypeMock());
+    participant->register_type(type_);
+
+    Topic* topic = participant->create_topic("footopic", type_->getName(), TOPIC_QOS_DEFAULT);
+    ASSERT_NE(topic, nullptr);
+
+    ASSERT_EQ(DomainParticipantFactory::get_instance()->delete_participant(participant), ReturnCode_t::RETCODE_PRECONDITION_NOT_MET);
+    ASSERT_EQ(participant->delete_topic(topic), ReturnCode_t::RETCODE_OK);
+    ASSERT_EQ(DomainParticipantFactory::get_instance()->delete_participant(participant), ReturnCode_t::RETCODE_OK);
 }
 
 TEST(ParticipantTests, ChangeDefaultParticipantQos)

--- a/test/unittest/dds/subscriber/SubscriberTests.cpp
+++ b/test/unittest/dds/subscriber/SubscriberTests.cpp
@@ -203,7 +203,8 @@ TEST(SubscriberTests, DeleteSubscriberWithReaders)
     ASSERT_EQ(DomainParticipantFactory::get_instance()->delete_participant(participant), ReturnCode_t::RETCODE_OK);
 }
 
-
+//TODO: [ILG] Activate the test once PSM API for DataReader is in place
+/*
 TEST(SubscriberTests, CreatePSMDataReader)
 {
     ::dds::domain::DomainParticipant participant = ::dds::domain::DomainParticipant(0, PARTICIPANT_QOS_DEFAULT);
@@ -226,7 +227,7 @@ TEST(SubscriberTests, CreatePSMDataReader)
 
     ASSERT_NE(data_reader, ::dds::core::null);
 }
-
+*/
 
 
 } // namespace dds

--- a/test/unittest/dds/subscriber/SubscriberTests.cpp
+++ b/test/unittest/dds/subscriber/SubscriberTests.cpp
@@ -23,7 +23,9 @@
 #include <dds/core/types.hpp>
 #include <fastdds/dds/subscriber/Subscriber.hpp>
 #include <dds/sub/Subscriber.hpp>
+#include <dds/sub/DataReader.hpp>
 #include <dds/sub/qos/DataReaderQos.hpp>
+#include <dds/topic/Topic.hpp>
 
 namespace eprosima {
 namespace fastdds {
@@ -200,6 +202,31 @@ TEST(SubscriberTests, DeleteSubscriberWithReaders)
     ASSERT_EQ(participant->delete_topic(topic), ReturnCode_t::RETCODE_OK);
     ASSERT_EQ(DomainParticipantFactory::get_instance()->delete_participant(participant), ReturnCode_t::RETCODE_OK);
 }
+
+
+TEST(SubscriberTests, CreatePSMDataReader)
+{
+    ::dds::domain::DomainParticipant participant = ::dds::domain::DomainParticipant(0, PARTICIPANT_QOS_DEFAULT);
+
+    ::dds::sub::Subscriber subscriber = ::dds::core::null;
+    subscriber = ::dds::sub::Subscriber(participant);
+
+    ASSERT_NE(subscriber, ::dds::core::null);
+
+    TypeSupport type_(new TopicDataTypeMock());
+    participant->register_type(type_, type_->getName());
+
+    ::dds::topic::Topic topic = ::dds::core::null;
+    topic = ::dds::topic::Topic(participant, "footopic", type_->getName(), TOPIC_QOS_DEFAULT);
+
+    ASSERT_NE(topic, ::dds::core::null);
+
+    ::dds::sub::DataReader data_reader = ::dds::core::null;
+    data_reader = ::dds::sub::DataReader(subscriber, topic);
+
+    ASSERT_NE(data_reader, ::dds::core::null);
+}
+
 
 
 } // namespace dds

--- a/test/xtypes/TestPublisher.cpp
+++ b/test/xtypes/TestPublisher.cpp
@@ -136,7 +136,6 @@ bool TestPublisher::init(
         }
 
         writer_ = mp_publisher->create_datawriter(topic, qos, &m_pubListener);
-
         m_Data = m_Type->createData();
     }
 

--- a/test/xtypes/TestSubscriber.h
+++ b/test/xtypes/TestSubscriber.h
@@ -47,7 +47,6 @@ public:
     bool init(
             const std::string& topicName,
             int domain,
-            eprosima::fastrtps::rtps::TopicKind_t topic_kind,
             eprosima::fastdds::dds::TypeSupport type,
             const eprosima::fastrtps::types::TypeObject* type_object,
             const eprosima::fastrtps::types::TypeIdentifier* type_identifier,
@@ -105,6 +104,7 @@ private:
     eprosima::fastdds::dds::DomainParticipant* mp_participant;
     eprosima::fastdds::dds::Subscriber* mp_subscriber;
     eprosima::fastdds::dds::DataReader* reader_;
+    eprosima::fastdds::dds::Topic* topic_;
     void* m_Data;
     bool m_bInitialized;
     std::mutex m_mDiscovery;
@@ -114,10 +114,12 @@ private:
     std::condition_variable cv_type_discovery_;
     std::condition_variable cv_;
     eprosima::fastrtps::types::DynamicType_ptr disc_type_;
-    eprosima::fastrtps::TopicAttributes topic_att;
     eprosima::fastdds::dds::DataReaderQos reader_qos;
     bool using_typelookup_;
     bool tls_callback_called_;
+    std::string topic_name_;
+    const eprosima::fastrtps::DataRepresentationQosPolicy* dataRepresentationQos_;
+    const eprosima::fastrtps::TypeConsistencyEnforcementQosPolicy* typeConsistencyQos_;
 
 public:
 

--- a/test/xtypes/XTypesTests.cpp
+++ b/test/xtypes/XTypesTests.cpp
@@ -88,7 +88,7 @@ TEST_F(xtypestests, NoTypeObjectSameType)
     pub.init("NoTypeObjectSameType", DOMAIN_ID_, type, nullptr, nullptr, nullptr, "Pub1", nullptr);
     ASSERT_TRUE(pub.isInitialized());
 
-    sub.init("NoTypeObjectSameType", DOMAIN_ID_, NO_KEY, type, nullptr, nullptr, nullptr, "Sub1", nullptr, nullptr);
+    sub.init("NoTypeObjectSameType", DOMAIN_ID_, type, nullptr, nullptr, nullptr, "Sub1", nullptr, nullptr);
     ASSERT_TRUE(sub.isInitialized());
 
     // Wait for discovery.
@@ -118,7 +118,7 @@ TEST_F(xtypestests, NoTypeObjectSameTypeForce)
     pub.init("NoTypeObjectSameTypeForce", DOMAIN_ID_, type, nullptr, nullptr, nullptr, "Pub1", nullptr);
     ASSERT_TRUE(pub.isInitialized());
 
-    sub.init("NoTypeObjectSameTypeForce", DOMAIN_ID_, NO_KEY, type, nullptr, nullptr, nullptr, "Sub1", nullptr,
+    sub.init("NoTypeObjectSameTypeForce", DOMAIN_ID_, type, nullptr, nullptr, nullptr, "Sub1", nullptr,
             &typeConQos);
     ASSERT_TRUE(sub.isInitialized());
 
@@ -141,7 +141,7 @@ TEST_F(xtypestests, NoTypeObjectDifferentType)
     pub.init("NoTypeObjectDifferentType", DOMAIN_ID_, type, nullptr, nullptr, nullptr, "Pub1", nullptr);
     ASSERT_TRUE(pub.isInitialized());
 
-    sub.init("NoTypeObjectDifferentType", DOMAIN_ID_, NO_KEY, type2, nullptr, nullptr, nullptr, "Sub1", nullptr,
+    sub.init("NoTypeObjectDifferentType", DOMAIN_ID_, type2, nullptr, nullptr, nullptr, "Sub1", nullptr,
             nullptr);
     ASSERT_TRUE(sub.isInitialized());
 
@@ -182,7 +182,7 @@ TEST_F(xtypestests, TypeObjectV1SameType)
     pub.init("TypeObjectV1SameType", DOMAIN_ID_, type, type_obj, type_id, nullptr, "Pub1", &dataRepQos);
     ASSERT_TRUE(pub.isInitialized());
 
-    sub.init("TypeObjectV1SameType", DOMAIN_ID_, NO_KEY, type, type_obj, type_id, nullptr, "Sub1", &dataRepQos,
+    sub.init("TypeObjectV1SameType", DOMAIN_ID_, type, type_obj, type_id, nullptr, "Sub1", &dataRepQos,
             nullptr);
     ASSERT_TRUE(sub.isInitialized());
 
@@ -221,8 +221,7 @@ TEST_F(xtypestests, TypeDiscoverySubs)
     pub.init("TypeDiscoverySubs", DOMAIN_ID_, type, type_obj, type_id, nullptr, "Pub1", &dataRepQos);
     ASSERT_TRUE(pub.isInitialized());
 
-    sub.init("TypeDiscoverySubs", DOMAIN_ID_, NO_KEY, TypeSupport(
-                nullptr), nullptr, nullptr, nullptr, "Sub1", &dataRepQos, nullptr);
+    sub.init("TypeDiscoverySubs", DOMAIN_ID_, TypeSupport(nullptr), nullptr, nullptr, nullptr, "Sub1", &dataRepQos, nullptr);
     ASSERT_TRUE(sub.isInitialized());
 
     // Wait for discovery.
@@ -232,13 +231,10 @@ TEST_F(xtypestests, TypeDiscoverySubs)
     ASSERT_TRUE(disc_type != nullptr);
 
     sub.register_discovered_type();
-    DataReader* reader = sub.create_datareader();
+    sub.create_datareader();
 
     pub.waitDiscovery(true, 3);
     sub.waitDiscovery(true, 3);
-
-    reader->set_listener(nullptr);
-    sub.delete_datareader(reader);
 }
 
 /*
@@ -271,7 +267,7 @@ TEST_F(xtypestests, TypeDiscoveryPubs)
     pub.init("TypeDiscoveryPubs", DOMAIN_ID_, TypeSupport(nullptr), nullptr, nullptr, nullptr, "Pub1", &dataRepQos);
     ASSERT_TRUE(pub.isInitialized());
 
-    sub.init("TypeDiscoveryPubs", DOMAIN_ID_, NO_KEY, type, type_obj, type_id, nullptr, "Sub1", &dataRepQos, nullptr);
+    sub.init("TypeDiscoveryPubs", DOMAIN_ID_, type, type_obj, type_id, nullptr, "Sub1", &dataRepQos, nullptr);
     ASSERT_TRUE(sub.isInitialized());
 
     // Wait for discovery.
@@ -322,7 +318,7 @@ TEST_F(xtypestests, TypeObjectV1DifferentType)
     pub.init("TypeObjectV1DifferentType", DOMAIN_ID_, type1, type_obj1, type_id1, nullptr, "Pub1", &dataRepQos);
     ASSERT_TRUE(pub.isInitialized());
 
-    sub.init("TypeObjectV1DifferentType", DOMAIN_ID_, NO_KEY, type2, type_obj2, type_id2, nullptr, "Sub1", &dataRepQos,
+    sub.init("TypeObjectV1DifferentType", DOMAIN_ID_, type2, type_obj2, type_id2, nullptr, "Sub1", &dataRepQos,
             &typeConQos);
     ASSERT_TRUE(sub.isInitialized());
 
@@ -364,7 +360,7 @@ TEST_F(xtypestests, TypeObjectV1NamesManaged)
     pub.init("TypeObjectV1NamesManaged", DOMAIN_ID_, type1, type_obj1, type_id1, nullptr, "Pub1", &dataRepQos);
     ASSERT_TRUE(pub.isInitialized());
 
-    sub.init("TypeObjectV1NamesManaged", DOMAIN_ID_, NO_KEY, type2, type_obj2, type_id2, nullptr, "Sub1", &dataRepQos,
+    sub.init("TypeObjectV1NamesManaged", DOMAIN_ID_, type2, type_obj2, type_id2, nullptr, "Sub1", &dataRepQos,
             &typeConQos);
     ASSERT_TRUE(sub.isInitialized());
 
@@ -406,7 +402,7 @@ TEST_F(xtypestests, DISABLED_TypeObjectV1NamesIgnored)
     pub.init("TypeObjectV1NamesIgnored", DOMAIN_ID_, type1, type_obj1, type_id1, nullptr, "Pub1", &dataRepQos);
     ASSERT_TRUE(pub.isInitialized());
 
-    sub.init("TypeObjectV1NamesIgnored", DOMAIN_ID_, NO_KEY, type2, type_obj2, type_id2, nullptr, "Sub1", &dataRepQos,
+    sub.init("TypeObjectV1NamesIgnored", DOMAIN_ID_, type2, type_obj2, type_id2, nullptr, "Sub1", &dataRepQos,
             &typeConQos);
     ASSERT_TRUE(sub.isInitialized());
 
@@ -449,7 +445,7 @@ TEST_F(xtypestests, TypeObjectV1NamesIgnoredDisallow)
     pub.init("TypeObjectV1NamesIgnoredDisallow", DOMAIN_ID_, type1, type_obj1, type_id1, nullptr, "Pub1", &dataRepQos);
     ASSERT_TRUE(pub.isInitialized());
 
-    sub.init("TypeObjectV1NamesIgnoredDisallow", DOMAIN_ID_, NO_KEY, type2, type_obj2, type_id2, nullptr, "Sub1",
+    sub.init("TypeObjectV1NamesIgnoredDisallow", DOMAIN_ID_, type2, type_obj2, type_id2, nullptr, "Sub1",
             &dataRepQos, &typeConQos);
     ASSERT_TRUE(sub.isInitialized());
 
@@ -491,7 +487,7 @@ TEST_F(xtypestests, DISABLED_TypeObjectV1TypeWidening)
     pub.init("TypeObjectV1TypeWidening", DOMAIN_ID_, type1, type_obj1, type_id1, nullptr, "Pub1", &dataRepQos);
     ASSERT_TRUE(pub.isInitialized());
 
-    sub.init("TypeObjectV1TypeWidening", DOMAIN_ID_, NO_KEY, type2, type_obj2, type_id2, nullptr, "Sub1", &dataRepQos,
+    sub.init("TypeObjectV1TypeWidening", DOMAIN_ID_, type2, type_obj2, type_id2, nullptr, "Sub1", &dataRepQos,
             &typeConQos);
     ASSERT_TRUE(sub.isInitialized());
 
@@ -533,7 +529,7 @@ TEST_F(xtypestests, TypeObjectV1BadTypeWidening)
     pub.init("TypeObjectV1BadTypeWidening", DOMAIN_ID_, type1, type_obj1, type_id1, nullptr, "Pub1", &dataRepQos);
     ASSERT_TRUE(pub.isInitialized());
 
-    sub.init("TypeObjectV1BadTypeWidening", DOMAIN_ID_, NO_KEY, type2, type_obj2, type_id2, nullptr, "Sub1",
+    sub.init("TypeObjectV1BadTypeWidening", DOMAIN_ID_, type2, type_obj2, type_id2, nullptr, "Sub1",
             &dataRepQos, &typeConQos);
     ASSERT_TRUE(sub.isInitialized());
 
@@ -576,7 +572,7 @@ TEST_F(xtypestests, DISABLED_TypeObjectV1TypeWideningPreventedNarrowToWide)
             &dataRepQos);
     ASSERT_TRUE(pub.isInitialized());
 
-    sub.init("TypeObjectV1TypeWideningPreventedNarrowToWide", DOMAIN_ID_, NO_KEY, type2, type_obj2, type_id2, nullptr,
+    sub.init("TypeObjectV1TypeWideningPreventedNarrowToWide", DOMAIN_ID_, type2, type_obj2, type_id2, nullptr,
             "Sub1", &dataRepQos, &typeConQos);
     ASSERT_TRUE(sub.isInitialized());
 
@@ -619,7 +615,7 @@ TEST_F(xtypestests, TypeObjectV1TypeWideningPreventedWideToNarrow)
             &dataRepQos);
     ASSERT_TRUE(pub.isInitialized());
 
-    sub.init("TypeObjectV1TypeWideningPreventedWideToNarrow", DOMAIN_ID_, NO_KEY, type1, type_obj1, type_id1, nullptr,
+    sub.init("TypeObjectV1TypeWideningPreventedWideToNarrow", DOMAIN_ID_, type1, type_obj1, type_id1, nullptr,
             "Sub1", &dataRepQos, &typeConQos);
     ASSERT_TRUE(sub.isInitialized());
 
@@ -661,7 +657,7 @@ TEST_F(xtypestests, TypeObjectV1TypeWideningDisallow)
     pub.init("TypeObjectV1TypeWideningDisallow", DOMAIN_ID_, type1, type_obj1, type_id1, nullptr, "Pub1", &dataRepQos);
     ASSERT_TRUE(pub.isInitialized());
 
-    sub.init("TypeObjectV1TypeWideningDisallow", DOMAIN_ID_, NO_KEY, type2, type_obj2, type_id2, nullptr, "Sub1",
+    sub.init("TypeObjectV1TypeWideningDisallow", DOMAIN_ID_, type2, type_obj2, type_id2, nullptr, "Sub1",
             &dataRepQos, &typeConQos);
     ASSERT_TRUE(sub.isInitialized());
 
@@ -703,7 +699,7 @@ TEST_F(xtypestests, DISABLED_TypeObjectV1SequenceBoundsIgnored)
     pub.init("TypeObjectV1SequenceBoundsIgnored", DOMAIN_ID_, type1, type_obj1, type_id1, nullptr, "Pub1", &dataRepQos);
     ASSERT_TRUE(pub.isInitialized());
 
-    sub.init("TypeObjectV1SequenceBoundsIgnored", DOMAIN_ID_, NO_KEY, type2, type_obj2, type_id2, nullptr, "Sub1",
+    sub.init("TypeObjectV1SequenceBoundsIgnored", DOMAIN_ID_, type2, type_obj2, type_id2, nullptr, "Sub1",
             &dataRepQos, &typeConQos);
     ASSERT_TRUE(sub.isInitialized());
 
@@ -745,7 +741,7 @@ TEST_F(xtypestests, TypeObjectV1SequenceBoundsManaged)
     pub.init("TypeObjectV1SequenceBoundsManaged", DOMAIN_ID_, type1, type_obj1, type_id1, nullptr, "Pub1", &dataRepQos);
     ASSERT_TRUE(pub.isInitialized());
 
-    sub.init("TypeObjectV1SequenceBoundsManaged", DOMAIN_ID_, NO_KEY, type2, type_obj2, type_id2, nullptr, "Sub1",
+    sub.init("TypeObjectV1SequenceBoundsManaged", DOMAIN_ID_, type2, type_obj2, type_id2, nullptr, "Sub1",
             &dataRepQos, &typeConQos);
     ASSERT_TRUE(sub.isInitialized());
 
@@ -788,7 +784,7 @@ TEST_F(xtypestests, DISABLED_TypeObjectV1LargeStringIgnored)
     pub.init("TypeObjectV1LargeStringIgnored", DOMAIN_ID_, type1, type_obj1, type_id1, nullptr, "Pub1", &dataRepQos);
     ASSERT_TRUE(pub.isInitialized());
 
-    sub.init("TypeObjectV1LargeStringIgnored", DOMAIN_ID_, NO_KEY, type2, type_obj2, type_id2, nullptr, "Sub1",
+    sub.init("TypeObjectV1LargeStringIgnored", DOMAIN_ID_, type2, type_obj2, type_id2, nullptr, "Sub1",
             &dataRepQos, &typeConQos);
     ASSERT_TRUE(sub.isInitialized());
 
@@ -831,7 +827,7 @@ TEST_F(xtypestests, TypeObjectV1LargeStringManaged)
     pub.init("TypeObjectV1LargeStringManaged", DOMAIN_ID_, type1, type_obj1, type_id1, nullptr, "Pub1", &dataRepQos);
     ASSERT_TRUE(pub.isInitialized());
 
-    sub.init("TypeObjectV1LargeStringManaged", DOMAIN_ID_, NO_KEY, type2, type_obj2, type_id2, nullptr, "Sub1",
+    sub.init("TypeObjectV1LargeStringManaged", DOMAIN_ID_, type2, type_obj2, type_id2, nullptr, "Sub1",
             &dataRepQos, &typeConQos);
     ASSERT_TRUE(sub.isInitialized());
 
@@ -869,7 +865,7 @@ TEST_F(xtypestests, TypeObjectV1SameTypeComplete)
     pub.init("TypeObjectV1SameTypeComplete", DOMAIN_ID_, type, type_obj, type_id, nullptr, "Pub1", &dataRepQos);
     ASSERT_TRUE(pub.isInitialized());
 
-    sub.init("TypeObjectV1SameTypeComplete", DOMAIN_ID_, NO_KEY, type, type_obj, type_id, nullptr, "Sub1", &dataRepQos,
+    sub.init("TypeObjectV1SameTypeComplete", DOMAIN_ID_, type, type_obj, type_id, nullptr, "Sub1", &dataRepQos,
             nullptr);
     ASSERT_TRUE(sub.isInitialized());
 
@@ -911,7 +907,7 @@ TEST_F(xtypestests, TypeObjectV1InvalidComplete)
     pub.init("TypeObjectV1InvalidComplete", DOMAIN_ID_, type1, type_obj1, type_id1, nullptr, "Pub1", &dataRepQos);
     ASSERT_TRUE(pub.isInitialized());
 
-    sub.init("TypeObjectV1InvalidComplete", DOMAIN_ID_, NO_KEY, type2, type_obj2, type_id2, nullptr, "Sub1",
+    sub.init("TypeObjectV1InvalidComplete", DOMAIN_ID_, type2, type_obj2, type_id2, nullptr, "Sub1",
             &dataRepQos, nullptr);
     ASSERT_TRUE(sub.isInitialized());
 
@@ -952,7 +948,7 @@ TEST_F(xtypestests, MixingMinimalAndComplete)
     pub.init("MixingMinimalAndComplete", DOMAIN_ID_, type1, type_obj1, type_id1, nullptr, "Pub1", &dataRepQos);
     ASSERT_TRUE(pub.isInitialized());
 
-    sub.init("MixingMinimalAndComplete", DOMAIN_ID_, NO_KEY, type1, type_obj2, type_id2, nullptr, "Sub1", &dataRepQos,
+    sub.init("MixingMinimalAndComplete", DOMAIN_ID_, type1, type_obj2, type_id2, nullptr, "Sub1", &dataRepQos,
             nullptr);
     ASSERT_TRUE(sub.isInitialized());
 
@@ -992,7 +988,7 @@ TEST_F(xtypestests, TypeIdentifierSameType)
     pub.init("TypeIdentifierSameType", DOMAIN_ID_, type, nullptr, type_id, nullptr, "Pub1", &dataRepQos);
     ASSERT_TRUE(pub.isInitialized());
 
-    sub.init("TypeIdentifierSameType", DOMAIN_ID_, NO_KEY, type, nullptr, type_id, nullptr, "Sub1", &dataRepQos,
+    sub.init("TypeIdentifierSameType", DOMAIN_ID_, type, nullptr, type_id, nullptr, "Sub1", &dataRepQos,
             nullptr);
     ASSERT_TRUE(sub.isInitialized());
 
@@ -1031,7 +1027,7 @@ TEST_F(xtypestests, TypeIdentifierDifferentType)
     pub.init("TypeIdentifierDifferentType", DOMAIN_ID_, type1, nullptr, type_id1, nullptr, "Pub1", &dataRepQos);
     ASSERT_TRUE(pub.isInitialized());
 
-    sub.init("TypeIdentifierDifferentType", DOMAIN_ID_, NO_KEY, type2, nullptr, type_id2, nullptr, "Sub1", &dataRepQos,
+    sub.init("TypeIdentifierDifferentType", DOMAIN_ID_, type2, nullptr, type_id2, nullptr, "Sub1", &dataRepQos,
             &typeConQos);
     ASSERT_TRUE(sub.isInitialized());
 
@@ -1071,7 +1067,7 @@ TEST_F(xtypestests, TypeIdentifierNamesManaged)
     pub.init("TypeIdentifierNamesManaged", DOMAIN_ID_, type1, nullptr, type_id1, nullptr, "Pub1", &dataRepQos);
     ASSERT_TRUE(pub.isInitialized());
 
-    sub.init("TypeIdentifierNamesManaged", DOMAIN_ID_, NO_KEY, type2, nullptr, type_id2, nullptr, "Sub1", &dataRepQos,
+    sub.init("TypeIdentifierNamesManaged", DOMAIN_ID_, type2, nullptr, type_id2, nullptr, "Sub1", &dataRepQos,
             &typeConQos);
     ASSERT_TRUE(sub.isInitialized());
 
@@ -1111,7 +1107,7 @@ TEST_F(xtypestests, DISABLED_TypeIdentifierNamesIgnored)
     pub.init("TypeIdentifierNamesIgnored", DOMAIN_ID_, type1, nullptr, type_id1, nullptr, "Pub1", &dataRepQos);
     ASSERT_TRUE(pub.isInitialized());
 
-    sub.init("TypeIdentifierNamesIgnored", DOMAIN_ID_, NO_KEY, type2, nullptr, type_id2, nullptr, "Sub1", &dataRepQos,
+    sub.init("TypeIdentifierNamesIgnored", DOMAIN_ID_, type2, nullptr, type_id2, nullptr, "Sub1", &dataRepQos,
             &typeConQos);
     ASSERT_TRUE(sub.isInitialized());
 
@@ -1150,7 +1146,7 @@ TEST_F(xtypestests, TypeInformationSameType)
     pub.init("TypeInformationSameType", DOMAIN_ID_, type, nullptr, nullptr, type_info, "Pub1", &dataRepQos);
     ASSERT_TRUE(pub.isInitialized());
 
-    sub.init("TypeInformationSameType", DOMAIN_ID_, NO_KEY, type, nullptr, nullptr, type_info, "Sub1", &dataRepQos,
+    sub.init("TypeInformationSameType", DOMAIN_ID_, type, nullptr, nullptr, type_info, "Sub1", &dataRepQos,
             nullptr);
     ASSERT_TRUE(sub.isInitialized());
 
@@ -1189,7 +1185,7 @@ TEST_F(xtypestests, TypeInformationDifferentType)
     pub.init("TypeInformationDifferentType", DOMAIN_ID_, type1, nullptr, nullptr, type_info1, "Pub1", &dataRepQos);
     ASSERT_TRUE(pub.isInitialized());
 
-    sub.init("TypeInformationDifferentType", DOMAIN_ID_, NO_KEY, type2, nullptr, nullptr, type_info2, "Sub1",
+    sub.init("TypeInformationDifferentType", DOMAIN_ID_, type2, nullptr, nullptr, type_info2, "Sub1",
             &dataRepQos, &typeConQos);
     ASSERT_TRUE(sub.isInitialized());
 
@@ -1229,7 +1225,7 @@ TEST_F(xtypestests, TypeInformationNamesManaged)
     pub.init("TypeInformationNamesManaged", DOMAIN_ID_, type1, nullptr, nullptr, type_info1, "Pub1", &dataRepQos);
     ASSERT_TRUE(pub.isInitialized());
 
-    sub.init("TypeInformationNamesManaged", DOMAIN_ID_, NO_KEY, type2, nullptr, nullptr, type_info2, "Sub1",
+    sub.init("TypeInformationNamesManaged", DOMAIN_ID_, type2, nullptr, nullptr, type_info2, "Sub1",
             &dataRepQos, &typeConQos);
     ASSERT_TRUE(sub.isInitialized());
 
@@ -1269,7 +1265,7 @@ TEST_F(xtypestests, DISABLED_TypeInformationNamesIgnored)
     pub.init("TypeInformationNamesIgnored", DOMAIN_ID_, type1, nullptr, nullptr, type_info1, "Pub1", &dataRepQos);
     ASSERT_TRUE(pub.isInitialized());
 
-    sub.init("TypeInformationNamesIgnored", DOMAIN_ID_, NO_KEY, type2, nullptr, nullptr, type_info2, "Sub1",
+    sub.init("TypeInformationNamesIgnored", DOMAIN_ID_, type2, nullptr, nullptr, type_info2, "Sub1",
             &dataRepQos, &typeConQos);
     ASSERT_TRUE(sub.isInitialized());
 
@@ -1295,7 +1291,7 @@ TEST_F(xtypestests, TypeIdentifier_TypeObject)
     pub.init("TypeIdentifier_TypeObject", DOMAIN_ID_, type, nullptr, type_id, nullptr, "Pub1", nullptr);
     ASSERT_TRUE(pub.isInitialized());
 
-    sub.init("TypeIdentifier_TypeObject", DOMAIN_ID_, NO_KEY, type, type_obj, nullptr, nullptr, "Sub1", nullptr,
+    sub.init("TypeIdentifier_TypeObject", DOMAIN_ID_, type, type_obj, nullptr, nullptr, "Sub1", nullptr,
             &typeConQos);
     ASSERT_TRUE(sub.isInitialized());
 
@@ -1319,7 +1315,7 @@ TEST_F(xtypestests, TypeIdentifier_TypeInformation)
     pub.init("TypeIdentifier_TypeInformation", DOMAIN_ID_, type, nullptr, type_id, nullptr, "Pub1", nullptr);
     ASSERT_TRUE(pub.isInitialized());
 
-    sub.init("TypeIdentifier_TypeInformation", DOMAIN_ID_, NO_KEY, type, nullptr, nullptr, type_info, "Sub1", nullptr,
+    sub.init("TypeIdentifier_TypeInformation", DOMAIN_ID_, type, nullptr, nullptr, type_info, "Sub1", nullptr,
             &typeConQos);
     ASSERT_TRUE(sub.isInitialized());
 
@@ -1343,7 +1339,7 @@ TEST_F(xtypestests, TypeObject_TypeInformation)
     pub.init("TypeObject_TypeInformation", DOMAIN_ID_, type, type_obj, nullptr, nullptr, "Pub1", nullptr);
     ASSERT_TRUE(pub.isInitialized());
 
-    sub.init("TypeObject_TypeInformation", DOMAIN_ID_, NO_KEY, type, nullptr, nullptr, type_info, "Sub1", nullptr,
+    sub.init("TypeObject_TypeInformation", DOMAIN_ID_, type, nullptr, nullptr, type_info, "Sub1", nullptr,
             &typeConQos);
     ASSERT_TRUE(sub.isInitialized());
 
@@ -1371,7 +1367,7 @@ TEST_F(xtypestests, DISABLED_DataRepQoSEE)
     pub.init("DataRepQoSEE", DOMAIN_ID_, type, nullptr, nullptr, nullptr, "Pub1", &dataRepQos);
     ASSERT_TRUE(pub.isInitialized());
 
-    sub.init("DataRepQoSEE", DOMAIN_ID_, NO_KEY, type, nullptr, nullptr, nullptr, "Sub1", &dataRepQos, nullptr);
+    sub.init("DataRepQoSEE", DOMAIN_ID_, type, nullptr, nullptr, nullptr, "Sub1", &dataRepQos, nullptr);
     ASSERT_TRUE(sub.isInitialized());
 
     // Wait for discovery.
@@ -1401,7 +1397,7 @@ TEST_F(xtypestests, DISABLED_DataRepQoSE1)
     pub.init("DataRepQoSE1", DOMAIN_ID_, type, nullptr, nullptr, nullptr, "Pub1", &dataRepQos1);
     ASSERT_TRUE(pub.isInitialized());
 
-    sub.init("DataRepQoSE1", DOMAIN_ID_, NO_KEY, type, nullptr, nullptr, nullptr, "Sub1", &dataRepQos2, nullptr);
+    sub.init("DataRepQoSE1", DOMAIN_ID_, type, nullptr, nullptr, nullptr, "Sub1", &dataRepQos2, nullptr);
     ASSERT_TRUE(sub.isInitialized());
 
     // Wait for discovery.
@@ -1431,7 +1427,7 @@ TEST_F(xtypestests, DISABLED_DataRepQoSE2)
     pub.init("DataRepQoSE2", DOMAIN_ID_, type, nullptr, nullptr, nullptr, "Pub1", &dataRepQos1);
     ASSERT_TRUE(pub.isInitialized());
 
-    sub.init("DataRepQoSE2", DOMAIN_ID_, NO_KEY, type, nullptr, nullptr, nullptr, "Sub1", &dataRepQos2, nullptr);
+    sub.init("DataRepQoSE2", DOMAIN_ID_, type, nullptr, nullptr, nullptr, "Sub1", &dataRepQos2, nullptr);
     ASSERT_TRUE(sub.isInitialized());
 
     // Wait for discovery.
@@ -1461,7 +1457,7 @@ TEST_F(xtypestests, DISABLED_DataRepQoSEX)
     pub.init("DataRepQoSEX", DOMAIN_ID_, type, nullptr, nullptr, nullptr, "Pub1", &dataRepQos1);
     ASSERT_TRUE(pub.isInitialized());
 
-    sub.init("DataRepQoSEX", DOMAIN_ID_, NO_KEY, type, nullptr, nullptr, nullptr, "Sub1", &dataRepQos2, nullptr);
+    sub.init("DataRepQoSEX", DOMAIN_ID_, type, nullptr, nullptr, nullptr, "Sub1", &dataRepQos2, nullptr);
     ASSERT_TRUE(sub.isInitialized());
 
     // Wait for discovery.
@@ -1491,7 +1487,7 @@ TEST_F(xtypestests, DISABLED_DataRepQoSE12)
     pub.init("DataRepQoSE12", DOMAIN_ID_, type, nullptr, nullptr, nullptr, "Pub1", &dataRepQos1);
     ASSERT_TRUE(pub.isInitialized());
 
-    sub.init("DataRepQoSE12", DOMAIN_ID_, NO_KEY, type, nullptr, nullptr, nullptr, "Sub1", &dataRepQos2, nullptr);
+    sub.init("DataRepQoSE12", DOMAIN_ID_, type, nullptr, nullptr, nullptr, "Sub1", &dataRepQos2, nullptr);
     ASSERT_TRUE(sub.isInitialized());
 
     // Wait for discovery.
@@ -1521,7 +1517,7 @@ TEST_F(xtypestests, DISABLED_DataRepQoS12)
     pub.init("DataRepQoS12", DOMAIN_ID_, type, nullptr, nullptr, nullptr, "Pub1", &dataRepQos1);
     ASSERT_TRUE(pub.isInitialized());
 
-    sub.init("DataRepQoS12", DOMAIN_ID_, NO_KEY, type, nullptr, nullptr, nullptr, "Sub1", &dataRepQos2, nullptr);
+    sub.init("DataRepQoS12", DOMAIN_ID_, type, nullptr, nullptr, nullptr, "Sub1", &dataRepQos2, nullptr);
     ASSERT_TRUE(sub.isInitialized());
 
     // Wait for discovery.
@@ -1551,7 +1547,7 @@ TEST_F(xtypestests, DISABLED_DataRepQoS2E)
     pub.init("DataRepQoS21", DOMAIN_ID_, type, nullptr, nullptr, nullptr, "Pub1", &dataRepQos2);
     ASSERT_TRUE(pub.isInitialized());
 
-    sub.init("DataRepQoS21", DOMAIN_ID_, NO_KEY, type, nullptr, nullptr, nullptr, "Sub1", &dataRepQos1, nullptr);
+    sub.init("DataRepQoS21", DOMAIN_ID_, type, nullptr, nullptr, nullptr, "Sub1", &dataRepQos1, nullptr);
     ASSERT_TRUE(sub.isInitialized());
 
     // Wait for discovery.
@@ -1581,7 +1577,7 @@ TEST_F(xtypestests, DISABLED_DataRepQoS21)
     pub.init("DataRepQoS21", DOMAIN_ID_, type, nullptr, nullptr, nullptr, "Pub1", &dataRepQos2);
     ASSERT_TRUE(pub.isInitialized());
 
-    sub.init("DataRepQoS21", DOMAIN_ID_, NO_KEY, type, nullptr, nullptr, nullptr, "Sub1", &dataRepQos1, nullptr);
+    sub.init("DataRepQoS21", DOMAIN_ID_, type, nullptr, nullptr, nullptr, "Sub1", &dataRepQos1, nullptr);
     ASSERT_TRUE(sub.isInitialized());
 
     // Wait for discovery.
@@ -1606,7 +1602,7 @@ TEST_F(xtypestests, DISABLED_DataRepQoS22)
     pub.init("DataRepQoS22", DOMAIN_ID_, type, nullptr, nullptr, nullptr, "Pub1", &dataRepQos2);
     ASSERT_TRUE(pub.isInitialized());
 
-    sub.init("DataRepQoS22", DOMAIN_ID_, NO_KEY, type, nullptr, nullptr, nullptr, "Sub1", &dataRepQos2, nullptr);
+    sub.init("DataRepQoS22", DOMAIN_ID_, type, nullptr, nullptr, nullptr, "Sub1", &dataRepQos2, nullptr);
     ASSERT_TRUE(sub.isInitialized());
 
     // Wait for discovery.
@@ -1636,7 +1632,7 @@ TEST_F(xtypestests, DISABLED_DataRepQoSXE)
     pub.init("DataRepQoSXE", DOMAIN_ID_, type, nullptr, nullptr, nullptr, "Pub1", &dataRepQos2);
     ASSERT_TRUE(pub.isInitialized());
 
-    sub.init("DataRepQoSXE", DOMAIN_ID_, NO_KEY, type, nullptr, nullptr, nullptr, "Sub1", &dataRepQos1, nullptr);
+    sub.init("DataRepQoSXE", DOMAIN_ID_, type, nullptr, nullptr, nullptr, "Sub1", &dataRepQos1, nullptr);
     ASSERT_TRUE(sub.isInitialized());
 
     // Wait for discovery.
@@ -1666,7 +1662,7 @@ TEST_F(xtypestests, DISABLED_DataRepQoSXX)
     pub.init("DataRepQoSXE", DOMAIN_ID_, type, nullptr, nullptr, nullptr, "Pub1", &dataRepQos2);
     ASSERT_TRUE(pub.isInitialized());
 
-    sub.init("DataRepQoSXE", DOMAIN_ID_, NO_KEY, type, nullptr, nullptr, nullptr, "Sub1", &dataRepQos1, nullptr);
+    sub.init("DataRepQoSXE", DOMAIN_ID_, type, nullptr, nullptr, nullptr, "Sub1", &dataRepQos1, nullptr);
     ASSERT_TRUE(sub.isInitialized());
 
     // Wait for discovery.


### PR DESCRIPTION
- PIM implementation of create_datareader
- PIM implementation of delete_datareader
- PIM unit tests for create and delete datareader
- Unit testing including delete_subscriber failing if there is a datareader alive
- Adaptation of testcases and examples to delete datareaders and subscribers and topics before deleting participants
- PSM implementation of datareader constructor
- PSM unit tests for datareader constructor
- Testcase to ensure a Topic cannot be removed if there is a datareader using it

**Must be merged after #1153 **