### PR TITLE
Disable TCP Throughput test <2.0.x> [7439]

### DIFF
--- a/test/performance/throughput/CMakeLists.txt
+++ b/test/performance/throughput/CMakeLists.txt
@@ -39,8 +39,8 @@ set(
     THROUGHPUT_TEST_LIST
     interprocess_best_effort
     interprocess_reliable
-    interprocess_best_effort_tcp
-    interprocess_reliable_tcp
+#    interprocess_best_effort_tcp
+#    interprocess_reliable_tcp
     interprocess_best_effort_shm
     interprocess_reliable_shm
 )


### PR DESCRIPTION
Since this issue is still open, and the test is failling constantly. I propose to disable it, and open a PR to re-enable it when the issue is corrected.