### PR TITLE
Initialize num_properties to 0 in ParameterSerializer.hpp

### DIFF
--- a/src/cpp/fastdds/core/policy/ParameterSerializer.hpp
+++ b/src/cpp/fastdds/core/policy/ParameterSerializer.hpp
@@ -629,9 +629,12 @@ inline bool ParameterSerializer<ParameterPropertyList_t>::read_content_from_cdr_
     parameter.length = parameter_length;
 
     uint32_t pos_ref = cdr_message->pos;
-    uint32_t num_properties;
+    uint32_t num_properties = 0;
     bool valid = fastrtps::rtps::CDRMessage::readUInt32(cdr_message, &num_properties);
-
+    if (!valid)
+    {
+      return false;
+    }
     //properties_.reserve(parameter_length - 4);
 
     for (size_t i = 0; i < num_properties; ++i)

--- a/src/cpp/fastdds/core/policy/ParameterSerializer.hpp
+++ b/src/cpp/fastdds/core/policy/ParameterSerializer.hpp
@@ -633,7 +633,7 @@ inline bool ParameterSerializer<ParameterPropertyList_t>::read_content_from_cdr_
     bool valid = fastrtps::rtps::CDRMessage::readUInt32(cdr_message, &num_properties);
     if (!valid)
     {
-      return false;
+        return false;
     }
     //properties_.reserve(parameter_length - 4);
 


### PR DESCRIPTION
Building Fast-RTPS 2.0.x issues a warning on my system because num_properties may be unitialized. This PR sets num_properties to 0 and adds a check on valid. I wasn't sure which branch to target. Let me know if this should be targeting master instead.

Builds `--packages-up-to rclcpp`, and tests `--packages-above fastrtps --packages-up-to rclcpp`
* Linux [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux&build=10686)](http://ci.ros2.org/job/ci_linux/10686/)
* Linux-aarch64 [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux-aarch64&build=6103)](http://ci.ros2.org/job/ci_linux-aarch64/6103/)
* macOS [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_osx&build=8698)](http://ci.ros2.org/job/ci_osx/8698/)
* Windows [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_windows&build=10583)](http://ci.ros2.org/job/ci_windows/10583/)

Signed-off-by: Stephen Brawner <brawner@gmail.com>