### PR TITLE
Fixes and improvements on StatefulWriter <2.0.x> [8324]

### DIFF
--- a/include/fastdds/rtps/transport/test_UDPv4Transport.h
+++ b/include/fastdds/rtps/transport/test_UDPv4Transport.h
@@ -66,15 +66,25 @@ private:
         uint8_t accumulator;
     };
 
+    typedef std::function<bool(fastrtps::rtps::CDRMessage_t& msg)> filter;
+
     PercentageData drop_data_messages_percentage_;
+    test_UDPv4TransportDescriptor::filter drop_data_messages_filter_;
     bool drop_participant_builtin_topic_data_;
     bool drop_publication_builtin_topic_data_;
     bool drop_subscription_builtin_topic_data_;
     PercentageData drop_data_frag_messages_percentage_;
+    test_UDPv4TransportDescriptor::filter drop_data_frag_messages_filter_;
     PercentageData drop_heartbeat_messages_percentage_;
+    test_UDPv4TransportDescriptor::filter drop_heartbeat_messages_filter_;
     PercentageData drop_ack_nack_messages_percentage_;
-    std::vector<fastrtps::rtps::SequenceNumber_t> sequence_number_data_messages_to_drop_;
+    test_UDPv4TransportDescriptor::filter drop_ack_nack_messages_filter_;
+    PercentageData drop_gap_messages_percentage_;
+    test_UDPv4TransportDescriptor::filter drop_gap_messages_filter_;
     PercentageData percentage_of_messages_to_drop_;
+    test_UDPv4TransportDescriptor::filter messages_filter_;
+    std::vector<fastrtps::rtps::SequenceNumber_t> sequence_number_data_messages_to_drop_;
+
 
     bool log_drop(const fastrtps::rtps::octet* buffer, uint32_t size);
     bool packet_should_drop(const fastrtps::rtps::octet* send_buffer, uint32_t send_buffer_size);

--- a/include/fastdds/rtps/transport/test_UDPv4TransportDescriptor.h
+++ b/include/fastdds/rtps/transport/test_UDPv4TransportDescriptor.h
@@ -17,25 +17,35 @@
 
 #include <fastdds/rtps/transport/SocketTransportDescriptor.h>
 #include <fastdds/rtps/common/SequenceNumber.h>
+#include <functional>
 
 namespace eprosima{
 namespace fastdds{
 namespace rtps{
 
 typedef struct test_UDPv4TransportDescriptor : public SocketTransportDescriptor{
-   bool granularMode;
+
+    typedef std::function<bool(fastrtps::rtps::CDRMessage_t& msg)> filter;
 
    // Test shim parameters
    uint8_t dropDataMessagesPercentage;
+   filter drop_data_messages_filter_;
    bool dropParticipantBuiltinTopicData;
    bool dropPublicationBuiltinTopicData;
    bool dropSubscriptionBuiltinTopicData;
    uint8_t dropDataFragMessagesPercentage;
+   filter drop_data_frag_messages_filter_;
    uint8_t dropHeartbeatMessagesPercentage;
+   filter drop_heartbeat_messages_filter_;
    uint8_t dropAckNackMessagesPercentage;
+   filter drop_ack_nack_messages_filter_;
+   uint8_t dropGapMessagesPercentage;
+   filter drop_gap_messages_filter_;
 
    // General drop percentage (indescriminate)
    uint8_t percentageOfMessagesToDrop;
+   filter messages_filter_;
+
    std::vector<fastrtps::rtps::SequenceNumber_t> sequenceNumberDataMessagesToDrop;
 
    uint32_t dropLogLength; // logs dropped packets.

--- a/include/fastdds/rtps/writer/StatefulWriter.h
+++ b/include/fastdds/rtps/writer/StatefulWriter.h
@@ -343,6 +343,9 @@ private:
             SequenceNumber_t max_sequence,
             bool& activateHeartbeatPeriod);
 
+    bool send_hole_gaps_to_group(
+            RTPSMessageGroup& group);
+
     //! True to disable piggyback heartbeats
     bool disable_heartbeat_piggyback_;
     //! True to disable positive ACKs

--- a/src/cpp/rtps/writer/StatefulWriter.cpp
+++ b/src/cpp/rtps/writer/StatefulWriter.cpp
@@ -307,6 +307,7 @@ void StatefulWriter::unsent_change_added_to_history(
                     {
                         if (it->is_local_reader())
                         {
+                            intraprocess_heartbeat(it, false);
                             bool delivered = intraprocess_delivery(change, it);
                             it->set_change_to_status(
                                 change->sequenceNumber,
@@ -321,6 +322,7 @@ void StatefulWriter::unsent_change_added_to_history(
                     {
                         if (it->is_local_reader())
                         {
+                            intraprocess_heartbeat(it, false);
                             bool delivered = intraprocess_delivery(change, it);
                             it->set_change_to_status(
                                 change->sequenceNumber,

--- a/src/cpp/rtps/writer/StatefulWriter.cpp
+++ b/src/cpp/rtps/writer/StatefulWriter.cpp
@@ -478,7 +478,10 @@ bool StatefulWriter::intraprocess_heartbeat(
                         this->getAttributes().durabilityKind < TRANSIENT_LOCAL)
                 {
                     SequenceNumber_t last_irrelevance = reader_proxy->changes_low_mark();
-                    reader->processGapMsg(m_guid, first_seq, SequenceNumberSet_t(last_irrelevance + 1));
+                    if (first_seq <= last_irrelevance)
+                    {
+                        reader->processGapMsg(m_guid, first_seq, SequenceNumberSet_t(last_irrelevance + 1));
+                    }
                 }
             }
         }

--- a/src/cpp/rtps/writer/StatefulWriter.cpp
+++ b/src/cpp/rtps/writer/StatefulWriter.cpp
@@ -478,10 +478,7 @@ bool StatefulWriter::intraprocess_heartbeat(
                         this->getAttributes().durabilityKind < TRANSIENT_LOCAL)
                 {
                     SequenceNumber_t last_irrelevance = reader_proxy->changes_low_mark();
-                    for (SequenceNumber_t seq_num = first_seq; seq_num <= last_irrelevance; ++seq_num)
-                    {
-                        intraprocess_gap(reader_proxy, seq_num);
-                    }
+                    reader->processGapMsg(m_guid, first_seq, SequenceNumberSet_t(last_irrelevance + 1));
                 }
             }
         }

--- a/src/cpp/rtps/writer/StatefulWriter.cpp
+++ b/src/cpp/rtps/writer/StatefulWriter.cpp
@@ -792,21 +792,8 @@ void StatefulWriter::send_all_unsent_changes(
         bool heartbeat_has_been_sent = false;
 
         RTPSMessageGroup group(mp_RTPSParticipant, this, *this);
-        RTPSGapBuilder gap_builder(group);
 
-        SequenceNumber_t max_removed = biggest_removed_sequence_number_;
-        SequenceNumber_t last_sequence = mp_history->next_sequence_number();
-        SequenceNumber_t min_history_seq = get_seq_num_min();
-        uint32_t history_size = static_cast<uint32_t>(mp_history->getHistorySize());
-
-        if ((next_all_acked_notify_sequence_ < max_removed) &&    // some holes pending acknowledgement
-            (min_history_seq + history_size != last_sequence))    // There is a hole in the history
-        {
-            send_heartbeat_nts_(all_remote_readers_.size(), group, !acknack_required);
-            heartbeat_has_been_sent = true;
-        }
-            
-        SequenceNumber_t seq = get_seq_num_min();
+        heartbeat_has_been_sent = send_hole_gaps_to_group(group);
 
         uint32_t lastBytesProcessed = 0;
         auto sent_fun = [this, &lastBytesProcessed, &group](
@@ -816,27 +803,27 @@ void StatefulWriter::send_all_unsent_changes(
             send_heartbeat_piggyback_nts_(nullptr, group, lastBytesProcessed);
         };
 
-        // Add holes in history and send them to all readers
+        RTPSGapBuilder gap_builder(group);
+
         for (auto cit = mp_history->changesBegin(); cit != mp_history->changesEnd(); cit++)
         {
-            // Add all sequence numbers until the change's sequence number
-            while (seq < (*cit)->sequenceNumber)
-            {
-                gap_builder.add(seq);
-                seq++;
-            }
+            SequenceNumber_t seq = (*cit)->sequenceNumber;
 
-            // Check if change is relevant for at least one reader
-            bool is_irrelevant = true;
+            // Deselect all entries on the locator selector (we will only activate the
+            // readers for which this sequence number is pending)
+            locator_selector_.reset(false);
+            
+            bool is_irrelevant = true;   // Will turn to false if change is relevant for at least one reader
             bool should_be_sent = false;
             bool inline_qos = false;
             for (ReaderProxy* remoteReader : matched_readers_)
             {
                 if (!remoteReader->is_local_reader())
                 {
-                    should_be_sent |= remoteReader->change_is_unsent(seq, is_irrelevant);
-                    if (should_be_sent)
+                    if(remoteReader->change_is_unsent(seq, is_irrelevant))
                     {
+                        should_be_sent = true;
+                        locator_selector_.enable(remoteReader->guid());
                         inline_qos |= remoteReader->expects_inline_qos();
                         if (is_irrelevant)
                         {
@@ -844,6 +831,13 @@ void StatefulWriter::send_all_unsent_changes(
                         }
                     }
                 }
+            }
+
+            if (locator_selector_.state_has_changed())
+            {
+                group.flush_and_reset();
+                network.select_locators(locator_selector_);
+                compute_selected_guids();
             }
 
             if (should_be_sent)
@@ -877,13 +871,6 @@ void StatefulWriter::send_all_unsent_changes(
             }
 
             // Skip change's sequence number
-            seq++;
-        }
-
-        // Add all sequence numbers above last change
-        while (seq < last_sequence)
-        {
-            gap_builder.add(seq);
             seq++;
         }
 
@@ -930,51 +917,7 @@ void StatefulWriter::send_unsent_changes_with_flow_control(
 
     RTPSMessageGroup group(mp_RTPSParticipant, this, *this);
 
-    // Add holes in history and send them to all readers
-    SequenceNumber_t max_removed = biggest_removed_sequence_number_;
-    SequenceNumber_t last_sequence = mp_history->next_sequence_number();
-    SequenceNumber_t min_history_seq = get_seq_num_min();
-    uint32_t history_size = static_cast<uint32_t>(mp_history->getHistorySize());
-    if ((next_all_acked_notify_sequence_ < max_removed) &&    // some holes pending acknowledgement
-        (min_history_seq + history_size != last_sequence))    // There is a hole in the history
-    {
-        try
-        {
-            send_heartbeat_nts_(all_remote_readers_.size(), group, true);
-            heartbeat_has_been_sent = true;
-
-            // Find holes in history from next_all_acked_notify_sequence_ to last_sequence - 1
-            RTPSGapBuilder gap_builder(group);
-
-            // Algorithm starts in next_all_acked_notify_sequence_
-            SequenceNumber_t seq = min_history_seq;
-
-            // Loop all history
-            for (auto cit = mp_history->changesBegin(); cit != mp_history->changesEnd(); cit++)
-            {
-                // Add all sequence numbers until the change's sequence number
-                while (seq < (*cit)->sequenceNumber)
-                {
-                    gap_builder.add(seq);
-                    seq++;
-                }
-
-                // Skip change's sequence number
-                seq++;
-            }
-
-            // Add all sequence numbers above last change
-            while (seq < last_sequence)
-            {
-                gap_builder.add(seq);
-                seq++;
-            }
-        }
-        catch (const RTPSMessageGroup::timeout&)
-        {
-            logError(RTPS_WRITER, "Max blocking time reached");
-        }
-    }
+    heartbeat_has_been_sent = send_hole_gaps_to_group(group);
 
     for (ReaderProxy* remoteReader : matched_readers_)
     {
@@ -1133,6 +1076,60 @@ void StatefulWriter::send_unsent_changes_with_flow_control(
     locator_selector_.reset(true);
     network.select_locators(locator_selector_);
     compute_selected_guids();
+}
+
+bool StatefulWriter::send_hole_gaps_to_group(
+        RTPSMessageGroup& group)
+{
+    bool ret_val = false;
+
+    // Add holes in history and send them to all readers in group
+    SequenceNumber_t max_removed = biggest_removed_sequence_number_;
+    SequenceNumber_t last_sequence = mp_history->next_sequence_number();
+    SequenceNumber_t min_history_seq = get_seq_num_min();
+    uint32_t history_size = static_cast<uint32_t>(mp_history->getHistorySize());
+    if ((next_all_acked_notify_sequence_ < max_removed) &&    // some holes pending acknowledgement
+        (min_history_seq + history_size != last_sequence))    // There is a hole in the history
+    {
+        try
+        {
+            send_heartbeat_nts_(all_remote_readers_.size(), group, true);
+            ret_val = true;
+
+            // Find holes in history from min_history_seq to last_sequence - 1
+            RTPSGapBuilder gap_builder(group);
+
+            // Algorithm starts in min_history_seq
+            SequenceNumber_t seq = min_history_seq;
+
+            // Loop all history
+            for (auto cit = mp_history->changesBegin(); cit != mp_history->changesEnd(); cit++)
+            {
+                // Add all sequence numbers until the change's sequence number
+                while (seq < (*cit)->sequenceNumber)
+                {
+                    gap_builder.add(seq);
+                    seq++;
+                }
+
+                // Skip change's sequence number
+                seq++;
+            }
+
+            // Add all sequence numbers above last change
+            while (seq < last_sequence)
+            {
+                gap_builder.add(seq);
+                seq++;
+            }
+        }
+        catch (const RTPSMessageGroup::timeout&)
+        {
+            logError(RTPS_WRITER, "Max blocking time reached");
+        }
+    }
+
+    return ret_val;
 }
 
 /*

--- a/src/cpp/rtps/writer/StatefulWriter.cpp
+++ b/src/cpp/rtps/writer/StatefulWriter.cpp
@@ -728,6 +728,7 @@ void StatefulWriter::send_all_intraprocess_changes(
     {
         if (remoteReader->is_local_reader())
         {
+            intraprocess_heartbeat(remoteReader, false);
             SequenceNumber_t max_ack_seq = SequenceNumber_t::unknown();
             auto unsent_change_process = [&](const SequenceNumber_t& seq_num, const ChangeForReader_t* unsentChange)
             {

--- a/test/blackbox/BlackboxTestsVolatile.cpp
+++ b/test/blackbox/BlackboxTestsVolatile.cpp
@@ -276,6 +276,47 @@ TEST_P(Volatile, AsyncVolatileSubBetweenPubs)
     reader.block_for_all();
 }
 
+TEST_P(Volatile, VolatileSubBetweenPubs)
+{
+    PubSubReader<HelloWorldType> reader(TEST_TOPIC_NAME);
+    PubSubWriter<HelloWorldType> writer(TEST_TOPIC_NAME);
+
+    writer.history_kind(eprosima::fastrtps::KEEP_ALL_HISTORY_QOS).
+        reliability(eprosima::fastrtps::RELIABLE_RELIABILITY_QOS).
+        durability_kind(eprosima::fastrtps::VOLATILE_DURABILITY_QOS).
+        resource_limits_allocated_samples(9).
+        resource_limits_max_samples(9).
+        heartbeat_period_seconds(3600).
+        init();
+
+    ASSERT_TRUE(writer.isInitialized());
+
+    HelloWorld hello;
+    hello.index(1);
+    hello.message("HelloWorld 1");
+
+    writer.send_sample(hello);
+
+    reader.history_kind(eprosima::fastrtps::KEEP_ALL_HISTORY_QOS).
+        reliability(eprosima::fastrtps::RELIABLE_RELIABILITY_QOS).
+        durability_kind(eprosima::fastrtps::VOLATILE_DURABILITY_QOS).
+        init();
+
+    ASSERT_TRUE(reader.isInitialized());
+
+    writer.wait_discovery();
+    reader.wait_discovery();
+
+    auto data = default_helloworld_data_generator(1);
+    reader.startReception(data);
+    // Send data with some interval, to let async writer thread send samples
+    writer.send(data, 300);
+    // In this test all data should be sent.
+    ASSERT_TRUE(data.empty());
+    // Block reader until reception finished or timeout.
+    reader.block_for_all();
+}
+
 TEST_P(Volatile, AsyncVolatileSubBetweenTransientPubs)
 {
     PubSubReader<HelloWorldType> reader(TEST_TOPIC_NAME);

--- a/test/blackbox/BlackboxTestsVolatile.cpp
+++ b/test/blackbox/BlackboxTestsVolatile.cpp
@@ -286,6 +286,7 @@ TEST_P(Volatile, VolatileSubBetweenPubs)
         durability_kind(eprosima::fastrtps::VOLATILE_DURABILITY_QOS).
         resource_limits_allocated_samples(9).
         resource_limits_max_samples(9).
+        asynchronously(eprosima::fastrtps::SYNCHRONOUS_PUBLISH_MODE).
         heartbeat_period_seconds(3600).
         init();
 
@@ -309,8 +310,8 @@ TEST_P(Volatile, VolatileSubBetweenPubs)
 
     auto data = default_helloworld_data_generator(1);
     reader.startReception(data);
-    // Send data with some interval, to let async writer thread send samples
-    writer.send(data, 300);
+    // Send all data
+    writer.send(data);
     // In this test all data should be sent.
     ASSERT_TRUE(data.empty());
     // Block reader until reception finished or timeout.
@@ -371,6 +372,7 @@ TEST_P(Volatile, VolatileSubBetweenTransientPubs)
         .durability_kind(eprosima::fastrtps::TRANSIENT_LOCAL_DURABILITY_QOS)
         .resource_limits_allocated_samples(9)
         .resource_limits_max_samples(9)
+        .asynchronously(eprosima::fastrtps::SYNCHRONOUS_PUBLISH_MODE)
         .heartbeat_period_seconds(3600)
         .init();
 
@@ -394,8 +396,8 @@ TEST_P(Volatile, VolatileSubBetweenTransientPubs)
 
     auto data = default_helloworld_data_generator(1);
     reader.startReception(data);
-    // Send data with some interval, to let async writer thread send samples
-    writer.send(data, 300);
+    // Send all data
+    writer.send(data);
     // In this test all data should be sent.
     ASSERT_TRUE(data.empty());
     // Block reader until reception finished or timeout.

--- a/test/blackbox/BlackboxTestsVolatile.cpp
+++ b/test/blackbox/BlackboxTestsVolatile.cpp
@@ -21,6 +21,8 @@
 
 #include <gtest/gtest.h>
 #include <fastrtps/xmlparser/XMLProfileManager.h>
+#include <fastrtps/transport/test_UDPv4Transport.h>
+#include <fastdds/rtps/common/CDRMessage_t.h>
 
 using namespace eprosima::fastrtps;
 
@@ -315,6 +317,79 @@ TEST_P(Volatile, AsyncVolatileSubBetweenTransientPubs)
     ASSERT_TRUE(data.empty());
     // Block reader until reception finished or timeout.
     reader.block_for_all();
+}
+
+TEST_P(Volatile, VolatileLateJoinerSubGapLost)
+{
+    PubSubReader<HelloWorldType> reader1(TEST_TOPIC_NAME);
+    PubSubReader<HelloWorldType> reader2(TEST_TOPIC_NAME);
+    PubSubWriter<HelloWorldType> writer(TEST_TOPIC_NAME);
+
+
+    reader1.history_kind(eprosima::fastrtps::KEEP_ALL_HISTORY_QOS).
+    reliability(eprosima::fastrtps::RELIABLE_RELIABILITY_QOS).
+    durability_kind(eprosima::fastrtps::VOLATILE_DURABILITY_QOS).
+    //heartbeatResponseDelay(5,0).
+    init();
+
+    ASSERT_TRUE(reader1.isInitialized());
+
+    // To simulate lossy conditions
+    int gaps_to_drop = 2;
+    auto testTransport = std::make_shared<rtps::test_UDPv4TransportDescriptor>();
+    testTransport->drop_gap_messages_filter_ = [&gaps_to_drop](rtps::CDRMessage_t& )
+            {
+                if (gaps_to_drop > 0)
+                {
+                    --gaps_to_drop;
+                    return true;
+                }
+                return false;
+            };
+    testTransport->dropLogLength = 1;
+
+    writer.history_kind(eprosima::fastrtps::KEEP_ALL_HISTORY_QOS).
+    reliability(eprosima::fastrtps::RELIABLE_RELIABILITY_QOS).
+    durability_kind(eprosima::fastrtps::VOLATILE_DURABILITY_QOS).
+    resource_limits_allocated_samples(9).
+    resource_limits_max_samples(9).
+    disable_builtin_transport().
+    add_user_transport_to_pparams(testTransport).
+    asynchronously(eprosima::fastrtps::SYNCHRONOUS_PUBLISH_MODE).
+    init();
+
+    ASSERT_TRUE(writer.isInitialized());
+
+
+    writer.wait_discovery();
+    reader1.wait_discovery();
+
+    auto data = default_helloworld_data_generator(5);
+
+    reader1.startReception(data);
+
+    writer.send_sample(data.front());
+
+    reader2.history_kind(eprosima::fastrtps::KEEP_ALL_HISTORY_QOS).
+    reliability(eprosima::fastrtps::RELIABLE_RELIABILITY_QOS).
+    durability_kind(eprosima::fastrtps::VOLATILE_DURABILITY_QOS).
+    init();
+
+    ASSERT_TRUE(reader2.isInitialized());
+
+    reader2.wait_discovery();
+
+    data.pop_front();
+
+    reader2.startReception(data);
+
+    // Send data with some interval, to let async writer thread send samples
+    writer.send(data, 300);
+    // In this test all data should be sent.
+    ASSERT_TRUE(data.empty());
+    // Block reader until reception finished or timeout.
+    reader1.block_for_all();
+    reader2.block_for_all();
 }
 
 INSTANTIATE_TEST_CASE_P(Volatile,

--- a/test/blackbox/BlackboxTestsVolatile.cpp
+++ b/test/blackbox/BlackboxTestsVolatile.cpp
@@ -274,6 +274,49 @@ TEST_P(Volatile, AsyncVolatileSubBetweenPubs)
     reader.block_for_all();
 }
 
+TEST_P(Volatile, AsyncVolatileSubBetweenTransientPubs)
+{
+    PubSubReader<HelloWorldType> reader(TEST_TOPIC_NAME);
+    PubSubWriter<HelloWorldType> writer(TEST_TOPIC_NAME);
+
+    writer
+        .history_kind(eprosima::fastrtps::KEEP_ALL_HISTORY_QOS)
+        .reliability(eprosima::fastrtps::RELIABLE_RELIABILITY_QOS)
+        .durability_kind(eprosima::fastrtps::TRANSIENT_LOCAL_DURABILITY_QOS)
+        .resource_limits_allocated_samples(9)
+        .resource_limits_max_samples(9)
+        .asynchronously(eprosima::fastrtps::ASYNCHRONOUS_PUBLISH_MODE)
+        .heartbeat_period_seconds(3600)
+        .init();
+
+    ASSERT_TRUE(writer.isInitialized());
+
+    HelloWorld hello;
+    hello.index(1);
+    hello.message("HelloWorld 1");
+
+    writer.send_sample(hello);
+
+    reader.history_kind(eprosima::fastrtps::KEEP_ALL_HISTORY_QOS).
+        reliability(eprosima::fastrtps::RELIABLE_RELIABILITY_QOS).
+        durability_kind(eprosima::fastrtps::VOLATILE_DURABILITY_QOS).
+        init();
+
+    ASSERT_TRUE(reader.isInitialized());
+
+    writer.wait_discovery();
+    reader.wait_discovery();
+
+    auto data = default_helloworld_data_generator(1);
+    reader.startReception(data);
+    // Send data with some interval, to let async writer thread send samples
+    writer.send(data, 300);
+    // In this test all data should be sent.
+    ASSERT_TRUE(data.empty());
+    // Block reader until reception finished or timeout.
+    reader.block_for_all();
+}
+
 INSTANTIATE_TEST_CASE_P(Volatile,
         Volatile,
         testing::Values(false, true),

--- a/test/blackbox/BlackboxTestsVolatile.cpp
+++ b/test/blackbox/BlackboxTestsVolatile.cpp
@@ -378,6 +378,7 @@ TEST_P(Volatile, VolatileLateJoinerSubGapLost)
     ASSERT_TRUE(reader2.isInitialized());
 
     reader2.wait_discovery();
+    writer.wait_discovery(2);
 
     data.pop_front();
 

--- a/test/blackbox/api/dds-pim/PubSubWriter.hpp
+++ b/test/blackbox/api/dds-pim/PubSubWriter.hpp
@@ -408,6 +408,30 @@ public:
         std::cout << "Writer discovery finished..." << std::endl;
     }
 
+    void wait_discovery(
+            unsigned int expected_match,
+            std::chrono::seconds timeout = std::chrono::seconds::zero())
+    {
+        std::unique_lock<std::mutex> lock(mutexDiscovery_);
+
+        std::cout << "Writer is waiting discovery..." << std::endl;
+
+        if (timeout == std::chrono::seconds::zero())
+        {
+            cv_.wait(lock, [&](){
+                return matched_ == expected_match;
+            });
+        }
+        else
+        {
+            cv_.wait_for(lock, timeout, [&](){
+                return matched_ == expected_match;
+            });
+        }
+
+        std::cout << "Writer discovery finished..." << std::endl;
+    }
+
     bool wait_participant_undiscovery(
             std::chrono::seconds timeout = std::chrono::seconds::zero())
     {

--- a/test/blackbox/api/fastrtps_deprecated/PubSubWriter.hpp
+++ b/test/blackbox/api/fastrtps_deprecated/PubSubWriter.hpp
@@ -385,6 +385,30 @@ public:
         std::cout << "Writer discovery finished..." << std::endl;
     }
 
+    void wait_discovery(
+            unsigned int expected_match,
+            std::chrono::seconds timeout = std::chrono::seconds::zero())
+    {
+        std::unique_lock<std::mutex> lock(mutexDiscovery_);
+
+        std::cout << "Writer is waiting discovery..." << std::endl;
+
+        if (timeout == std::chrono::seconds::zero())
+        {
+            cv_.wait(lock, [&](){
+                return matched_ == expected_match;
+            });
+        }
+        else
+        {
+            cv_.wait_for(lock, timeout, [&](){
+                return matched_ == expected_match;
+            });
+        }
+
+        std::cout << "Writer discovery finished..." << std::endl;
+    }
+
     bool wait_participant_undiscovery(
             std::chrono::seconds timeout = std::chrono::seconds::zero())
     {


### PR DESCRIPTION
This PR:
* Adds generic filtering mechanisms to the test_udpv4 transport
* Improves sending gaps for holes in history
* Fixes locator selection when re-sending samples to specific readers
* Fixes late-joining reliable volatile readers never notifying samples on some cases