### PR TITLE
Fixing gcc 9 warnings [8231]

### DIFF
--- a/include/dds/core/Reference.hpp
+++ b/include/dds/core/Reference.hpp
@@ -116,6 +116,18 @@ public:
         : impl_(ref.impl_)
     {
     }
+    
+    /**
+     * Assign a Reference from another.
+     *
+     * @param ref the other reference
+     */
+    Reference& operator = (
+            const Reference& ref)
+    {
+        impl_ = ref.impl_;
+        return *this;
+    }
 
     /**
      * Creates a Reference from other Reference type safely.

--- a/include/fastdds/dds/core/status/StatusMask.hpp
+++ b/include/fastdds/dds/core/status/StatusMask.hpp
@@ -70,26 +70,6 @@ public:
     }
 
     /**
-     * Copy constructor.
-     *
-     * Construct an StatusMask with existing StatusMask.
-     *
-     * @param other the StatusMask to copy from
-     */
-    StatusMask(
-            const StatusMask& other)
-        : std::bitset<FASTDDS_STATUS_COUNT>(other)
-    {
-    }
-
-    /** @cond */
-    ~StatusMask()
-    {
-    }
-
-    /** @endcond */
-
-    /**
      * Shift (merge) given StatusMask bits into this StatusMask bitset.
      *
      * @return StatusMask this


### PR DESCRIPTION
This fixes some `-Wdeprecated-copy` warnings.