### PR TITLE
[8255] Solving validation error when creating SERVER or BACKUP participant

### DIFF
--- a/src/cpp/rtps/participant/RTPSParticipantImpl.cpp
+++ b/src/cpp/rtps/participant/RTPSParticipantImpl.cpp
@@ -1458,6 +1458,7 @@ bool RTPSParticipantImpl::did_mutation_took_place_on_meta(
                 {
                     Locator_t specific(loc);
                     specific.port = an_any.port;
+                    specific.kind = an_any.kind;
                     return specific;
                 });
 


### PR DESCRIPTION
**HelloWorldExampleDS** failed when using default **tcp** setup. Debugging led to zero a bug in Fast-RTPS library. This bug was in the mechanism devoted to assessing if a **SERVER** or **BACKUP** participant is able to open the listener portsspecified.

If an **any** locator (``0.0.0.0``) is specified the library internally replaces it for locators associated to all available interfaces.The function that returns these interfaces generates UDPv4 locators that must be  modified to match the **any** locator kind provided (in this case TCPv4).

