### PR TITLE
Writer improvements <2.0.x> [8382]

### DIFF
--- a/include/fastdds/rtps/common/CacheChange.h
+++ b/include/fastdds/rtps/common/CacheChange.h
@@ -536,10 +536,7 @@ public:
             assert(!unsent_fragments_.is_set(base));
 
             // Update base to first bit set
-            do
-            {
-                ++base;
-            } while (!unsent_fragments_.is_set(base));
+            base = unsent_fragments_.min();
             unsent_fragments_.base_update(base);
 
             // Add all possible fragments

--- a/include/fastdds/rtps/writer/StatelessWriter.h
+++ b/include/fastdds/rtps/writer/StatelessWriter.h
@@ -125,10 +125,7 @@ public:
 
     bool try_remove_change(
             std::chrono::steady_clock::time_point&,
-            std::unique_lock<RecursiveTimedMutex>&) override
-    {
-        return remove_older_changes(1);
-    }
+            std::unique_lock<RecursiveTimedMutex>&) override;
 
     void add_flow_controller(
             std::unique_ptr<FlowController> controller) override;

--- a/src/cpp/rtps/history/WriterHistory.cpp
+++ b/src/cpp/rtps/history/WriterHistory.cpp
@@ -85,8 +85,7 @@ bool WriterHistory::add_change_(CacheChange_t* a_change, WriteParams &wparams,
 
     ++m_lastCacheChangeSeqNum;
     a_change->sequenceNumber = m_lastCacheChangeSeqNum;
-    a_change->sourceTimestamp = Time_t(std::chrono::duration_cast<std::chrono::nanoseconds>(
-                                           std::chrono::system_clock::now().time_since_epoch()).count() * 1e-9);
+    Time_t::now(a_change->sourceTimestamp);
 
     a_change->write_params = wparams;
     // Updated sample identity

--- a/src/cpp/rtps/writer/StatelessWriter.cpp
+++ b/src/cpp/rtps/writer/StatelessWriter.cpp
@@ -53,11 +53,7 @@ static bool add_change_to_rtps_group(
         {
             for (uint32_t frag = 1; frag <= n_fragments; frag++)
             {
-                if (group.add_data_frag(*change, frag, inline_qos))
-                {
-                    reader_change->markFragmentsAsSent(frag);
-                }
-                else
+                if (!group.add_data_frag(*change, frag, inline_qos))
                 {
                     logError(RTPS_WRITER, "Error sending fragment (" << change->sequenceNumber << ", " << frag << ")");
                 }

--- a/src/cpp/rtps/writer/StatelessWriter.cpp
+++ b/src/cpp/rtps/writer/StatelessWriter.cpp
@@ -362,6 +362,13 @@ bool StatelessWriter::is_acked_by_all(
     return true;
 }
 
+bool StatelessWriter::try_remove_change(
+        std::chrono::steady_clock::time_point&,
+        std::unique_lock<RecursiveTimedMutex>&)
+{
+    return mp_history->remove_min_change();
+}
+
 void StatelessWriter::update_unsent_changes(
         const SequenceNumber_t& seq_num,
         const FragmentNumber_t& frag_num)

--- a/test/unittest/utils/BitmapRangeTests.cpp
+++ b/test/unittest/utils/BitmapRangeTests.cpp
@@ -25,6 +25,8 @@ using TestType = eprosima::fastrtps::BitmapRange<ValueType>;
 struct TestResult
 {
     bool result;
+    ValueType min;
+    ValueType max;
     uint32_t num_bits;
     uint32_t num_longs;
     TestType::bitmap_type bitmap;
@@ -42,6 +44,16 @@ struct TestResult
         {
             return false;
         }
+
+        if (!uut.empty())
+        {
+            ValueType base = uut.base();
+            if (uut.max() != (base + max) || uut.min() != (base + min))
+            {
+                return false;
+            }
+        }
+
         return std::equal(bitmap.cbegin(), bitmap.cbegin() + num_longs, check.bitmap.cbegin());
     }
 };
@@ -121,7 +133,7 @@ class BitmapRangeTests: public ::testing::Test
         {
             // initialization
             {
-                true, 0, 0, {0,0,0,0,0,0,0,0}
+                true, 0, 0, 0, 0, {0,0,0,0,0,0,0,0}
             },
             // steps
             {
@@ -129,63 +141,63 @@ class BitmapRangeTests: public ::testing::Test
                 {
                     {0},
                     {
-                        true, 1, 1, {0x80000000UL,0,0,0,0,0,0,0}
+                        true, 0, 0, 1, 1, {0x80000000UL,0,0,0,0,0,0,0}
                     }
                 },
                 // Adding base again
                 {
                     {0},
                     {
-                        true, 1, 1, {0x80000000UL,0,0,0,0,0,0,0}
+                        true, 0, 0, 1, 1, {0x80000000UL,0,0,0,0,0,0,0}
                     }
                 },
                 // Adding out of range
                 {
                     {256},
                     {
-                        false, 1, 1, {0x80000000UL,0,0,0,0,0,0,0}
+                        false, 0, 0, 1, 1, {0x80000000UL,0,0,0,0,0,0,0}
                     }
                 },
                 // Middle of first word
                 {
                     {16},
                     {
-                        true, 17, 1, {0x80008000UL,0,0,0,0,0,0,0}
+                        true, 0, 16, 17, 1, {0x80008000UL,0,0,0,0,0,0,0}
                     }
                 },
                 // Before previous one
                 {
                     {15},
                     {
-                        true, 17, 1, {0x80018000UL,0,0,0,0,0,0,0}
+                        true, 0, 16, 17, 1, {0x80018000UL,0,0,0,0,0,0,0}
                     }
                 },
                 // On third word
                 {
                     {67},
                     {
-                        true, 68, 3, {0x80018000UL,0,0x10000000UL,0,0,0,0,0}
+                        true, 0, 67, 68, 3, {0x80018000UL,0,0x10000000UL,0,0,0,0,0}
                     }
                 },
                 // Before last on third word
                 {
                     {94},
                     {
-                        true, 95, 3, {0x80018000UL,0,0x10000002UL,0,0,0,0,0}
+                        true, 0, 94, 95, 3, {0x80018000UL,0,0x10000002UL,0,0,0,0,0}
                     }
                 },
                 // Last on third word
                 {
                     {95},
                     {
-                        true, 96, 3, {0x80018000UL,0,0x10000003UL,0,0,0,0,0}
+                        true, 0, 95, 96, 3, {0x80018000UL,0,0x10000003UL,0,0,0,0,0}
                     }
                 },
                 // Last possible item
                 {
                     {255},
                     {
-                        true, 256, 8, {0x80018000UL,0,0x10000003UL,0,0,0,0,0x00000001UL}
+                        true, 0, 255, 256, 8, {0x80018000UL,0,0x10000003UL,0,0,0,0,0x00000001UL}
                     }
                 }
             }
@@ -194,6 +206,8 @@ class BitmapRangeTests: public ::testing::Test
         const TestResult all_ones =
         {
             true,
+            0UL,
+            255UL,
             256UL,
             8UL,
             { 0xFFFFFFFFUL, 0xFFFFFFFFUL, 0xFFFFFFFFUL, 0xFFFFFFFFUL, 0xFFFFFFFFUL, 0xFFFFFFFFUL, 0xFFFFFFFFUL, 0xFFFFFFFFUL }
@@ -203,7 +217,7 @@ class BitmapRangeTests: public ::testing::Test
         {
             // initialization
             {
-                true, 0, 0, {0,0,0,0,0,0,0,0}
+                true, 0, 0, 0, 0, {0,0,0,0,0,0,0,0}
             },
             // steps
             {
@@ -211,63 +225,63 @@ class BitmapRangeTests: public ::testing::Test
                 {
                     {0, 0},
                     {
-                        true, 0, 0, {0,0,0,0,0,0,0,0}
+                        true, 0, 0, 0, 0, {0,0,0,0,0,0,0,0}
                     }
                 },
                 // Adding base
                 {
                     {0, 1},
                     {
-                        true, 1, 1, {0x80000000UL,0,0,0,0,0,0,0}
+                        true, 0, 0, 1, 1, {0x80000000UL,0,0,0,0,0,0,0}
                     }
                 },
                 // Wrong order params
                 {
                     {10, 1},
                     {
-                        true, 1, 1, {0x80000000UL,0,0,0,0,0,0,0}
+                        true, 0, 0, 1, 1, {0x80000000UL,0,0,0,0,0,0,0}
                     }
                 },
                 // Adding out of range
                 {
                     {256, 257},
                     {
-                        true, 1, 1, {0x80000000UL,0,0,0,0,0,0,0}
+                        true, 0, 0, 1, 1, {0x80000000UL,0,0,0,0,0,0,0}
                     }
                 },
                 // Middle of first word
                 {
                     {15, 17},
                     {
-                        true, 17, 1, {0x80018000UL,0,0,0,0,0,0,0}
+                        true, 0, 16, 17, 1, {0x80018000UL,0,0,0,0,0,0,0}
                     }
                 },
                 // On second and third word
                 {
                     {35, 68},
                     {
-                        true, 68, 3, {0x80018000UL,0x1FFFFFFF,0xF0000000,0,0,0,0,0}
+                        true, 0, 67, 68, 3, {0x80018000UL,0x1FFFFFFF,0xF0000000,0,0,0,0,0}
                     }
                 },
                 // Crossing more than one word
                 {
                     {94, 133},
                     {
-                        true, 133, 5, {0x80018000UL,0x1FFFFFFF,0xF0000003,0xFFFFFFFF,0xF8000000,0,0,0}
+                        true, 0, 132, 133, 5, {0x80018000UL,0x1FFFFFFF,0xF0000003,0xFFFFFFFF,0xF8000000,0,0,0}
                     }
                 },
                 // Exactly one word
                 {
                     {64, 96},
                     {
-                        true, 133, 5, {0x80018000UL,0x1FFFFFFF,0xFFFFFFFF,0xFFFFFFFF,0xF8000000,0,0,0}
+                        true, 0, 132, 133, 5, {0x80018000UL,0x1FFFFFFF,0xFFFFFFFF,0xFFFFFFFF,0xF8000000,0,0,0}
                     }
                 },
                 // Exactly two words
                 {
                     {128, 192},
                     {
-                        true, 192, 6, {0x80018000UL,0x1FFFFFFF,0xFFFFFFFF,0xFFFFFFFF,0xFFFFFFFF,0xFFFFFFFF,0,0}
+                        true, 0, 191, 192, 6, {0x80018000UL,0x1FFFFFFF,0xFFFFFFFF,0xFFFFFFFF,0xFFFFFFFF,0xFFFFFFFF,0,0}
                     }
                 },
                 // Full range
@@ -282,7 +296,7 @@ class BitmapRangeTests: public ::testing::Test
         {
             // initialization (starts from full word)
             {
-                true, 32, 1, {0xFFFFFFFFUL, 0, 0, 0, 0, 0, 0, 0}
+                true, 0, 31, 32, 1, {0xFFFFFFFFUL, 0, 0, 0, 0, 0, 0, 0}
             },
             // steps
             {
@@ -290,42 +304,56 @@ class BitmapRangeTests: public ::testing::Test
                 {
                     {32, 33},
                     {
-                        true, 32, 1, {0xFFFFFFFFUL, 0, 0, 0, 0, 0, 0, 0}
+                        true, 0, 31, 32, 1, {0xFFFFFFFFUL, 0, 0, 0, 0, 0, 0, 0}
                     }
                 },
                 // Removing single in the middle
                 {
                     {5, 6},
                     {
-                        true, 32, 1, {0xFBFFFFFFUL, 0, 0, 0, 0, 0, 0, 0}
+                        true, 0, 31, 32, 1, {0xFBFFFFFFUL, 0, 0, 0, 0, 0, 0, 0}
                     }
                 },
                 // Removing several in the middle
                 {
                     {6, 31},
                     {
-                        true, 32, 1, {0xF8000001UL, 0, 0, 0, 0, 0, 0, 0}
-                    }
-                },
-                // Removing all except first and last
-                {
-                    {1, 31},
-                    {
-                        true, 32, 1, {0x80000001UL, 0, 0, 0, 0, 0, 0, 0}
+                        true, 0, 31, 32, 1, {0xF8000001UL, 0, 0, 0, 0, 0, 0, 0}
                     }
                 },
                 // Removing last
                 {
                     {31, 32},
                     {
-                        true, 1, 1, {0x80000000UL, 0, 0, 0, 0, 0, 0, 0}
+                        true, 0, 4, 5, 1, {0xF8000000UL, 0, 0, 0, 0, 0, 0, 0}
                     }
                 },
                 // Removing first
                 {
                     {0, 1},
                     {
-                        true, 0, 0, {0, 0, 0, 0, 0, 0, 0, 0}
+                        true, 1, 4, 5, 1, {0x78000000UL, 0, 0, 0, 0, 0, 0, 0}
+                    }
+                },
+                // Removing all except first and last
+                {
+                    {2, 4},
+                    {
+                        true, 1, 4, 5, 1, {0x48000000UL, 0, 0, 0, 0, 0, 0, 0}
+                    }
+                },
+                // Removing last
+                {
+                    {4, 5},
+                    {
+                        true, 1, 1, 2, 1, {0x40000000UL, 0, 0, 0, 0, 0, 0, 0}
+                    }
+                },
+                // Removing first
+                {
+                    {1, 2},
+                    {
+                        true, 0, 0, 0, 0, {0, 0, 0, 0, 0, 0, 0, 0}
                     }
                 }
             }


### PR DESCRIPTION
This PR alleviates #1062, #1107 and #1120 with several improvements on the writers.

* Several loops reduced on fragment management, on b2b528c, 071febe and c1151a8
* Changed algorithm on `StatefulWriter::check_acked_status` from `O(n*log(n))` to `O(n)` on 4340614
* Removed loop on `StatelessWriter::try_remove_change` on adcce30
* Implicit flow controller added to both writers on 3f7fef2 and efb08fc