### PR TITLE
SHM Buffer recovery mechanishm <1.10.x> [8220]

### DIFF
--- a/src/cpp/rtps/transport/shared_mem/SharedMemGlobal.hpp
+++ b/src/cpp/rtps/transport/shared_mem/SharedMemGlobal.hpp
@@ -357,7 +357,7 @@ public:
                                 (*port_it)->node->is_port_ok = false;
 
                                 logWarning(RTPS_TRANSPORT_SHM, "Port " << (*port_it)->node->port_id
-                                    << " error: " << e.what());
+                                    << ": " << e.what());
 
                                 // Remove the port from watch
                                 port_it = watched_ports_.erase(port_it);

--- a/src/cpp/rtps/transport/shared_mem/SharedMemGlobal.hpp
+++ b/src/cpp/rtps/transport/shared_mem/SharedMemGlobal.hpp
@@ -790,7 +790,7 @@ public:
             }
 
             try
-            {                
+            {
                 port->healthy_check();
 
                 if ( (port_node->is_opened_read_exclusive && open_mode != Port::OpenMode::Write) ||
@@ -864,6 +864,16 @@ public:
         }
 
         return port;
+    }
+
+    /**
+     * Remove a port from the system.
+     */
+    void remove_port(
+            uint32_t port_id)
+    {
+        auto port_segment_name = domain_name_ + "_port" + std::to_string(port_id);
+        SharedMemSegment::remove(port_segment_name.c_str());
     }
 
 private:

--- a/src/cpp/rtps/transport/shared_mem/SharedMemGlobal.hpp
+++ b/src/cpp/rtps/transport/shared_mem/SharedMemGlobal.hpp
@@ -72,10 +72,9 @@ public:
      */
     struct BufferDescriptor
     {
-        alignas(8) uint32_t flags;
-        uint64_t enqueue_tick;
         SharedMemSegment::Id source_segment_id;
         SharedMemSegment::Offset buffer_node_offset;
+        uint32_t validity_id;
     };
 
     typedef MultiProducerConsumerRingBuffer<BufferDescriptor>::Listener Listener;

--- a/src/cpp/rtps/transport/shared_mem/SharedMemManager.hpp
+++ b/src/cpp/rtps/transport/shared_mem/SharedMemManager.hpp
@@ -234,10 +234,10 @@ public:
         : global_segment_(
             domain_name,
             []( const std::vector<const SharedMemGlobal::BufferDescriptor*>& buffer_descriptors,
-            const std::string& domain_name)
-                {
-                    on_failure_buffer_descriptor_handler(buffer_descriptors, domain_name);
-                })
+                const std::string& domain_name)
+            {
+                on_failure_buffer_descriptor_handler(buffer_descriptors, domain_name);
+            })
     {
         static_assert(std::alignment_of<BufferNode>::value % 8 == 0, "SharedMemManager::BufferNode bad alignment");
 
@@ -252,11 +252,10 @@ public:
 
         SharedMemGlobal::Port::on_failure_buffer_descriptors_handler(
             []( const std::vector<const SharedMemGlobal::BufferDescriptor*>& buffer_descriptors,
-            const std::string& domain_name)
-                    {
-                        on_failure_buffer_descriptor_handler(buffer_descriptors, domain_name);
-                    }
-            );
+                const std::string& domain_name)
+            {
+                on_failure_buffer_descriptor_handler(buffer_descriptors, domain_name);
+            });
 
         per_allocation_extra_size_ =
                 SharedMemSegment::compute_per_allocation_extra_size(std::alignment_of<BufferNode>::value);

--- a/src/cpp/rtps/transport/shared_mem/SharedMemManager.hpp
+++ b/src/cpp/rtps/transport/shared_mem/SharedMemManager.hpp
@@ -875,6 +875,14 @@ public:
     }
 
     /**
+     * Remove a port from the system.
+     */
+    void remove_port(uint32_t port_id)
+    {
+        global_segment_.remove_port(port_id);
+    }
+
+    /**
      * @return Pointer to the underlying global segment. The pointer is only valid
      * while this SharedMemManager is alive.
      */

--- a/src/cpp/rtps/transport/shared_mem/SharedMemTransport.cpp
+++ b/src/cpp/rtps/transport/shared_mem/SharedMemTransport.cpp
@@ -410,7 +410,8 @@ bool SharedMemTransport::send(
     }
     catch (const std::exception& e)
     {
-        logWarning(RTPS_MSG_OUT, e.what());
+        logInfo(RTPS_TRANSPORT_SHM, e.what());
+        (void)e;
 
         // Segment overflow with discard policy doesn't return error.
         if (!shared_buffer)
@@ -454,7 +455,7 @@ bool SharedMemTransport::push_discard(
     {
         if (!find_port(remote_locator.port)->try_push(buffer))
         {
-            logWarning(RTPS_MSG_OUT, "Port " << remote_locator.port << " full. Buffer dropped");
+            logInfo(RTPS_MSG_OUT, "Port " << remote_locator.port << " full. Buffer dropped");
         }
     }
     catch (const std::exception& error)

--- a/src/cpp/rtps/transport/shared_mem/SharedMemTransport.cpp
+++ b/src/cpp/rtps/transport/shared_mem/SharedMemTransport.cpp
@@ -223,7 +223,7 @@ bool SharedMemTransport::init()
     }
 
     try
-    {        
+    {
         shared_mem_manager_ = std::make_shared<SharedMemManager>(SHM_MANAGER_DOMAIN);
         shared_mem_segment_ = shared_mem_manager_->create_segment(configuration_.segment_size(),
                         configuration_.port_queue_capacity());

--- a/test/unittest/transport/SharedMemTests.cpp
+++ b/test/unittest/transport/SharedMemTests.cpp
@@ -896,7 +896,7 @@ TEST_F(SHMTransportTests, port_listener_dead_recover)
 
             thread_listener2_state = 3;
         }
-            );
+    );
 
     auto port_sender = shared_mem_manager.open_port(0, 1, 1000, SharedMemGlobal::Port::OpenMode::Write);
     auto segment = shared_mem_manager.create_segment(1024, 16);
@@ -973,9 +973,6 @@ TEST_F(SHMTransportTests, on_port_failure_free_enqueued_descriptors)
         *static_cast<uint8_t*>(buffers.back()->data()) = static_cast<uint8_t>(i+1);
     }
 
-    // Not enough space for more allocations
-    ASSERT_THROW(buffers.push_back(segment->alloc_buffer(4, std::chrono::steady_clock::time_point())), std::exception);
-
     auto port_sender = shared_mem_manager.open_port(0, 1, 1000, SharedMemGlobal::Port::OpenMode::Write);
 
     // Enqueued all buffers in the port
@@ -985,9 +982,6 @@ TEST_F(SHMTransportTests, on_port_failure_free_enqueued_descriptors)
     }
 
     buffers.clear();
-
-    // Not enough space for more allocations
-    ASSERT_THROW(buffers.push_back(segment->alloc_buffer(4, std::chrono::steady_clock::time_point())), std::exception);
 
     std::atomic<uint32_t> thread_listener2_state(0);
     std::thread thread_listener2([&]
@@ -1071,7 +1065,7 @@ TEST_F(SHMTransportTests, empty_cv_mutex_deadlocked_try_push)
     bool listerner_active;
     SharedMemSegment::Id random_id;
     random_id.generate();
-    SharedMemGlobal::BufferDescriptor foo = {0, 0, random_id, 0};
+    SharedMemGlobal::BufferDescriptor foo = {random_id, 0, 0};
     ASSERT_THROW(global_port->try_push(foo, &listerner_active), std::exception);
 
     ASSERT_THROW(global_port->healthy_check(), std::exception);
@@ -1110,7 +1104,7 @@ TEST_F(SHMTransportTests, dead_listener_port_recover)
     bool listerners_active;
     SharedMemSegment::Id random_id;
     random_id.generate();
-    SharedMemGlobal::BufferDescriptor foo = {0,0,random_id, 0};
+    SharedMemGlobal::BufferDescriptor foo = {random_id, 0, 0};
     ASSERT_TRUE(port->try_push(foo, &listerners_active));
     ASSERT_TRUE(listerners_active);
     ASSERT_TRUE(listener->head() != nullptr);


### PR DESCRIPTION
To merge after #1147 

This PR solves SHM transport issues when there are mutiple subscribers and one of them freezes or is super slow processing messages. This could provoke the "slow" subscriber holds all the publisher buffers leading to a cotinuous publisher's segment overflow, so all subscribers stop receiving messages.

* Changes buffer-node / buffer-data allocation structure. Now buffer-nodes are allocated (at the segment creation stage) as fixed buffer-node pool independent from the buffer-data. This way, a node never change its address.
* The node contains an atomic validity counter so all subscribers can check whether its reference to the buffer has been invalidated. The node also contains atomic status counters to know how many subscribers are processing the buffer and in how many ports is it enqueued.

* Implement mecanishms to invalidate buffers already enqueued or beign processed by remote subscribers, although only buffers not beign processed are invalidated in this version.

