### PR TITLE
Fixing wrong check should be intraprocess [8356]

### DIFF
--- a/include/fastdds/rtps/writer/ReaderLocator.h
+++ b/include/fastdds/rtps/writer/ReaderLocator.h
@@ -32,6 +32,7 @@ namespace fastrtps {
 namespace rtps {
 
 class RTPSParticipantImpl;
+class RTPSWriter;
 class RTPSReader;
 
 /**
@@ -53,7 +54,8 @@ public:
      * @param max_multicast_locators  Maximum number of multicast locators to hold.
      */
     ReaderLocator(
-            RTPSParticipantImpl* owner,
+            RTPSParticipantImpl* participant_owner,
+            RTPSWriter* owner,
             size_t max_unicast_locators,
             size_t max_multicast_locators);
 
@@ -179,7 +181,8 @@ public:
 
 private:
 
-    RTPSParticipantImpl* owner_;
+    RTPSParticipantImpl* participant_owner_;
+    RTPSWriter* owner_;
     LocatorSelectorEntry locator_info_;
     bool expects_inline_qos_;
     bool is_local_reader_;

--- a/include/fastdds/rtps/writer/ReaderLocator.h
+++ b/include/fastdds/rtps/writer/ReaderLocator.h
@@ -14,7 +14,7 @@
 
 /**
  * @file ReaderLocator.h
-*/
+ */
 #ifndef _FASTDDS_RTPS_READERLOCATOR_H_
 #define _FASTDDS_RTPS_READERLOCATOR_H_
 
@@ -41,149 +41,151 @@ class RTPSReader;
  */
 class ReaderLocator : public RTPSMessageSenderInterface
 {
-    public:
+public:
 
-        virtual ~ReaderLocator() = default;
+    virtual ~ReaderLocator() = default;
 
-        /**
-         * Construct a ReaderLocator.
-         *
-         * @param owner                   Pointer to the RTPSParticipantImpl creating this object.
-         * @param max_unicast_locators    Maximum number of unicast locators to hold.
-         * @param max_multicast_locators  Maximum number of multicast locators to hold.
-         */
-        ReaderLocator(
-                RTPSParticipantImpl* owner,
-                size_t max_unicast_locators,
-                size_t max_multicast_locators);
+    /**
+     * Construct a ReaderLocator.
+     *
+     * @param owner                   Pointer to the RTPSParticipantImpl creating this object.
+     * @param max_unicast_locators    Maximum number of unicast locators to hold.
+     * @param max_multicast_locators  Maximum number of multicast locators to hold.
+     */
+    ReaderLocator(
+            RTPSParticipantImpl* owner,
+            size_t max_unicast_locators,
+            size_t max_multicast_locators);
 
-        bool expects_inline_qos() const
-        {
-            return expects_inline_qos_;
-        }
+    bool expects_inline_qos() const
+    {
+        return expects_inline_qos_;
+    }
 
-        bool is_local_reader() const
-        {
-            return is_local_reader_;
-        }
+    bool is_local_reader() const
+    {
+        return is_local_reader_;
+    }
 
-        RTPSReader* local_reader();
+    RTPSReader* local_reader();
 
-        void local_reader(RTPSReader* local_reader)
-        {
-            local_reader_ = local_reader;
-        }
+    void local_reader(
+            RTPSReader* local_reader)
+    {
+        local_reader_ = local_reader;
+    }
 
-        const GUID_t& remote_guid() const
-        {
-            return locator_info_.remote_guid;
-        }
+    const GUID_t& remote_guid() const
+    {
+        return locator_info_.remote_guid;
+    }
 
-        LocatorSelectorEntry* locator_selector_entry()
-        {
-            return &locator_info_;
-        }
+    LocatorSelectorEntry* locator_selector_entry()
+    {
+        return &locator_info_;
+    }
 
-        /**
-         * Try to start using this object for a new matched reader.
-         *
-         * @param remote_guid         GUID of the remote reader.
-         * @param unicast_locators    Unicast locators of the remote reader.
-         * @param multicast_locators  Multicast locators of the remote reader.
-         * @param expects_inline_qos  Whether remote reader expects to receive inline QoS.
-         *
-         * @return false when this object was already started, true otherwise.
-         */
-        bool start(
-                const GUID_t& remote_guid,
-                const ResourceLimitedVector<Locator_t>& unicast_locators,
-                const ResourceLimitedVector<Locator_t>& multicast_locators,
-                bool expects_inline_qos);
+    /**
+     * Try to start using this object for a new matched reader.
+     *
+     * @param remote_guid         GUID of the remote reader.
+     * @param unicast_locators    Unicast locators of the remote reader.
+     * @param multicast_locators  Multicast locators of the remote reader.
+     * @param expects_inline_qos  Whether remote reader expects to receive inline QoS.
+     *
+     * @return false when this object was already started, true otherwise.
+     */
+    bool start(
+            const GUID_t& remote_guid,
+            const ResourceLimitedVector<Locator_t>& unicast_locators,
+            const ResourceLimitedVector<Locator_t>& multicast_locators,
+            bool expects_inline_qos);
 
-        /**
-         * Try to update information of this object.
-         *
-         * @param unicast_locators    Unicast locators of the remote reader.
-         * @param multicast_locators  Multicast locators of the remote reader.
-         * @param expects_inline_qos  Whether remote reader expects to receive inline QoS.
-         *
-         * @return true when information has changed, false otherwise.
-         */
-        bool update(
-                const ResourceLimitedVector<Locator_t>& unicast_locators,
-                const ResourceLimitedVector<Locator_t>& multicast_locators,
-                bool expects_inline_qos);
+    /**
+     * Try to update information of this object.
+     *
+     * @param unicast_locators    Unicast locators of the remote reader.
+     * @param multicast_locators  Multicast locators of the remote reader.
+     * @param expects_inline_qos  Whether remote reader expects to receive inline QoS.
+     *
+     * @return true when information has changed, false otherwise.
+     */
+    bool update(
+            const ResourceLimitedVector<Locator_t>& unicast_locators,
+            const ResourceLimitedVector<Locator_t>& multicast_locators,
+            bool expects_inline_qos);
 
-        /**
-         * Try to stop using this object for an unmatched reader.
-         *
-         * @param remote_guid  GUID of the remote reader.
-         *
-         * @return true if this object was started for remote_guid, false otherwise.
-         */
-        bool stop(const GUID_t& remote_guid);
+    /**
+     * Try to stop using this object for an unmatched reader.
+     *
+     * @param remote_guid  GUID of the remote reader.
+     *
+     * @return true if this object was started for remote_guid, false otherwise.
+     */
+    bool stop(
+            const GUID_t& remote_guid);
 
-        /**
-         * Check if the destinations managed by this sender interface have changed.
-         *
-         * @return true if destinations have changed, false otherwise.
-         */
-        bool destinations_have_changed() const override
-        {
-            return false;
-        }
+    /**
+     * Check if the destinations managed by this sender interface have changed.
+     *
+     * @return true if destinations have changed, false otherwise.
+     */
+    bool destinations_have_changed() const override
+    {
+        return false;
+    }
 
-        /**
-         * Get a GUID prefix representing all destinations.
-         *
-         * @return When all the destinations share the same prefix (i.e. belong to the same participant)
-         * that prefix is returned. When there are no destinations, or they belong to different
-         * participants, c_GuidPrefix_Unknown is returned.
-         */
-        GuidPrefix_t destination_guid_prefix() const override
-        {
-            return locator_info_.remote_guid.guidPrefix;
-        }
+    /**
+     * Get a GUID prefix representing all destinations.
+     *
+     * @return When all the destinations share the same prefix (i.e. belong to the same participant)
+     * that prefix is returned. When there are no destinations, or they belong to different
+     * participants, c_GuidPrefix_Unknown is returned.
+     */
+    GuidPrefix_t destination_guid_prefix() const override
+    {
+        return locator_info_.remote_guid.guidPrefix;
+    }
 
-        /**
-         * Get the GUID prefix of all the destination participants.
-         *
-         * @return a const reference to a vector with the GUID prefix of all destination participants.
-         */
-        const std::vector<GuidPrefix_t>& remote_participants() const override
-        {
-            return guid_prefix_as_vector_;
-        }
+    /**
+     * Get the GUID prefix of all the destination participants.
+     *
+     * @return a const reference to a vector with the GUID prefix of all destination participants.
+     */
+    const std::vector<GuidPrefix_t>& remote_participants() const override
+    {
+        return guid_prefix_as_vector_;
+    }
 
-        /**
-         * Get the GUID of all destinations.
-         *
-         * @return a const reference to a vector with the GUID of all destinations.
-         */
-        const std::vector<GUID_t>& remote_guids() const override
-        {
-            return guid_as_vector_;
-        }
+    /**
+     * Get the GUID of all destinations.
+     *
+     * @return a const reference to a vector with the GUID of all destinations.
+     */
+    const std::vector<GUID_t>& remote_guids() const override
+    {
+        return guid_as_vector_;
+    }
 
-        /**
-         * Send a message through this interface.
-         *
-         * @param message Pointer to the buffer with the message already serialized.
-         * @param max_blocking_time_point Future timepoint where blocking send should end.
-         */
-        bool send(
-                CDRMessage_t* message,
-                std::chrono::steady_clock::time_point& max_blocking_time_point) const override;
+    /**
+     * Send a message through this interface.
+     *
+     * @param message Pointer to the buffer with the message already serialized.
+     * @param max_blocking_time_point Future timepoint where blocking send should end.
+     */
+    bool send(
+            CDRMessage_t* message,
+            std::chrono::steady_clock::time_point& max_blocking_time_point) const override;
 
-    private:
+private:
 
-        RTPSParticipantImpl* owner_;
-        LocatorSelectorEntry locator_info_;
-        bool expects_inline_qos_;
-        bool is_local_reader_;
-        RTPSReader* local_reader_;
-        std::vector<GuidPrefix_t> guid_prefix_as_vector_;
-        std::vector<GUID_t> guid_as_vector_;
+    RTPSParticipantImpl* owner_;
+    LocatorSelectorEntry locator_info_;
+    bool expects_inline_qos_;
+    bool is_local_reader_;
+    RTPSReader* local_reader_;
+    std::vector<GuidPrefix_t> guid_prefix_as_vector_;
+    std::vector<GUID_t> guid_as_vector_;
 };
 
 } /* namespace rtps */

--- a/include/fastdds/rtps/writer/ReaderLocator.h
+++ b/include/fastdds/rtps/writer/ReaderLocator.h
@@ -49,12 +49,11 @@ public:
     /**
      * Construct a ReaderLocator.
      *
-     * @param owner                   Pointer to the RTPSParticipantImpl creating this object.
+     * @param owner                   Pointer to the RTPSWriter creating this object.
      * @param max_unicast_locators    Maximum number of unicast locators to hold.
      * @param max_multicast_locators  Maximum number of multicast locators to hold.
      */
     ReaderLocator(
-            RTPSParticipantImpl* participant_owner,
             RTPSWriter* owner,
             size_t max_unicast_locators,
             size_t max_multicast_locators);
@@ -181,8 +180,8 @@ public:
 
 private:
 
-    RTPSParticipantImpl* participant_owner_;
     RTPSWriter* owner_;
+    RTPSParticipantImpl* participant_owner_;
     LocatorSelectorEntry locator_info_;
     bool expects_inline_qos_;
     bool is_local_reader_;

--- a/src/cpp/rtps/writer/ReaderLocator.cpp
+++ b/src/cpp/rtps/writer/ReaderLocator.cpp
@@ -31,12 +31,11 @@ namespace fastrtps {
 namespace rtps {
 
 ReaderLocator::ReaderLocator(
-        RTPSParticipantImpl* participant_owner,
         RTPSWriter* owner,
         size_t max_unicast_locators,
         size_t max_multicast_locators)
-    : participant_owner_(participant_owner)
-    , owner_(owner)
+    : owner_(owner)
+    , participant_owner_(owner->getRTPSParticipant())
     , locator_info_(max_unicast_locators, max_multicast_locators)
     , expects_inline_qos_(false)
     , is_local_reader_(false)

--- a/src/cpp/rtps/writer/ReaderLocator.cpp
+++ b/src/cpp/rtps/writer/ReaderLocator.cpp
@@ -132,11 +132,13 @@ bool ReaderLocator::send(
     {
         if (locator_info_.unicast.size() > 0)
         {
-            return owner_->sendSync(message, Locators(locator_info_.unicast.begin()), Locators(locator_info_.unicast.end()), max_blocking_time_point);
+            return owner_->sendSync(message, Locators(locator_info_.unicast.begin()),
+                           Locators(locator_info_.unicast.end()), max_blocking_time_point);
         }
         else
         {
-            return owner_->sendSync(message, Locators(locator_info_.multicast.begin()), Locators(locator_info_.multicast.end()), max_blocking_time_point);
+            return owner_->sendSync(message, Locators(locator_info_.multicast.begin()),
+                           Locators(locator_info_.multicast.end()), max_blocking_time_point);
         }
     }
 

--- a/src/cpp/rtps/writer/ReaderLocator.cpp
+++ b/src/cpp/rtps/writer/ReaderLocator.cpp
@@ -31,10 +31,12 @@ namespace fastrtps {
 namespace rtps {
 
 ReaderLocator::ReaderLocator(
-        RTPSParticipantImpl* owner,
+        RTPSParticipantImpl* participant_owner,
+        RTPSWriter* owner,
         size_t max_unicast_locators,
         size_t max_multicast_locators)
-    : owner_(owner)
+    : participant_owner_(participant_owner)
+    , owner_(owner)
     , locator_info_(max_unicast_locators, max_multicast_locators)
     , expects_inline_qos_(false)
     , is_local_reader_(false)
@@ -132,12 +134,12 @@ bool ReaderLocator::send(
     {
         if (locator_info_.unicast.size() > 0)
         {
-            return owner_->sendSync(message, Locators(locator_info_.unicast.begin()),
+            return participant_owner_->sendSync(message, Locators(locator_info_.unicast.begin()),
                            Locators(locator_info_.unicast.end()), max_blocking_time_point);
         }
         else
         {
-            return owner_->sendSync(message, Locators(locator_info_.multicast.begin()),
+            return participant_owner_->sendSync(message, Locators(locator_info_.multicast.begin()),
                            Locators(locator_info_.multicast.end()), max_blocking_time_point);
         }
     }

--- a/src/cpp/rtps/writer/ReaderProxy.cpp
+++ b/src/cpp/rtps/writer/ReaderProxy.cpp
@@ -56,15 +56,15 @@ ReaderProxy::ReaderProxy(
     , last_nackfrag_count_(0)
 {
     nack_supression_event_ = new TimedEvent(writer_->getRTPSParticipant()->getEventResource(),
-            [&]() -> bool
-            {
-                writer_->perform_nack_supression(guid());
-                return false;
-            },
-            TimeConv::Time_t2MilliSecondsDouble(times.nackSupressionDuration));
+                    [&]() -> bool
+                {
+                    writer_->perform_nack_supression(guid());
+                    return false;
+                },
+                    TimeConv::Time_t2MilliSecondsDouble(times.nackSupressionDuration));
 
     initial_heartbeat_event_ = new TimedEvent(writer_->getRTPSParticipant()->getEventResource(),
-            [&]() -> bool
+                    [&]() -> bool
                 {
                     writer_->intraprocess_heartbeat(this);
                     return false;
@@ -106,7 +106,7 @@ void ReaderProxy::start(
     {
         SequenceNumber_t min_sequence = writer_->get_seq_num_min();
         changes_low_mark_ = (min_sequence == SequenceNumber_t::unknown()) ?
-            writer_->next_sequence_number() - 1 : min_sequence - 1;
+                writer_->next_sequence_number() - 1 : min_sequence - 1;
     }
     else
     {
@@ -259,7 +259,7 @@ bool ReaderProxy::change_is_unsent(
     }
 
     ChangeConstIterator chit = find_change(seq_num);
-     if (chit == changes_for_reader_.end())
+    if (chit == changes_for_reader_.end())
     {
         // There is a hole in changes_for_reader_
         // This means a change was removed.

--- a/src/cpp/rtps/writer/ReaderProxy.cpp
+++ b/src/cpp/rtps/writer/ReaderProxy.cpp
@@ -42,7 +42,9 @@ ReaderProxy::ReaderProxy(
         const RemoteLocatorsAllocationAttributes& loc_alloc,
         StatefulWriter* writer)
     : is_active_(false)
-    , locator_info_(writer->getRTPSParticipant(), loc_alloc.max_unicast_locators, loc_alloc.max_multicast_locators)
+    , locator_info_(
+        writer->getRTPSParticipant(), writer, loc_alloc.max_unicast_locators,
+        loc_alloc.max_multicast_locators)
     , durability_kind_(VOLATILE)
     , expects_inline_qos_(false)
     , is_reliable_(false)

--- a/src/cpp/rtps/writer/ReaderProxy.cpp
+++ b/src/cpp/rtps/writer/ReaderProxy.cpp
@@ -43,7 +43,7 @@ ReaderProxy::ReaderProxy(
         StatefulWriter* writer)
     : is_active_(false)
     , locator_info_(
-        writer->getRTPSParticipant(), writer, loc_alloc.max_unicast_locators,
+        writer, loc_alloc.max_unicast_locators,
         loc_alloc.max_multicast_locators)
     , durability_kind_(VOLATILE)
     , expects_inline_qos_(false)

--- a/src/cpp/rtps/writer/StatelessWriter.cpp
+++ b/src/cpp/rtps/writer/StatelessWriter.cpp
@@ -104,7 +104,6 @@ StatelessWriter::StatelessWriter(
     for (size_t i = 0; i < attributes.matched_readers_allocation.initial; ++i)
     {
         matched_readers_.emplace_back(
-            mp_RTPSParticipant,
             this,
             loc_alloc.max_unicast_locators,
             loc_alloc.max_multicast_locators);
@@ -674,7 +673,6 @@ bool StatelessWriter::matched_reader_add(
         const RemoteLocatorsAllocationAttributes& loc_alloc =
                 mp_RTPSParticipant->getRTPSParticipantAttributes().allocation.locators;
         new_reader = matched_readers_.emplace_back(
-            mp_RTPSParticipant,
             this,
             loc_alloc.max_unicast_locators,
             loc_alloc.max_multicast_locators);

--- a/src/cpp/rtps/writer/StatelessWriter.cpp
+++ b/src/cpp/rtps/writer/StatelessWriter.cpp
@@ -105,6 +105,7 @@ StatelessWriter::StatelessWriter(
     {
         matched_readers_.emplace_back(
             mp_RTPSParticipant,
+            this,
             loc_alloc.max_unicast_locators,
             loc_alloc.max_multicast_locators);
     }
@@ -674,6 +675,7 @@ bool StatelessWriter::matched_reader_add(
                 mp_RTPSParticipant->getRTPSParticipantAttributes().allocation.locators;
         new_reader = matched_readers_.emplace_back(
             mp_RTPSParticipant,
+            this,
             loc_alloc.max_unicast_locators,
             loc_alloc.max_multicast_locators);
         if (new_reader != nullptr)

--- a/test/mock/rtps/ReaderLocator/fastdds/rtps/writer/ReaderLocator.h
+++ b/test/mock/rtps/ReaderLocator/fastdds/rtps/writer/ReaderLocator.h
@@ -14,7 +14,7 @@
 
 /**
  * @file ReaderLocator.h
-*/
+ */
 
 
 
@@ -35,6 +35,7 @@ namespace fastrtps {
 namespace rtps {
 
 class RTPSParticipantImpl;
+class RTPSWriter;
 class RTPSReader;
 
 /**
@@ -44,152 +45,154 @@ class RTPSReader;
  */
 class ReaderLocator : public RTPSMessageSenderInterface
 {
-    public:
+public:
 
-        virtual ~ReaderLocator() = default;
+    virtual ~ReaderLocator() = default;
 
-        /**
-         * Construct a ReaderLocator.
-         *
-         * @param owner                   Pointer to the RTPSParticipantImpl creating this object.
-         * @param max_unicast_locators    Maximum number of unicast locators to hold.
-         * @param max_multicast_locators  Maximum number of multicast locators to hold.
-         */
-        ReaderLocator(
-                RTPSParticipantImpl* /*owner*/,
-                size_t /*max_unicast_locators*/,
-                size_t /*max_multicast_locators*/)
-        {
-        }
+    /**
+     * Construct a ReaderLocator.
+     *
+     * @param owner                   Pointer to the RTPSParticipantImpl creating this object.
+     * @param max_unicast_locators    Maximum number of unicast locators to hold.
+     * @param max_multicast_locators  Maximum number of multicast locators to hold.
+     */
+    ReaderLocator(
+            RTPSParticipantImpl* /*participant_owner*/,
+            RTPSWriter* /*owner*/,
+            size_t /*max_unicast_locators*/,
+            size_t /*max_multicast_locators*/)
+    {
+    }
 
-        LocatorSelectorEntry* locator_selector_entry()
-        {
-            return nullptr;
-        }
+    LocatorSelectorEntry* locator_selector_entry()
+    {
+        return nullptr;
+    }
 
-        const GUID_t& remote_guid() const
-        {
-            return remote_guid_;
-        }
+    const GUID_t& remote_guid() const
+    {
+        return remote_guid_;
+    }
 
-        /**
-         * Try to start using this object for a new matched reader.
-         *
-         * @param remote_guid         GUID of the remote reader.
-         * @param unicast_locators    Unicast locators of the remote reader.
-         * @param multicast_locators  Multicast locators of the remote reader.
-         * @param expects_inline_qos  Whether remote reader expects to receive inline QoS.
-         *
-         * @return false when this object was already started, true otherwise.
-         */
-        bool start(
-                const GUID_t& /*remote_guid*/,
-                const ResourceLimitedVector<Locator_t>& /*unicast_locators*/,
-                const ResourceLimitedVector<Locator_t>& /*multicast_locators*/,
-                bool /*expects_inline_qos*/)
-        {
-            return true;
-        }
+    /**
+     * Try to start using this object for a new matched reader.
+     *
+     * @param remote_guid         GUID of the remote reader.
+     * @param unicast_locators    Unicast locators of the remote reader.
+     * @param multicast_locators  Multicast locators of the remote reader.
+     * @param expects_inline_qos  Whether remote reader expects to receive inline QoS.
+     *
+     * @return false when this object was already started, true otherwise.
+     */
+    bool start(
+            const GUID_t& /*remote_guid*/,
+            const ResourceLimitedVector<Locator_t>& /*unicast_locators*/,
+            const ResourceLimitedVector<Locator_t>& /*multicast_locators*/,
+            bool /*expects_inline_qos*/)
+    {
+        return true;
+    }
 
-        /**
-         * Try to update information of this object.
-         *
-         * @param unicast_locators    Unicast locators of the remote reader.
-         * @param multicast_locators  Multicast locators of the remote reader.
-         * @param expects_inline_qos  Whether remote reader expects to receive inline QoS.
-         *
-         * @return true when information has changed, false otherwise.
-         */
-        bool update(
-                const ResourceLimitedVector<Locator_t>& /*unicast_locators*/,
-                const ResourceLimitedVector<Locator_t>& /*multicast_locators*/,
-                bool /*expects_inline_qos*/)
-        {
-            return true;
-        }
+    /**
+     * Try to update information of this object.
+     *
+     * @param unicast_locators    Unicast locators of the remote reader.
+     * @param multicast_locators  Multicast locators of the remote reader.
+     * @param expects_inline_qos  Whether remote reader expects to receive inline QoS.
+     *
+     * @return true when information has changed, false otherwise.
+     */
+    bool update(
+            const ResourceLimitedVector<Locator_t>& /*unicast_locators*/,
+            const ResourceLimitedVector<Locator_t>& /*multicast_locators*/,
+            bool /*expects_inline_qos*/)
+    {
+        return true;
+    }
 
-        /**
-         * Try to stop using this object for an unmatched reader.
-         *
-         * @param remote_guid  GUID of the remote reader.
-         *
-         * @return true if this object was started for remote_guid, false otherwise.
-         */
-        bool stop(const GUID_t& /*remote_guid*/)
-        {
-            return true;
-        }
+    /**
+     * Try to stop using this object for an unmatched reader.
+     *
+     * @param remote_guid  GUID of the remote reader.
+     *
+     * @return true if this object was started for remote_guid, false otherwise.
+     */
+    bool stop(
+            const GUID_t& /*remote_guid*/)
+    {
+        return true;
+    }
 
-        /**
-         * Check if the destinations managed by this sender interface have changed.
-         *
-         * @return true if destinations have changed, false otherwise.
-         */
-        bool destinations_have_changed() const override
-        {
-            return false;
-        }
+    /**
+     * Check if the destinations managed by this sender interface have changed.
+     *
+     * @return true if destinations have changed, false otherwise.
+     */
+    bool destinations_have_changed() const override
+    {
+        return false;
+    }
 
-        /**
-         * Get a GUID prefix representing all destinations.
-         *
-         * @return When all the destinations share the same prefix (i.e. belong to the same participant)
-         * that prefix is returned. When there are no destinations, or they belong to different
-         * participants, c_GuidPrefix_Unknown is returned.
-         */
-        GuidPrefix_t destination_guid_prefix() const override
-        {
-            return remote_guid_.guidPrefix;
-        }
+    /**
+     * Get a GUID prefix representing all destinations.
+     *
+     * @return When all the destinations share the same prefix (i.e. belong to the same participant)
+     * that prefix is returned. When there are no destinations, or they belong to different
+     * participants, c_GuidPrefix_Unknown is returned.
+     */
+    GuidPrefix_t destination_guid_prefix() const override
+    {
+        return remote_guid_.guidPrefix;
+    }
 
-        /**
-         * Get the GUID prefix of all the destination participants.
-         *
-         * @return a const reference to a vector with the GUID prefix of all destination participants.
-         */
-        const std::vector<GuidPrefix_t>& remote_participants() const override
-        {
-            return guid_prefix_as_vector_;
-        }
+    /**
+     * Get the GUID prefix of all the destination participants.
+     *
+     * @return a const reference to a vector with the GUID prefix of all destination participants.
+     */
+    const std::vector<GuidPrefix_t>& remote_participants() const override
+    {
+        return guid_prefix_as_vector_;
+    }
 
-        /**
-         * Get the GUID of all destinations.
-         *
-         * @return a const reference to a vector with the GUID of all destinations.
-         */
-        const std::vector<GUID_t>& remote_guids() const override
-        {
-            return guid_as_vector_;
-        }
+    /**
+     * Get the GUID of all destinations.
+     *
+     * @return a const reference to a vector with the GUID of all destinations.
+     */
+    const std::vector<GUID_t>& remote_guids() const override
+    {
+        return guid_as_vector_;
+    }
 
-        /**
-         * Send a message through this interface.
-         *
-         * @param message Pointer to the buffer with the message already serialized.
-         * @param max_blocking_time_point Future timepoint where blocking send should end.
-         */
-        bool send(
-                CDRMessage_t* /*message*/,
-                std::chrono::steady_clock::time_point& /*max_blocking_time_point*/) const override
-        {
-            return true;
-        }
+    /**
+     * Send a message through this interface.
+     *
+     * @param message Pointer to the buffer with the message already serialized.
+     * @param max_blocking_time_point Future timepoint where blocking send should end.
+     */
+    bool send(
+            CDRMessage_t* /*message*/,
+            std::chrono::steady_clock::time_point& /*max_blocking_time_point*/) const override
+    {
+        return true;
+    }
 
-        bool is_local_reader() const
-        {
-            return false;
-        }
+    bool is_local_reader() const
+    {
+        return false;
+    }
 
-        RTPSReader* local_reader()
-        {
-            return nullptr;
-        }
+    RTPSReader* local_reader()
+    {
+        return nullptr;
+    }
 
-    private:
+private:
 
-        GUID_t remote_guid_;
-        std::vector<GuidPrefix_t> guid_prefix_as_vector_;
-        std::vector<GUID_t> guid_as_vector_;
+    GUID_t remote_guid_;
+    std::vector<GuidPrefix_t> guid_prefix_as_vector_;
+    std::vector<GUID_t> guid_as_vector_;
 };
 
 } /* namespace rtps */

--- a/test/mock/rtps/ReaderLocator/fastdds/rtps/writer/ReaderLocator.h
+++ b/test/mock/rtps/ReaderLocator/fastdds/rtps/writer/ReaderLocator.h
@@ -52,12 +52,11 @@ public:
     /**
      * Construct a ReaderLocator.
      *
-     * @param owner                   Pointer to the RTPSParticipantImpl creating this object.
+     * @param owner                   Pointer to the RTPSWriter creating this object.
      * @param max_unicast_locators    Maximum number of unicast locators to hold.
      * @param max_multicast_locators  Maximum number of multicast locators to hold.
      */
     ReaderLocator(
-            RTPSParticipantImpl* /*participant_owner*/,
             RTPSWriter* /*owner*/,
             size_t /*max_unicast_locators*/,
             size_t /*max_multicast_locators*/)


### PR DESCRIPTION
`StatelessWriter` is using the `RTPSParticipantImpl::guid` to decide if use the intraprocess mechanism, but it should use its own GUID.