### PR TITLE
Solve localhost issues on default server client discovery setup via environmental variable

### DIFF
--- a/src/cpp/rtps/RTPSDomain.cpp
+++ b/src/cpp/rtps/RTPSDomain.cpp
@@ -422,14 +422,15 @@ RTPSParticipant* RTPSDomain::clientServerEnvironmentCreationOverride(
     Locator_t server_address(port);
     IPLocator::setIPv4(server_address, ip_address);
 
-    // if any choose localhost
-    if(IPLocator::isAny(server_address))
+    // indulge the people that thinks 127.0.0.1 means actually 0.0.0.0
+    if(IPLocator::isLocal(server_address))
     {
-        IPLocator::setIPv4(server_address,"127.0.0.1");
+        // by doing this using 127.0.0.1 allows over network not only interprocess (the expected result)
+        IPLocator::setIPv4(server_address, "0.0.0.0");
     }
 
     IPFinder::getIP4Address(&locals);
-    if( IPLocator::isLocal(server_address)
+    if( IPLocator::isAny(server_address)
         || (locals.end() != std::find_if(locals.begin(), locals.end(),
             [&server_address](const Locator_t & loc) -> bool
             {


### PR DESCRIPTION
This PR is related with: https://github.com/eProsima/Fast-RTPS/pull/1160

The **ROS2_AUTO_CLIENT_SERVER** or **FASTDDS_AUTO_CLIENT_SERVER** environment variables are used to specify the server address. Now:
+ the server may use the addresses 127.0.0.1 or 0.0.0.0 to listening in all local machine interfaces.
+ the client may use the addresses 127.0.0.1 or 0.0.0.0 to be indicated the server is local.

To summarize one can setup intermachine communication by first launching a server as 127.0.0.1 or 0.0.0.0.
If a client launch later:
+ shares machine with the server it suffices to use 127.0.0.1 or 0.0.0.0 to communicate.
+ is in another machine must specify the real IP address of any of the server machine interfaces.
+ shares machine with the