### PR TITLE
Fix error on BitmapRange::remove [8354]

### DIFF
--- a/include/fastrtps/utils/fixed_size_bitmap.hpp
+++ b/include/fastrtps/utils/fixed_size_bitmap.hpp
@@ -297,7 +297,7 @@ public:
 
             if (item == max_value)
             {
-                calc_maximum_bit_set(pos, 0);
+                calc_maximum_bit_set(pos + 1, 0);
             }
         }
     }

--- a/src/cpp/rtps/transport/shared_mem/SharedMemChannelResource.hpp
+++ b/src/cpp/rtps/transport/shared_mem/SharedMemChannelResource.hpp
@@ -36,7 +36,8 @@ public:
             std::shared_ptr<SharedMemManager::Listener> listener,
             const fastrtps::rtps::Locator_t& locator,
             TransportReceiverInterface* receiver,
-            const std::string& dump_file)
+            const std::string& dump_file,
+            bool should_init_thread = true)
         : ChannelResource()
         , message_receiver_(receiver)
         , listener_(listener)
@@ -52,7 +53,10 @@ public:
             packet_logger_->RegisterConsumer(std::move(packets_file_consumer));
         }
 
-        thread(std::thread(&SharedMemChannelResource::perform_listen_operation, this, locator));
+        if (should_init_thread)
+        {
+            init_thread(locator);
+        }
     }
 
     virtual ~SharedMemChannelResource() override
@@ -150,6 +154,13 @@ private:
     }
 
 protected:
+
+    void init_thread(
+            const fastrtps::rtps::Locator_t& locator)
+    {
+        this->thread(std::thread(&SharedMemChannelResource::perform_listen_operation, this, locator));
+    }
+
 
     /**
      * Blocking Receive from the specified channel.

--- a/src/cpp/rtps/transport/shared_mem/test_SharedMemChannelResource.hpp
+++ b/src/cpp/rtps/transport/shared_mem/test_SharedMemChannelResource.hpp
@@ -33,13 +33,18 @@ public:
             TransportReceiverInterface* receiver,
             uint32_t big_buffer_size,
             uint32_t* big_buffer_size_count)
-        : SharedMemChannelResource(listener, locator, receiver, std::string())
+        : SharedMemChannelResource(listener, locator, receiver, std::string(), false)
         , big_buffer_size_(big_buffer_size)
         , big_buffer_size_count_(big_buffer_size_count)
     {
+        init_thread(locator);
     }
 
-private:
+    virtual ~test_SharedMemChannelResource() override
+    {
+    }
+
+protected:
 
     uint32_t big_buffer_size_;
     uint32_t* big_buffer_size_count_;


### PR DESCRIPTION
This PR adds a unit test for `BitmapRange::remove` and fixes an error found while investigating timing issues on big data.

This method is only used when sending fragments on a reliable writer, and should only provoke errors on some corner cases related to certain fragments requiring retransmission.