### PR TITLE
Feature/dds domainparticipant enable

### DIFF
--- a/examples/C++/DDS/DynamicHelloWorldExample/HelloWorldSubscriber.h
+++ b/examples/C++/DDS/DynamicHelloWorldExample/HelloWorldSubscriber.h
@@ -52,8 +52,6 @@ public:
     void run(
             uint32_t number);
 
-    eprosima::fastdds::dds::DomainParticipant* participant();
-
 private:
 
     eprosima::fastdds::dds::DomainParticipant* mp_participant;
@@ -69,8 +67,6 @@ private:
     eprosima::fastrtps::SubscriberAttributes att_;
 
     eprosima::fastdds::dds::DataReaderQos qos_;
-
-    std::mutex mutex_;
 
 public:
 

--- a/examples/C++/DDS/TypeLookupService/TypeLookupSubscriber.h
+++ b/examples/C++/DDS/TypeLookupService/TypeLookupSubscriber.h
@@ -52,8 +52,6 @@ public:
     void run(
             uint32_t number);
 
-    eprosima::fastdds::dds::DomainParticipant* participant();
-
 private:
 
     eprosima::fastdds::dds::DomainParticipant* mp_participant;
@@ -69,8 +67,6 @@ private:
     eprosima::fastrtps::SubscriberAttributes att_;
 
     eprosima::fastdds::dds::DataReaderQos qos_;
-
-    std::mutex mutex_;
 
 public:
 

--- a/include/fastdds/dds/domain/DomainParticipant.hpp
+++ b/include/fastdds/dds/domain/DomainParticipant.hpp
@@ -90,6 +90,12 @@ public:
     RTPS_DllAPI const DomainParticipantQos& get_qos() const;
 
     /**
+     * @brief enable This operation enables the DomainParticipant
+     * @return true
+     */
+    RTPS_DllAPI ReturnCode_t enable() override;
+
+    /**
      * This operation sets the value of the DomainParticipant QoS policies.
      * This operation will check that the resulting policies are self consistent; if they are not,
      * the operation will have no effect and return INCONSISTENT_POLICY.

--- a/include/fastdds/rtps/RTPSDomain.h
+++ b/include/fastdds/rtps/RTPSDomain.h
@@ -77,6 +77,21 @@ public:
             RTPSParticipantListener* plisten = nullptr);
 
     /**
+     * @brief Create a RTPSParticipant.
+     * @snippet fastrtps_example.cpp ex_RTPSParticipantCreation
+     * @param domain_id DomainId to be used by the RTPSParticipant (80 by default).
+     * @param enabled True if the RTPSParticipant should be enabled on creation. False if it will be enabled later with RTPSParticipant::enable()
+     * @param attrs RTPSParticipant Attributes.
+     * @param plisten Pointer to the ParticipantListener.
+     * @return Pointer to the RTPSParticipant.
+     */
+    RTPS_DllAPI static RTPSParticipant* createParticipant(
+            uint32_t domain_id,
+            bool enabled,
+            const RTPSParticipantAttributes& attrs,
+            RTPSParticipantListener* plisten = nullptr);
+
+    /**
      * Create a RTPSWriter in a participant.
      * @param p Pointer to the RTPSParticipant.
      * @param watt Writer Attributes.

--- a/include/fastdds/rtps/participant/RTPSParticipant.h
+++ b/include/fastdds/rtps/participant/RTPSParticipant.h
@@ -233,6 +233,11 @@ public:
      */
     uint32_t get_domain_id() const;
 
+    /**
+     * @brief This operation enables the RTPSParticipantImpl
+     */
+    void enable();
+
 private:
 
     //!Pointer to the implementation.

--- a/src/cpp/fastdds/domain/DomainParticipant.cpp
+++ b/src/cpp/fastdds/domain/DomainParticipant.cpp
@@ -45,6 +45,12 @@ DomainParticipant::~DomainParticipant()
 {
 }
 
+ReturnCode_t DomainParticipant::enable()
+{
+    Entity::enable();
+    return impl_->enable();
+}
+
 ReturnCode_t DomainParticipant::set_qos(
         const DomainParticipantQos& qos) const
 {

--- a/src/cpp/fastdds/domain/DomainParticipantFactory.cpp
+++ b/src/cpp/fastdds/domain/DomainParticipantFactory.cpp
@@ -75,14 +75,7 @@ DomainParticipantFactory::~DomainParticipantFactory()
             for (auto pit : it.second)
             {
                 pit->disable();
-            }
-        }
-        // Delete participants
-        for (auto it : participants_)
-        {
-            for (auto pit = it.second.begin(); pit != it.second.end(); ++pit)
-            {
-                delete *pit;
+                delete pit;
             }
         }
         participants_.clear();
@@ -147,6 +140,7 @@ ReturnCode_t DomainParticipantFactory::delete_participant(
                 if ((*pit)->get_participant() == part
                         || (*pit)->get_participant()->guid() == part->guid())
                 {
+                    (*pit)->disable();
                     delete (*pit);
                     PartVectorIt next_it = vit->second.erase(pit);
                     pit = next_it;
@@ -179,7 +173,7 @@ DomainParticipant* DomainParticipantFactory::create_participant(
     DomainParticipantImpl* dom_part_impl = new DomainParticipantImpl(dom_part, pqos, listen);
 
     fastrtps::rtps::RTPSParticipantAttributes rtps_attr = get_attributes(pqos);
-    RTPSParticipant* part = RTPSDomain::createParticipant(did, rtps_attr, &dom_part_impl->rtps_listener_);
+    RTPSParticipant* part = RTPSDomain::createParticipant(did, false, rtps_attr, &dom_part_impl->rtps_listener_);
 
     if (part == nullptr)
     {

--- a/src/cpp/fastdds/domain/DomainParticipantImpl.cpp
+++ b/src/cpp/fastdds/domain/DomainParticipantImpl.cpp
@@ -162,6 +162,13 @@ DomainParticipantImpl::~DomainParticipantImpl()
     participant_ = nullptr;
 }
 
+ReturnCode_t DomainParticipantImpl::enable()
+{
+    rtps_participant_->enable();
+    return ReturnCode_t::RETCODE_OK;
+}
+
+
 ReturnCode_t DomainParticipantImpl::set_qos(
         const DomainParticipantQos& qos)
 {

--- a/src/cpp/fastdds/domain/DomainParticipantImpl.hpp
+++ b/src/cpp/fastdds/domain/DomainParticipantImpl.hpp
@@ -83,6 +83,8 @@ private:
 
 public:
 
+    ReturnCode_t enable();
+
     ReturnCode_t get_qos(
             DomainParticipantQos& qos) const;
 

--- a/src/cpp/rtps/RTPSDomain.cpp
+++ b/src/cpp/rtps/RTPSDomain.cpp
@@ -90,6 +90,15 @@ RTPSParticipant* RTPSDomain::createParticipant(
         const RTPSParticipantAttributes& attrs,
         RTPSParticipantListener* listen)
 {
+    return createParticipant(domain_id, true, attrs, listen);
+}
+
+RTPSParticipant* RTPSDomain::createParticipant(
+        uint32_t domain_id,
+        bool enabled,
+        const RTPSParticipantAttributes& attrs,
+        RTPSParticipantListener* listen)
+{
     logInfo(RTPS_PARTICIPANT, "");
 
     RTPSParticipantAttributes PParam = attrs;
@@ -222,8 +231,11 @@ RTPSParticipant* RTPSDomain::createParticipant(
         m_RTPSParticipants.push_back(t_p_RTPSParticipant(p, pimpl));
     }
 
-    // Start protocols
-    pimpl->enable();
+    if (enabled)
+    {
+        // Start protocols
+        pimpl->enable();
+    }
     return p;
 }
 

--- a/src/cpp/rtps/participant/RTPSParticipant.cpp
+++ b/src/cpp/rtps/participant/RTPSParticipant.cpp
@@ -165,6 +165,11 @@ uint32_t RTPSParticipant::get_domain_id() const
     return mp_impl->get_domain_id();
 }
 
+void RTPSParticipant::enable()
+{
+    mp_impl->enable();
+}
+
 } /* namespace rtps */
 } /* namespace fastrtps */
 } /* namespace eprosima */

--- a/src/cpp/rtps/participant/RTPSParticipantImpl.cpp
+++ b/src/cpp/rtps/participant/RTPSParticipantImpl.cpp
@@ -353,12 +353,6 @@ RTPSParticipantImpl::RTPSParticipantImpl(
 
     mp_builtinProtocols = new BuiltinProtocols();
 
-    //Start reception
-    for (auto& receiver : m_receiverResourcelist)
-    {
-        receiver.Receiver->RegisterReceiver(receiver.mp_receiver);
-    }
-
     logInfo(RTPS_PARTICIPANT, "RTPSParticipant \"" << m_att.getName() << "\" with guidPrefix: " << m_guid.guidPrefix);
 }
 

--- a/test/dds/communication/Publisher.cpp
+++ b/test/dds/communication/Publisher.cpp
@@ -248,6 +248,7 @@ int main(
 
     if (participant == nullptr)
     {
+        std::cout << "Error creating publisher participant" << std::endl;
         return 1;
     }
 
@@ -270,12 +271,14 @@ int main(
     Publisher* publisher = participant->create_publisher(PUBLISHER_QOS_DEFAULT, &listener);
     if (publisher == nullptr)
     {
+        std::cout << "Error creating publisher" << std::endl;
         DomainParticipantFactory::get_instance()->delete_participant(participant);
         return 1;
     }
     Topic* topic = participant->create_topic(topic_name.str(), type.get_type_name(), TOPIC_QOS_DEFAULT);
     if (topic == nullptr)
     {
+        std::cout << "Error creating publisher topic" << std::endl;
         participant->delete_publisher(publisher);
         DomainParticipantFactory::get_instance()->delete_participant(participant);
         return 1;

--- a/test/dds/communication/Subscriber.cpp
+++ b/test/dds/communication/Subscriber.cpp
@@ -329,6 +329,11 @@ int main(
        }
      */
 
+    //Do not enable entities on creation
+    DomainParticipantFactoryQos factory_qos;
+    factory_qos.entity_factory().autoenable_created_entities = false;
+    DomainParticipantFactory::get_instance()->set_qos(factory_qos);
+
     DomainParticipantQos participant_qos;
     participant_qos.wire_protocol().builtin.typelookup_config.use_client = true;
     ParListener participant_listener;
@@ -338,6 +343,7 @@ int main(
 
     if (g_participant == nullptr)
     {
+        std::cout << "Error creating subscriber participant" << std::endl;
         return 1;
     }
 
@@ -352,9 +358,13 @@ int main(
 
     if (g_subscriber == nullptr)
     {
+        std::cout << "Error creating subscriber" << std::endl;
         DomainParticipantFactory::get_instance()->delete_participant(g_participant);
         return 1;
     }
+
+    //Now that everything is created we can enable the protocols
+    g_participant->enable();
 
     while (notexit && g_run)
     {

--- a/test/unittest/dds/participant/ParticipantTests.cpp
+++ b/test/unittest/dds/participant/ParticipantTests.cpp
@@ -87,7 +87,7 @@ public:
 };
 
 
-TEST(ParticipantTest, DomainParticipantFactoryGetInstance)
+TEST(ParticipantTests, DomainParticipantFactoryGetInstance)
 {
     DomainParticipantFactory* factory = DomainParticipantFactory::get_instance();
 

--- a/test/xtypes/TestPublisher.h
+++ b/test/xtypes/TestPublisher.h
@@ -91,8 +91,6 @@ public:
         return disc_type_;
     }
 
-    eprosima::fastdds::dds::DomainParticipant* participant();
-
     eprosima::fastdds::dds::DataWriter* create_datawriter();
 
     void delete_datawriter(
@@ -127,8 +125,6 @@ private:
     std::mutex m_mDiscovery;
 
     std::mutex mtx_type_discovery_;
-
-    std::mutex mutex_;
 
     std::condition_variable m_cvDiscovery;
 

--- a/test/xtypes/TestSubscriber.h
+++ b/test/xtypes/TestSubscriber.h
@@ -95,8 +95,6 @@ public:
     void delete_datareader(
             eprosima::fastdds::dds::DataReader* reader);
 
-    eprosima::fastdds::dds::DomainParticipant* participant();
-
     eprosima::fastdds::dds::TypeSupport m_Type;
 
 private:
@@ -111,7 +109,6 @@ private:
     bool m_bInitialized;
     std::mutex m_mDiscovery;
     std::mutex mtx_type_discovery_;
-    std::mutex mutex_;
     std::condition_variable m_cvDiscovery;
     std::condition_variable cv_type_discovery_;
     std::condition_variable cv_;


### PR DESCRIPTION
- Let RTPSDomain::createParticipant take a new argument to create the participant not enabled. This is needed to observe `autoenable_created_entities`
- Implement DomainParticipant::enable so that it ends up calling RTPSParticipant::enable
- Update all testcases and examples that need to create a non-enabled participant and enable it later.

This PR reverts #1044 while still correcting the situation it tried to correct:

> Some of the tests have pubsubs with listeners that access the participant
pointer when receiving a message. Depending on the timing, the receive
resources can be up and running and start receiving before the pointer
is stored internally. When the listener tries to access this pointer,
the test crashes.

This PR also solves issues with DDSSimpleCommunicationTypeDiscovery on master.