### PR TITLE
Fix api break on profiling tests [8243]

### DIFF
--- a/test/performance/video/VideoTestPublisher.cpp
+++ b/test/performance/video/VideoTestPublisher.cpp
@@ -115,11 +115,11 @@ bool VideoTestPublisher::init(int n_sub, int n_sam, bool reliable, uint32_t pid,
     ParticipantAttributes PParam;
     if (m_forcedDomain >= 0)
     {
-        PParam.rtps.builtin.domainId = m_forcedDomain;
+        PParam.domainId = m_forcedDomain;
     }
     else
     {
-        PParam.rtps.builtin.domainId = pid % 230;
+        PParam.domainId = pid % 230;
     }
     PParam.rtps.properties = part_property_policy;
     PParam.rtps.setName("video_test_publisher");
@@ -133,7 +133,7 @@ bool VideoTestPublisher::init(int n_sub, int n_sam, bool reliable, uint32_t pid,
                 eprosima::fastrtps::xmlparser::XMLProfileManager::fillParticipantAttributes(participant_profile_name,
                     participant_att))
             {
-                participant_att.rtps.builtin.domainId = m_forcedDomain;
+                participant_att.domainId = m_forcedDomain;
                 mp_participant = Domain::createParticipant(participant_att);
             }
         }

--- a/test/performance/video/VideoTestSubscriber.cpp
+++ b/test/performance/video/VideoTestSubscriber.cpp
@@ -106,11 +106,11 @@ bool VideoTestSubscriber::init(int nsam, bool reliable, uint32_t pid, bool hostn
 
     if (m_forcedDomain >= 0)
     {
-        PParam.rtps.builtin.domainId = m_forcedDomain;
+        PParam.domainId = m_forcedDomain;
     }
     else
     {
-        PParam.rtps.builtin.domainId = pid % 230;
+        PParam.domainId = pid % 230;
     }
     PParam.rtps.setName("video_test_subscriber");
     PParam.rtps.properties = part_property_policy;
@@ -124,7 +124,7 @@ bool VideoTestSubscriber::init(int nsam, bool reliable, uint32_t pid, bool hostn
                 eprosima::fastrtps::xmlparser::XMLProfileManager::fillParticipantAttributes(participant_profile_name,
                     participant_att))
             {
-                participant_att.rtps.builtin.domainId = m_forcedDomain;
+                participant_att.domainId = m_forcedDomain;
                 mp_participant = Domain::createParticipant(participant_att);
             }
         }

--- a/test/profiling/MemoryTestPublisher.cpp
+++ b/test/profiling/MemoryTestPublisher.cpp
@@ -102,7 +102,7 @@ bool MemoryTestPublisher::init(int n_sub, int n_sam, bool reliable, uint32_t pid
     // Create RTPSParticipant
     std::string participant_profile_name = "participant_profile";
     ParticipantAttributes PParam;
-    PParam.rtps.builtin.domainId = pid % 230;
+    PParam.domainId = pid % 230;
     PParam.rtps.properties = part_property_policy;
     PParam.rtps.setName("Participant_pub");
 

--- a/test/profiling/MemoryTestPublisher.cpp
+++ b/test/profiling/MemoryTestPublisher.cpp
@@ -20,6 +20,9 @@
 #include "MemoryTestPublisher.h"
 #include <fastdds/dds/log/Log.hpp>
 #include "fastrtps/log/Colors.h"
+
+#include <dds/core/LengthUnlimited.hpp>
+
 #include <numeric>
 #include <cmath>
 #include <fstream>
@@ -91,7 +94,7 @@ bool MemoryTestPublisher::init(int n_sub, int n_sam, bool reliable, uint32_t pid
         struct_type_builder->add_member(0, "seqnum", DynamicTypeBuilderFactory::get_instance()->create_uint32_type());
         struct_type_builder->add_member(1, "data",
             DynamicTypeBuilderFactory::get_instance()->create_sequence_builder(
-                DynamicTypeBuilderFactory::get_instance()->create_byte_type(), LENGTH_UNLIMITED
+                DynamicTypeBuilderFactory::get_instance()->create_byte_type(), ::dds::core::LENGTH_UNLIMITED
             ));
         struct_type_builder->set_name("MemoryType");
 

--- a/test/profiling/MemoryTestSubscriber.cpp
+++ b/test/profiling/MemoryTestSubscriber.cpp
@@ -21,6 +21,8 @@
 #include <fastdds/dds/log/Log.hpp>
 #include "fastrtps/log/Colors.h"
 
+#include <dds/core/LengthUnlimited.hpp>
+
 using namespace eprosima::fastrtps;
 using namespace eprosima::fastrtps::rtps;
 using namespace eprosima::fastrtps::types;
@@ -74,7 +76,7 @@ bool MemoryTestSubscriber::init(bool echo, int nsam, bool reliable, uint32_t pid
         struct_type_builder->add_member(0, "seqnum", DynamicTypeBuilderFactory::get_instance()->create_uint32_type());
         struct_type_builder->add_member(1, "data",
             DynamicTypeBuilderFactory::get_instance()->create_sequence_builder(
-                DynamicTypeBuilderFactory::get_instance()->create_byte_type(), LENGTH_UNLIMITED
+                DynamicTypeBuilderFactory::get_instance()->create_byte_type(), ::dds::core::LENGTH_UNLIMITED
             ));
         struct_type_builder->set_name("MemoryType");
 

--- a/test/profiling/MemoryTestSubscriber.cpp
+++ b/test/profiling/MemoryTestSubscriber.cpp
@@ -85,7 +85,7 @@ bool MemoryTestSubscriber::init(bool echo, int nsam, bool reliable, uint32_t pid
     // Create RTPSParticipant
     std::string participant_profile_name = "participant_profile";
     ParticipantAttributes PParam;
-    PParam.rtps.builtin.domainId = pid % 230;
+    PParam.domainId = pid % 230;
     PParam.rtps.setName("Participant_sub");
     PParam.rtps.properties = part_property_policy;
 

--- a/test/profiling/allocations/AllocTestPublisher.cpp
+++ b/test/profiling/allocations/AllocTestPublisher.cpp
@@ -50,7 +50,7 @@ bool AllocTestPublisher::init(const char* profile, int domainId, const std::stri
         eprosima::fastrtps::xmlparser::XMLProfileManager::fillParticipantAttributes("test_participant_profile",
             participant_att))
     {
-        participant_att.rtps.builtin.domainId = domainId;
+        participant_att.domainId = domainId;
         mp_participant = Domain::createParticipant(participant_att);
     }
 

--- a/test/profiling/allocations/AllocTestSubscriber.cpp
+++ b/test/profiling/allocations/AllocTestSubscriber.cpp
@@ -45,7 +45,7 @@ bool AllocTestSubscriber::init(const char* profile, int domainId, const std::str
         eprosima::fastrtps::xmlparser::XMLProfileManager::fillParticipantAttributes("test_participant_profile",
             participant_att))
     {
-        participant_att.rtps.builtin.domainId = domainId;
+        participant_att.domainId = domainId;
         mp_participant = Domain::createParticipant(participant_att);
     }
 

--- a/utils/pcTests/HelloWorldTestLiveliness/HelloWorldPublisher.cpp
+++ b/utils/pcTests/HelloWorldTestLiveliness/HelloWorldPublisher.cpp
@@ -45,7 +45,7 @@ bool HelloWorldPublisher::init()
 	PParam.rtps.builtin.discovery_config.use_SIMPLE_EndpointDiscoveryProtocol = true;
 	PParam.rtps.builtin.discovery_config.m_simpleEDP.use_PublicationReaderANDSubscriptionWriter = true;
 	PParam.rtps.builtin.discovery_config.m_simpleEDP.use_PublicationWriterANDSubscriptionReader = true;
-	PParam.rtps.builtin.domainId = 80;
+	PParam.domainId = 80;
 	PParam.rtps.builtin.leaseDuration = c_TimeInfinite;
 	PParam.rtps.sendSocketBufferSize = 8712;
 	PParam.rtps.listenSocketBufferSize = 17424;

--- a/utils/pcTests/HelloWorldTestLiveliness/HelloWorldSubscriber.cpp
+++ b/utils/pcTests/HelloWorldTestLiveliness/HelloWorldSubscriber.cpp
@@ -39,7 +39,7 @@ bool HelloWorldSubscriber::init()
 	PParam.rtps.builtin.discovery_config.use_SIMPLE_EndpointDiscoveryProtocol = true;
 	PParam.rtps.builtin.discovery_config.m_simpleEDP.use_PublicationReaderANDSubscriptionWriter = true;
 	PParam.rtps.builtin.discovery_config.m_simpleEDP.use_PublicationWriterANDSubscriptionReader = true;
-	PParam.rtps.builtin.domainId = 80;
+	PParam.domainId = 80;
 	PParam.rtps.builtin.leaseDuration = c_TimeInfinite;
 	PParam.rtps.sendSocketBufferSize = 8712;
 	PParam.rtps.listenSocketBufferSize = 17424;


### PR DESCRIPTION
As profiling tests are not built on CI, api breaks were missed on them.

This PR fixes that.