### PR TITLE
Readers fixes and improvements <2.0.x> [8375]

### DIFF
--- a/include/fastdds/rtps/common/CacheChange.h
+++ b/include/fastdds/rtps/common/CacheChange.h
@@ -382,19 +382,6 @@ enum ChangeForReaderStatus_t
 };
 
 /**
- * Enum ChangeFromWriterStatus_t, possible states for a CacheChange_t in a WriterProxy.
- *  @ingroup COMMON_MODULE
- */
-enum ChangeFromWriterStatus_t
-{
-    UNKNOWN = 0,
-    MISSING = 1,
-    //REQUESTED_WITH_NACK,
-    RECEIVED = 2,
-    LOST = 3
-};
-
-/**
  * Struct ChangeForReader_t used to represent the state of a specific change with respect to a specific reader, as well as its relevance.
  *  @ingroup COMMON_MODULE
  */
@@ -594,102 +581,6 @@ struct ChangeForReaderCmp
 
 };
 
-/**
- * Struct ChangeFromWriter_t used to indicate the state of a specific change with respect to a specific writer, as well as its relevance.
- *  @ingroup COMMON_MODULE
- */
-class ChangeFromWriter_t
-{
-    friend struct ChangeFromWriterCmp;
-
-public:
-
-    ChangeFromWriter_t()
-        : status_(UNKNOWN)
-        , is_relevant_(true)
-    {
-
-    }
-
-    ChangeFromWriter_t(
-            const ChangeFromWriter_t& ch)
-        : status_(ch.status_)
-        , is_relevant_(ch.is_relevant_)
-        , seq_num_(ch.seq_num_)
-    {
-    }
-
-    ChangeFromWriter_t(
-            const SequenceNumber_t& seq_num)
-        : status_(UNKNOWN)
-        , is_relevant_(true)
-        , seq_num_(seq_num)
-    {
-    }
-
-    ~ChangeFromWriter_t()
-    {
-    };
-
-    ChangeFromWriter_t& operator =(
-            const ChangeFromWriter_t& ch)
-    {
-        status_ = ch.status_;
-        is_relevant_ = ch.is_relevant_;
-        seq_num_ = ch.seq_num_;
-        return *this;
-    }
-
-    void setStatus(
-            const ChangeFromWriterStatus_t status)
-    {
-        status_ = status;
-    }
-
-    ChangeFromWriterStatus_t getStatus() const
-    {
-        return status_;
-    }
-
-    void setRelevance(
-            const bool relevance)
-    {
-        is_relevant_ = relevance;
-    }
-
-    bool isRelevant() const
-    {
-        return is_relevant_;
-    }
-
-    const SequenceNumber_t getSequenceNumber() const
-    {
-        return seq_num_;
-    }
-
-    //! Set change as not valid
-    void notValid()
-    {
-        is_relevant_ = false;
-    }
-
-    bool operator < (
-            const ChangeFromWriter_t& rhs) const
-    {
-        return seq_num_ < rhs.seq_num_;
-    }
-
-private:
-
-    //! Status
-    ChangeFromWriterStatus_t status_;
-
-    //! Boolean specifying if this change is relevant
-    bool is_relevant_;
-
-    //! Sequence number
-    SequenceNumber_t seq_num_;
-};
 #endif
 }
 }

--- a/include/fastdds/rtps/history/History.h
+++ b/include/fastdds/rtps/history/History.h
@@ -118,11 +118,6 @@ public:
     RTPS_DllAPI bool remove_all_changes();
 
     /**
-     * Update the maximum and minimum sequenceNumbers.
-     */
-    virtual void updateMaxMinSeqNum() = 0;
-
-    /**
      * Remove a specific change from the history.
      * @param ch Pointer to the CacheChange_t.
      * @return True if removed.
@@ -219,17 +214,8 @@ protected:
     //!Variable to know if the history is full without needing to block the History mutex.
     bool m_isHistoryFull;
 
-    //!Pointer to and invalid cacheChange used to return the maximum and minimum when no changes are stored in the history.
-    CacheChange_t* mp_invalidCache;
-
     //!Pool of cache changes reserved when the History is created.
     CacheChangePool m_changePool;
-
-    //!Pointer to the minimum sequeceNumber CacheChange.
-    CacheChange_t* mp_minSeqCacheChange;
-
-    //!Pointer to the maximum sequeceNumber CacheChange.
-    CacheChange_t* mp_maxSeqCacheChange;
 
     //!Print the seqNum of the changes in the History (for debuggisi, mng purposes).
     void print_changes_seqNum2();

--- a/include/fastdds/rtps/history/ReaderHistory.h
+++ b/include/fastdds/rtps/history/ReaderHistory.h
@@ -105,11 +105,6 @@ public:
             const SequenceNumber_t& seq_num,
             const GUID_t& writer_guid);
 
-    /**
-     * Update the maximum and minimum sequenceNumber cacheChanges.
-     */
-    RTPS_DllAPI void updateMaxMinSeqNum() override;
-
     RTPS_DllAPI bool get_min_change_from(
             CacheChange_t** min_change,
             const GUID_t& writerGuid);

--- a/include/fastdds/rtps/history/WriterHistory.h
+++ b/include/fastdds/rtps/history/WriterHistory.h
@@ -50,11 +50,6 @@ class WriterHistory : public History
     RTPS_DllAPI virtual ~WriterHistory() override;
 
     /**
-     * Update the maximum and minimum sequenceNumber cacheChanges.
-     */
-    RTPS_DllAPI void updateMaxMinSeqNum() override;
-
-    /**
      * Add a CacheChange_t to the WriterHistory.
      * @param a_change Pointer to the CacheChange_t to be added.
      * @return True if added.

--- a/src/cpp/rtps/history/ReaderHistory.cpp
+++ b/src/cpp/rtps/history/ReaderHistory.cpp
@@ -132,6 +132,7 @@ History::const_iterator ReaderHistory::remove_change_nts(
     (void)a_change;
     assert(nullptr != a_change);
     assert((*position) == a_change);
+    m_changePool.release_Cache(a_change);
     return m_changes.erase(position);
 }
 

--- a/src/cpp/rtps/history/ReaderHistory.cpp
+++ b/src/cpp/rtps/history/ReaderHistory.cpp
@@ -85,7 +85,6 @@ bool ReaderHistory::add_change(
         m_changes.push_back(a_change);
     }
 
-    updateMaxMinSeqNum();
     logInfo(RTPS_HISTORY,
             "Change " << a_change->sequenceNumber << " added with " << a_change->serializedPayload.length << " bytes");
 
@@ -117,7 +116,6 @@ bool ReaderHistory::remove_change(
             mp_reader->change_removed_by_history(a_change);
             m_changePool.release_Cache(a_change);
             m_changes.erase(chit);
-            updateMaxMinSeqNum();
             return true;
         }
     }
@@ -180,7 +178,6 @@ bool ReaderHistory::remove_fragmented_changes_until(
         return false;
     }
 
-    bool at_least_one_removed = false;
     std::lock_guard<RecursiveTimedMutex> guard(*mp_mutex);
     std::vector<CacheChange_t*>::iterator chit = m_changes.begin();
     while (chit != m_changes.end())
@@ -196,7 +193,6 @@ bool ReaderHistory::remove_fragmented_changes_until(
                     mp_reader->change_removed_by_history(item);
                     m_changePool.release_Cache(item);
                     chit = m_changes.erase(chit);
-                    at_least_one_removed = true;
                     continue;
                 }
             }
@@ -208,26 +204,7 @@ bool ReaderHistory::remove_fragmented_changes_until(
         ++chit;
     }
 
-    if (at_least_one_removed)
-    {
-        updateMaxMinSeqNum();
-    }
-
     return true;
-}
-
-void ReaderHistory::updateMaxMinSeqNum()
-{
-    if (m_changes.size() == 0)
-    {
-        mp_minSeqCacheChange = mp_invalidCache;
-        mp_maxSeqCacheChange = mp_invalidCache;
-    }
-    else
-    {
-        mp_minSeqCacheChange = m_changes.front();
-        mp_maxSeqCacheChange = m_changes.back();
-    }
 }
 
 bool ReaderHistory::get_min_change_from(
@@ -250,6 +227,6 @@ bool ReaderHistory::get_min_change_from(
     return ret;
 }
 
-}
 } /* namespace rtps */
+} /* namespace fastrtps */
 } /* namespace eprosima */

--- a/src/cpp/rtps/history/ReaderHistory.cpp
+++ b/src/cpp/rtps/history/ReaderHistory.cpp
@@ -225,13 +225,8 @@ void ReaderHistory::updateMaxMinSeqNum()
     }
     else
     {
-        auto minmax = std::minmax_element(m_changes.begin(),
-                        m_changes.end(),
-                        [](CacheChange_t* c1, CacheChange_t* c2){
-                        return c1->sequenceNumber < c2->sequenceNumber;
-                    });
-        mp_minSeqCacheChange = *(minmax.first);
-        mp_maxSeqCacheChange = *(minmax.second);
+        mp_minSeqCacheChange = m_changes.front();
+        mp_maxSeqCacheChange = m_changes.back();
     }
 }
 

--- a/src/cpp/rtps/reader/StatefulReader.cpp
+++ b/src/cpp/rtps/reader/StatefulReader.cpp
@@ -620,6 +620,8 @@ bool StatefulReader::processGapMsg(
             }
         });
 
+        mp_history->updateMaxMinSeqNum();
+
         // Maybe now we have to notify user from new CacheChanges.
         NotifyChanges(pWP);
 

--- a/src/cpp/rtps/reader/StatefulReader.cpp
+++ b/src/cpp/rtps/reader/StatefulReader.cpp
@@ -620,8 +620,6 @@ bool StatefulReader::processGapMsg(
             }
         });
 
-        mp_history->updateMaxMinSeqNum();
-
         // Maybe now we have to notify user from new CacheChanges.
         NotifyChanges(pWP);
 

--- a/src/cpp/rtps/writer/PersistentWriter.cpp
+++ b/src/cpp/rtps/writer/PersistentWriter.cpp
@@ -39,7 +39,6 @@ PersistentWriter::PersistentWriter(GUID_t& guid,WriterAttributes& att,WriterHist
 
      if (persistence_->load_writer_from_storage(persistence_guid_, guid, hist->m_changes, &(hist->m_changePool)))
      {
-         hist->updateMaxMinSeqNum();
          CacheChange_t* max_change;
          if (hist->get_max_change(&max_change))
          {


### PR DESCRIPTION
This PR should alleviate #1062, #1107 and #1120 

It includes the following:
* Fixes the case when removing a change due to reception of GAP not being returned to the change pool.
* Improves the min-max calculation on ReaderHistory, so the complete history is not traversed every time a new change is added or removed
* Improves reception of fragmented data, by avoiding copies of already received fragments.