### PR TITLE
Allow setting up a client-server environment using a ROS1 alike environment variable

### DIFF
--- a/include/fastdds/rtps/RTPSDomain.h
+++ b/include/fastdds/rtps/RTPSDomain.h
@@ -145,7 +145,7 @@ public:
      * @param plisten Pointer to the ParticipantListener.
      * @return Pointer to the RTPSParticipant.
      */
-    static RTPSParticipant* rosEnvironmentCreationOverride(
+    static RTPSParticipant* clientServerEnvironmentCreationOverride(
             uint32_t domain_id,
             const RTPSParticipantAttributes& attrs,
             RTPSParticipantListener* listen /*= nullptr*/);

--- a/include/fastdds/rtps/RTPSDomain.h
+++ b/include/fastdds/rtps/RTPSDomain.h
@@ -16,8 +16,6 @@
  * @file RTPSDomain.h
  */
 
-
-
 #ifndef _FASTDDS_RTPS_DOMAIN_H_
 #define _FASTDDS_RTPS_DOMAIN_H_
 
@@ -139,6 +137,16 @@ public:
     {
         m_maxRTPSParticipantID = maxRTPSParticipantId;
     }
+
+    /**
+     * Creates a RTPSParticipant as default server or client if ROS_MASTER_URI environment variable is set.
+     * @param attrs RTPSParticipant Attributes.
+     * @param plisten Pointer to the ParticipantListener.
+     * @return Pointer to the RTPSParticipant.
+     */
+    static RTPSParticipant* rosEnvironmentCreationOverride(
+            const RTPSParticipantAttributes& attrs,
+            RTPSParticipantListener* listen /*= nullptr*/);
 
 private:
 

--- a/include/fastdds/rtps/RTPSDomain.h
+++ b/include/fastdds/rtps/RTPSDomain.h
@@ -140,11 +140,13 @@ public:
 
     /**
      * Creates a RTPSParticipant as default server or client if ROS_MASTER_URI environment variable is set.
+     * @param domain_id DDS domain associated
      * @param attrs RTPSParticipant Attributes.
      * @param plisten Pointer to the ParticipantListener.
      * @return Pointer to the RTPSParticipant.
      */
     static RTPSParticipant* rosEnvironmentCreationOverride(
+            uint32_t domain_id,
             const RTPSParticipantAttributes& attrs,
             RTPSParticipantListener* listen /*= nullptr*/);
 

--- a/include/fastrtps/Domain.h
+++ b/include/fastrtps/Domain.h
@@ -214,17 +214,7 @@ class Domain
 
     private:
 
-         /**
-         * Creates a RTPSParticipant as default server or client if ROS_MASTER_URI environment variable is set.
-         * @param attrs RTPSParticipant Attributes.
-         * @param plisten Pointer to the ParticipantListener.
-         * @return Pointer to the RTPSParticipant.
-         */
-        static Participant* rosEnvironmentCreationOverride(
-                const eprosima::fastrtps::ParticipantAttributes& att,
-                ParticipantListener* listen = nullptr);
-
-       typedef std::pair<Participant*,ParticipantImpl*> t_p_Participant;
+        typedef std::pair<Participant*,ParticipantImpl*> t_p_Participant;
 
         Domain();
 

--- a/include/fastrtps/Domain.h
+++ b/include/fastrtps/Domain.h
@@ -213,7 +213,18 @@ class Domain
         RTPS_DllAPI static bool loadXMLProfilesFile(const std::string& xml_profile_file);
 
     private:
-        typedef std::pair<Participant*,ParticipantImpl*> t_p_Participant;
+
+         /**
+         * Creates a RTPSParticipant as default server or client if ROS_MASTER_URI environment variable is set.
+         * @param attrs RTPSParticipant Attributes.
+         * @param plisten Pointer to the ParticipantListener.
+         * @return Pointer to the RTPSParticipant.
+         */
+        static Participant* rosEnvironmentCreationOverride(
+                const eprosima::fastrtps::ParticipantAttributes& att,
+                ParticipantListener* listen = nullptr);
+
+       typedef std::pair<Participant*,ParticipantImpl*> t_p_Participant;
 
         Domain();
 

--- a/src/cpp/fastrtps_deprecated/Domain.cpp
+++ b/src/cpp/fastrtps_deprecated/Domain.cpp
@@ -169,9 +169,9 @@ Participant* Domain::createParticipant(
     Participant* pubsubpar = new Participant();
     ParticipantImpl* pspartimpl = new ParticipantImpl(att,pubsubpar,listen);
 
-    // If ROS_MASTER_URI is specified then try to create default server or client if
+    // If DEFAULT_ROS2_MASTER_URI is specified then try to create default server or client if
     // that already exists.
-    RTPSParticipant* part = RTPSDomain::rosEnvironmentCreationOverride(
+    RTPSParticipant* part = RTPSDomain::clientServerEnvironmentCreationOverride(
         att.domainId,
         att.rtps,
         &pspartimpl->m_rtps_listener);

--- a/src/cpp/fastrtps_deprecated/Domain.cpp
+++ b/src/cpp/fastrtps_deprecated/Domain.cpp
@@ -171,12 +171,15 @@ Participant* Domain::createParticipant(
 
     // If ROS_MASTER_URI is specified then try to create default server or client if
     // that already exists.
-    RTPSParticipant* part = RTPSDomain::rosEnvironmentCreationOverride(att.rtps, &pspartimpl->m_rtps_listener);
+    RTPSParticipant* part = RTPSDomain::rosEnvironmentCreationOverride(
+        att.domainId,
+        att.rtps,
+        &pspartimpl->m_rtps_listener);
 
     if(part == nullptr)
     {
         // Default creation procedure
-        part = RTPSDomain::createParticipant(att.rtps, &pspartimpl->m_rtps_listener);
+        part = RTPSDomain::createParticipant(att.domainId, att.rtps, &pspartimpl->m_rtps_listener);
     }
 
     if (part == nullptr)

--- a/src/cpp/fastrtps_deprecated/Domain.cpp
+++ b/src/cpp/fastrtps_deprecated/Domain.cpp
@@ -167,8 +167,17 @@ Participant* Domain::createParticipant(
         ParticipantListener* listen)
 {
     Participant* pubsubpar = new Participant();
-    ParticipantImpl* pspartimpl = new ParticipantImpl(att, pubsubpar, listen);
-    RTPSParticipant* part = RTPSDomain::createParticipant(att.domainId, att.rtps, &pspartimpl->m_rtps_listener);
+    ParticipantImpl* pspartimpl = new ParticipantImpl(att,pubsubpar,listen);
+
+    // If ROS_MASTER_URI is specified then try to create default server or client if
+    // that already exists.
+    RTPSParticipant* part = RTPSDomain::rosEnvironmentCreationOverride(att.rtps, &pspartimpl->m_rtps_listener);
+
+    if(part == nullptr)
+    {
+        // Default creation procedure
+        part = RTPSDomain::createParticipant(att.rtps, &pspartimpl->m_rtps_listener);
+    }
 
     if (part == nullptr)
     {

--- a/src/cpp/rtps/RTPSDomain.cpp
+++ b/src/cpp/rtps/RTPSDomain.cpp
@@ -410,7 +410,7 @@ RTPSParticipant* RTPSDomain::rosEnvironmentCreationOverride(
         server_attr.builtin.metatrafficUnicastLocatorList.push_back(server_address);
 
         part = RTPSDomain::createParticipant(domain_id, server_attr, listen);
-        if(nullptr == part)
+        if(nullptr != part)
         {
             // There wasn't any previous default server, now there is one
             logInfo(DOMAIN, "Ros2 default client-server setup. Default server created.");
@@ -433,7 +433,7 @@ RTPSParticipant* RTPSDomain::rosEnvironmentCreationOverride(
         client_attr.builtin.discovery_config.m_DiscoveryServers.push_back(ratt);
 
         part = RTPSDomain::createParticipant(domain_id, client_attr, listen);
-        if(nullptr == part)
+        if(nullptr != part)
         {
             // client successfully created
             logInfo(DOMAIN, "Ros2 default client-server setup. Default client created.");

--- a/src/cpp/rtps/RTPSDomain.cpp
+++ b/src/cpp/rtps/RTPSDomain.cpp
@@ -358,6 +358,7 @@ RTPSParticipant* RTPSDomain::rosEnvironmentCreationOverride(
     }
 
     // Check for the environment variable
+    #pragma warning(suppress:4996)
     const char* address = std::getenv(DEFAULT_ROS2_MASTER_URI);
 
     if( nullptr == address )
@@ -408,7 +409,8 @@ RTPSParticipant* RTPSDomain::rosEnvironmentCreationOverride(
         server_attr.ReadguidPrefix(DEFAULT_ROS2_SERVER_GUIDPREFIX);
         server_attr.builtin.metatrafficUnicastLocatorList.push_back(server_address);
 
-        if(part = RTPSDomain::createParticipant(domain_id, server_attr, listen))
+        part = RTPSDomain::createParticipant(domain_id, server_attr, listen);
+        if(nullptr == part)
         {
             // There wasn't any previous default server, now there is one
             logInfo(DOMAIN, "Ros2 default client-server setup. Default server created.");
@@ -430,7 +432,8 @@ RTPSParticipant* RTPSDomain::rosEnvironmentCreationOverride(
         ratt.metatrafficUnicastLocatorList.push_back(server_address);
         client_attr.builtin.discovery_config.m_DiscoveryServers.push_back(ratt);
 
-        if( part = RTPSDomain::createParticipant(domain_id, client_attr, listen) )
+        part = RTPSDomain::createParticipant(domain_id, client_attr, listen);
+        if(nullptr == part)
         {
             // client successfully created
             logInfo(DOMAIN, "Ros2 default client-server setup. Default client created.");

--- a/src/cpp/rtps/RTPSDomain.cpp
+++ b/src/cpp/rtps/RTPSDomain.cpp
@@ -378,7 +378,8 @@ RTPSParticipant* RTPSDomain::clientServerEnvironmentCreationOverride(
         if( address_fastdds && address.compare(address_fastdds) )
         {
             logError(DOMAIN, "The environment variables " << DEFAULT_ROS2_MASTER_URI
-                << " and " << DEFAULT_FASTDDS_MASTER_URI << " are both present with different values");
+                << " and " << DEFAULT_FASTDDS_MASTER_URI << " are both present with different values."
+                << " Using configuration from " << DEFAULT_ROS2_MASTER_URI);
         }
     }
     else if( address_fastdds )

--- a/src/cpp/rtps/RTPSDomain.cpp
+++ b/src/cpp/rtps/RTPSDomain.cpp
@@ -359,10 +359,16 @@ RTPSParticipant* RTPSDomain::clientServerEnvironmentCreationOverride(
     }
 
     // Check for the environment variable
+    #pragma warning( push )
+    #pragma warning( disable:4996 )
+
     std::string address;
-    #pragma warning(suppress:4996)
-    const char *address_ros(std::getenv(DEFAULT_ROS2_MASTER_URI)), \
-               *address_fastdds(std::getenv(DEFAULT_FASTDDS_MASTER_URI));
+    const char *address_ros, *address_fastdds;
+
+    address_ros = std::getenv(DEFAULT_ROS2_MASTER_URI);
+    address_fastdds = std::getenv(DEFAULT_FASTDDS_MASTER_URI);
+
+    #pragma warning( pop )
 
     // ros variable has precedence over fastdds one
     if( address_ros )

--- a/src/cpp/rtps/RTPSDomain.cpp
+++ b/src/cpp/rtps/RTPSDomain.cpp
@@ -370,7 +370,7 @@ RTPSParticipant* RTPSDomain::clientServerEnvironmentCreationOverride(
 
     #pragma warning( pop )
 
-    // ros variable has precedence over fastdds one
+    // ros variable has preference over fastdds one
     if( address_ros )
     {
         address = address_ros;

--- a/src/cpp/rtps/participant/RTPSParticipantImpl.cpp
+++ b/src/cpp/rtps/participant/RTPSParticipantImpl.cpp
@@ -317,10 +317,6 @@ RTPSParticipantImpl::RTPSParticipantImpl(
         m_att.defaultMulticastLocatorList.clear();
     }
 
-    // keep original metatraffic locatorList_t values to detect mutation
-    LocatorList_t former_multicast(m_att.builtin.metatrafficMulticastLocatorList),
-    former_unicast(m_att.builtin.metatrafficUnicastLocatorList);
-
     createReceiverResources(m_att.builtin.metatrafficMulticastLocatorList, true, false);
     createReceiverResources(m_att.builtin.metatrafficUnicastLocatorList, true, false);
     createReceiverResources(m_att.defaultUnicastLocatorList, true, false);
@@ -352,15 +348,6 @@ RTPSParticipantImpl::RTPSParticipantImpl(
         }
     }
 #endif
-
-    if ((PParam.builtin.discovery_config.discoveryProtocol == DiscoveryProtocol_t::SERVER
-            || PParam.builtin.discovery_config.discoveryProtocol == DiscoveryProtocol_t::BACKUP)
-            && !(former_multicast == m_att.builtin.metatrafficMulticastLocatorList
-            && former_unicast == m_att.builtin.metatrafficUnicastLocatorList))
-    {
-        logError(RTPS_PARTICIPANT, "Cannot create server participant,"
-                " because the desired locators were not available.");
-    }
 
     mp_builtinProtocols = new BuiltinProtocols();
 
@@ -1428,6 +1415,15 @@ void RTPSParticipantImpl::return_send_buffer(
 uint32_t RTPSParticipantImpl::get_domain_id() const
 {
     return domain_id_;
+}
+
+//!Compare metatraffic locators list searching for mutations
+bool RTPSParticipantImpl::did_mutation_took_place_on_meta(
+    LocatorList_t MulticastLocatorList,
+    LocatorList_t UnicastLocatorList) const
+{
+    return !(m_att.builtin.metatrafficMulticastLocatorList == MulticastLocatorList
+        && m_att.builtin.metatrafficUnicastLocatorList == UnicastLocatorList);
 }
 
 } /* namespace rtps */

--- a/src/cpp/rtps/participant/RTPSParticipantImpl.cpp
+++ b/src/cpp/rtps/participant/RTPSParticipantImpl.cpp
@@ -37,6 +37,7 @@
 #include <fastdds/rtps/participant/RTPSParticipant.h>
 #include <fastdds/rtps/transport/UDPv4TransportDescriptor.h>
 #include <fastdds/rtps/transport/TCPv4TransportDescriptor.h>
+#include <fastdds/rtps/transport/TCPv6TransportDescriptor.h>
 #include <fastdds/rtps/transport/shared_mem/SharedMemTransportDescriptor.h>
 
 #include <fastdds/rtps/RTPSDomain.h>
@@ -52,6 +53,7 @@
 #include <fastrtps/utils/System.h>
 
 #include <mutex>
+#include <functional>
 #include <algorithm>
 
 #include <fastdds/dds/log/Log.hpp>
@@ -1419,11 +1421,98 @@ uint32_t RTPSParticipantImpl::get_domain_id() const
 
 //!Compare metatraffic locators list searching for mutations
 bool RTPSParticipantImpl::did_mutation_took_place_on_meta(
-    LocatorList_t MulticastLocatorList,
-    LocatorList_t UnicastLocatorList) const
+    const LocatorList_t& MulticastLocatorList,
+    const LocatorList_t& UnicastLocatorList) const
 {
-    return !(m_att.builtin.metatrafficMulticastLocatorList == MulticastLocatorList
-        && m_att.builtin.metatrafficUnicastLocatorList == UnicastLocatorList);
+    if(m_att.builtin.metatrafficMulticastLocatorList == MulticastLocatorList
+        && m_att.builtin.metatrafficUnicastLocatorList == UnicastLocatorList)
+    {
+        // no mutation
+        return false;
+    }
+
+    // TCP is a special case because physical ports are taken from the TransportDescriptors
+    struct ResetLogical : public std::unary_function<Locator_t, const Locator_t&>
+    {
+        typedef std::vector<std::shared_ptr<fastdds::rtps::TransportDescriptorInterface>> Transports;
+
+        ResetLogical(const Transports& tp) 
+            : Transports_(tp)
+            , tcp4(nullptr)
+            , tcp6(nullptr)
+        {
+            for(auto desc : Transports_)
+            {
+                if(nullptr == tcp4)
+                {
+                    tcp4 = dynamic_cast<fastdds::rtps::TCPv4TransportDescriptor*>(desc.get());
+                }
+
+                if(nullptr == tcp6)
+                {
+                    tcp6 = dynamic_cast<fastdds::rtps::TCPv6TransportDescriptor*>(desc.get());
+                }
+            }
+        }
+
+        uint16_t Tcp4ListeningPort() const
+        {
+            return tcp4 ? ( tcp4->listening_ports.empty() ? 0 : tcp4->listening_ports[0]) : 0;
+        }
+
+        uint16_t Tcp6ListeningPort() const
+        {
+            return tcp6 ? ( tcp6->listening_ports.empty() ? 0 : tcp6->listening_ports[0]) : 0;
+        }
+
+        Locator_t operator()(const Locator_t& loc) const
+        {
+            Locator_t ret(loc);
+            switch(loc.kind)
+            {
+            case LOCATOR_KIND_TCPv4:
+                IPLocator::setPhysicalPort(ret, Tcp4ListeningPort());
+                break;
+            case LOCATOR_KIND_TCPv6:
+                IPLocator::setPhysicalPort(ret, Tcp6ListeningPort());
+                break;
+            }
+            return ret;
+        }
+
+        // reference to the transports
+        const Transports& Transports_;
+        TCPTransportDescriptor *tcp4, *tcp6;
+
+    } transform_functor(m_att.userTransports);
+
+    // transform-copy
+    std::list<Locator_t> update_attributes;
+
+    std::transform(m_att.builtin.metatrafficMulticastLocatorList.begin(),
+            m_att.builtin.metatrafficMulticastLocatorList.end(),
+            std::back_inserter(update_attributes),
+            transform_functor);
+
+    std::transform(m_att.builtin.metatrafficUnicastLocatorList.begin(),
+            m_att.builtin.metatrafficUnicastLocatorList.end(),
+            std::back_inserter(update_attributes),
+            transform_functor);
+
+    std::list<Locator_t> original_ones;
+
+    std::transform(MulticastLocatorList.begin(),
+        MulticastLocatorList.end(),
+        std::back_inserter(original_ones),
+        transform_functor);
+
+    std::transform(UnicastLocatorList.begin(),
+        UnicastLocatorList.end(),
+        std::back_inserter(original_ones),
+        transform_functor);
+
+    // if equal then no mutation took place on physical ports
+    return !(update_attributes == original_ones);
 }
 
 } /* namespace rtps */

--- a/src/cpp/rtps/participant/RTPSParticipantImpl.h
+++ b/src/cpp/rtps/participant/RTPSParticipantImpl.h
@@ -442,8 +442,8 @@ public:
 
     //!Compare metatraffic locators list searching for mutations
     bool did_mutation_took_place_on_meta(
-        LocatorList_t MulticastLocatorList,
-        LocatorList_t UnicastLocatorList) const;
+        const LocatorList_t& MulticastLocatorList,
+        const LocatorList_t& UnicastLocatorList) const;
 
 private:
 

--- a/src/cpp/rtps/participant/RTPSParticipantImpl.h
+++ b/src/cpp/rtps/participant/RTPSParticipantImpl.h
@@ -440,6 +440,11 @@ public:
 
     uint32_t get_domain_id() const;
 
+    //!Compare metatraffic locators list searching for mutations
+    bool did_mutation_took_place_on_meta(
+        LocatorList_t MulticastLocatorList,
+        LocatorList_t UnicastLocatorList) const;
+
 private:
 
     //! DomainId


### PR DESCRIPTION
Now a simple client-server discovery strategy using UDP can be specified by setting an environment variable
**ROS2_AUTO_CLIENT_SERVER** or **FASTDDS_AUTO_CLIENT_SERVER** to *IPAddress:port* where the port is optional (if not given a default one of 11311 is used). 
For example ``127.0.0.1``, ``192.168.36.34:3253`` or ``192.168.36.34`` are well formed.

If both set, Ros variable has precedence over FastDDS one.

The first participant with an interface that matches the IPAddress will try to reserve the UDP port given. If not able
to reserved it, a server presence is assumed and the participant becames a client.

If the participant attributes specifies a different mechanism from simple discovery the **ROS_AUTO_CLIENT_SERVER** and **FASTDDS_AUTO_CLIENT_SERVER** are ignored.

Note that if the server participant is killed and no new participant is created the clients will remain orphan. One
workaround is make the Domain create a new server whenever the server is killed but this is open to discussion.
