### PR TITLE
Unregister/Dispose instances on Writer side [8437]

### DIFF
--- a/examples/C++/Keys/keys.cpp
+++ b/examples/C++/Keys/keys.cpp
@@ -265,6 +265,13 @@ void keys()
         return pubListener.n_matched > 0;
     });
 
+    // Registering 5 instances.
+    for (uint8_t i = 0; i < 5; i++)
+    {
+        my_sample.key_value(i + 1);
+        myPub->register_instance(&my_sample);
+    }
+
     //Send 10 samples
     std::cout << "Publishing 5 keys, 10 samples per key..." << std::endl;
     for (uint8_t i = 0; i < 5; i++)
@@ -329,6 +336,13 @@ void publisherKeys()
     {
         return pubListener.n_matched > 0;
     });
+
+    // Registering 5 instances.
+    for (uint8_t i = 0; i < 5; i++)
+    {
+        my_sample.key_value(i + 1);
+        myPub->register_instance(&my_sample);
+    }
 
     //Send 10 samples
     std::cout << "Publishing 5 keys, 10 samples per key..." << std::endl;

--- a/include/fastdds/dds/publisher/DataWriter.hpp
+++ b/include/fastdds/dds/publisher/DataWriter.hpp
@@ -112,23 +112,41 @@ public:
      * instance should be automatically deduced from the instance_data (by means of the key).
      *
      * @param data Pointer to the data
+<<<<<<< HEAD
      * @param handle InstanceHandle_t.
      * @return RETCODE_PRECONDITION_NOT_MET if the handle introduced does not match with the one associated to the data,
      * RETCODE_OK if the data is correctly sent and RETCODE_ERROR otherwise.
+=======
+     * @param[in] handle InstanceHandle_t.
+     * @return True if correct
+     * @par Calling example:
+     * @snippet fastrtps_example.cpp ex_PublisherWrite
+>>>>>>> 6977ade15... Refs #7297. Added doxygen documentation.
      */
     RTPS_DllAPI ReturnCode_t write(
             void* data,
             const fastrtps::rtps::InstanceHandle_t& handle);
 
-    /**!
-     * @brief
-     * @param key
-     * @param[out] instance_handle
-     * @return
+    /*!
+     * @brief Informs that the application will be modifying a particular instance.
+     * It gives and opportunity to the middleware to pre-configure itself to improve performance.
+     * @param[in] instance Sample used to get the instance's key.
+     * @return Handle containing the instance's key.
+     * This handle could be used in successive `write` or `dispose` operations.
+     * In case of error, HANDLE_NIL will be returned.
      */
     RTPS_DllAPI fastrtps::rtps::InstanceHandle_t register_instance(
             void* instance);
 
+    /*!
+     * @brief This operation reserves the action of `register_instance`.
+     * Informs the middleware that the DataWriter is not intending to modify any more of that data instance.
+     * Also indicates that the middleware can locally remove all information regarding that instance.
+     * @param[in] instance Sample used to deduce instance's key in case of `handle` parameter is HANDLE_NIL.
+     * @param[in] handle Instance's key to be unregistered.
+     * @return Returns the operation's result.
+     * If the operation finishes successfully, ReturnCode_t::RETCODE_OK is returned.
+     */
     RTPS_DllAPI ReturnCode_t unregister_instance(
             void* instance,
             const fastrtps::rtps::InstanceHandle_t& handle);
@@ -225,8 +243,8 @@ public:
      * available to DataReader objects by means of the source_timestamp attribute inside the SampleInfo. The constraints
      * on the values of the handle parameter and the corresponding error behavior are the same specified for the
      * unregister_instance operation.
-     * @param data Pointer to data
-     * @param handle InstanceHandle of the data
+     * @param[in] data Sample used to deduce instance's key in case of `handle` parameter is HANDLE_NIL.
+     * @param[in] handle InstanceHandle of the data
      * @return RETCODE_PRECONDITION_NOT_MET if the handle introduced does not match with the one associated to the data,
      * RETCODE_OK if the data is correctly sent and RETCODE_ERROR otherwise.
      */

--- a/include/fastdds/dds/publisher/DataWriter.hpp
+++ b/include/fastdds/dds/publisher/DataWriter.hpp
@@ -126,8 +126,12 @@ public:
      * @param[out] instance_handle
      * @return
      */
-    fastrtps::rtps::InstanceHandle_t register_instance(
-            void* key);
+    RTPS_DllAPI fastrtps::rtps::InstanceHandle_t register_instance(
+            void* instance);
+
+    RTPS_DllAPI ReturnCode_t unregister_instance(
+            void* instance,
+            const fastrtps::rtps::InstanceHandle_t& handle);
 
     /**
      * Returns the DataWriter's GUID

--- a/include/fastdds/dds/publisher/DataWriter.hpp
+++ b/include/fastdds/dds/publisher/DataWriter.hpp
@@ -234,26 +234,6 @@ public:
             void* data,
             const fastrtps::rtps::InstanceHandle_t& handle);
 
-    /**
-     * @brief This operation requests the middleware to delete the data (the actual deletion is postponed until there is no
-     * more use for that data in the whole system). In general, applications are made aware of the deletion by means of
-     * operations on the DataReader objects that already knew that instance. This operation does not modify the value of
-     * the instance. The instance parameter is passed just for the purposes of identifying the instance.
-     * When this operation is used, the Service will automatically supply the value of the source_timestamp that is made
-     * available to DataReader objects by means of the source_timestamp attribute inside the SampleInfo. The constraints
-     * on the values of the handle parameter and the corresponding error behavior are the same specified for the
-     * unregister_instance operation.
-     * @param data Pointer to data.
-     * @return true if disposed, false if not.
-     */
-    RTPS_DllAPI bool dispose(
-            void* data);
-
-    /**
-     * @brief Returns the liveliness lost status
-     * @param status Liveliness lost status struct
-     * @return RETCODE_OK
-     */
     RTPS_DllAPI ReturnCode_t get_liveliness_lost_status(
             LivelinessLostStatus& status);
 

--- a/include/fastdds/dds/publisher/DataWriter.hpp
+++ b/include/fastdds/dds/publisher/DataWriter.hpp
@@ -112,16 +112,9 @@ public:
      * instance should be automatically deduced from the instance_data (by means of the key).
      *
      * @param data Pointer to the data
-<<<<<<< HEAD
      * @param handle InstanceHandle_t.
      * @return RETCODE_PRECONDITION_NOT_MET if the handle introduced does not match with the one associated to the data,
      * RETCODE_OK if the data is correctly sent and RETCODE_ERROR otherwise.
-=======
-     * @param[in] handle InstanceHandle_t.
-     * @return True if correct
-     * @par Calling example:
-     * @snippet fastrtps_example.cpp ex_PublisherWrite
->>>>>>> 6977ade15... Refs #7297. Added doxygen documentation.
      */
     RTPS_DllAPI ReturnCode_t write(
             void* data,
@@ -129,7 +122,7 @@ public:
 
     /*!
      * @brief Informs that the application will be modifying a particular instance.
-     * It gives and opportunity to the middleware to pre-configure itself to improve performance.
+     * It gives an opportunity to the middleware to pre-configure itself to improve performance.
      * @param[in] instance Sample used to get the instance's key.
      * @return Handle containing the instance's key.
      * This handle could be used in successive `write` or `dispose` operations.
@@ -139,7 +132,8 @@ public:
             void* instance);
 
     /*!
-     * @brief This operation reserves the action of `register_instance`.
+     * @brief This operation reverses the action of `register_instance`.
+     * It should only be called on an instance that is currently registered.
      * Informs the middleware that the DataWriter is not intending to modify any more of that data instance.
      * Also indicates that the middleware can locally remove all information regarding that instance.
      * @param[in] instance Sample used to deduce instance's key in case of `handle` parameter is HANDLE_NIL.

--- a/include/fastdds/dds/publisher/DataWriter.hpp
+++ b/include/fastdds/dds/publisher/DataWriter.hpp
@@ -246,6 +246,11 @@ public:
             void* data,
             const fastrtps::rtps::InstanceHandle_t& handle);
 
+    /**
+     * @brief Returns the liveliness lost status
+     * @param status Liveliness lost status struct
+     * @return RETCODE_OK
+     */
     RTPS_DllAPI ReturnCode_t get_liveliness_lost_status(
             LivelinessLostStatus& status);
 

--- a/include/fastdds/dds/publisher/DataWriter.hpp
+++ b/include/fastdds/dds/publisher/DataWriter.hpp
@@ -120,6 +120,15 @@ public:
             void* data,
             const fastrtps::rtps::InstanceHandle_t& handle);
 
+    /**!
+     * @brief
+     * @param key
+     * @param[out] instance_handle
+     * @return
+     */
+    fastrtps::rtps::InstanceHandle_t register_instance(
+            void* key);
+
     /**
      * Returns the DataWriter's GUID
      * @return Reference to the DataWriter GUID

--- a/include/fastdds/rtps/common/CacheChange.h
+++ b/include/fastdds/rtps/common/CacheChange.h
@@ -554,10 +554,10 @@ public:
         }
         unsentFragments.for_each(
             [this](
-                FragmentNumber_t element)
-                    {
-                        unsent_fragments_.add(element);
-                    });
+                    FragmentNumber_t element)
+            {
+                unsent_fragments_.add(element);
+            });
     }
 
 private:

--- a/include/fastdds/rtps/common/CacheChange.h
+++ b/include/fastdds/rtps/common/CacheChange.h
@@ -159,8 +159,8 @@ struct RTPS_DllAPI CacheChange_t
      * @return size of fragment (0 means change is not fragmented).
      */
     uint16_t getFragmentSize() const
-    { 
-        return fragment_size_; 
+    {
+        return fragment_size_;
     }
 
     /*!
@@ -554,10 +554,10 @@ public:
         }
         unsentFragments.for_each(
             [this](
-                    FragmentNumber_t element)
-            {
-                unsent_fragments_.add(element);
-            });
+                FragmentNumber_t element)
+                    {
+                        unsent_fragments_.add(element);
+                    });
     }
 
 private:

--- a/include/fastdds/rtps/common/InstanceHandle.h
+++ b/include/fastdds/rtps/common/InstanceHandle.h
@@ -23,30 +23,37 @@
 #include <fastdds/rtps/common/Types.h>
 #include <fastdds/rtps/common/Guid.h>
 
-namespace eprosima{
-namespace fastrtps{
-namespace rtps{
+namespace eprosima {
+namespace fastrtps {
+namespace rtps {
 
 /**
  * Struct InstanceHandle_t, used to contain the key for WITH_KEY topics.
  * @ingroup COMMON_MODULE
  */
-struct RTPS_DllAPI InstanceHandle_t{
+struct RTPS_DllAPI InstanceHandle_t
+{
     //!Value
     octet value[16];
     InstanceHandle_t()
     {
-        for(uint8_t i=0;i<16;i++)
+        for (uint8_t i = 0; i < 16; i++)
+        {
             value[i] = 0;
+        }
     }
 
-    InstanceHandle_t(const InstanceHandle_t& ihandle)
+    InstanceHandle_t(
+            const InstanceHandle_t& ihandle)
     {
-        for(uint8_t i = 0; i < 16; i++)
+        for (uint8_t i = 0; i < 16; i++)
+        {
             value[i] = ihandle.value[i];
+        }
     }
 
-    InstanceHandle_t(const GUID_t& guid)
+    InstanceHandle_t(
+            const GUID_t& guid)
     {
         for (uint8_t i = 0; i < 16; ++i)
         {
@@ -62,12 +69,14 @@ struct RTPS_DllAPI InstanceHandle_t{
     }
 
     /**
-    * Assingment operator
-    * @param ihandle Instance handle to copy the data from
-    */
-    InstanceHandle_t& operator=(const InstanceHandle_t& ihandle){
+     * Assingment operator
+     * @param ihandle Instance handle to copy the data from
+     */
+    InstanceHandle_t& operator =(
+            const InstanceHandle_t& ihandle)
+    {
 
-        for(uint8_t i =0;i<16;i++)
+        for (uint8_t i = 0; i < 16; i++)
         {
             value[i] = ihandle.value[i];
         }
@@ -75,31 +84,38 @@ struct RTPS_DllAPI InstanceHandle_t{
     }
 
     /**
-    * Assingment operator
-    * @param guid GUID to copy the data from
-    */
-    InstanceHandle_t& operator=(const GUID_t& guid)
+     * Assingment operator
+     * @param guid GUID to copy the data from
+     */
+    InstanceHandle_t& operator =(
+            const GUID_t& guid)
     {
-        for(uint8_t i =0;i<16;i++)
+        for (uint8_t i = 0; i < 16; i++)
         {
-            if(i<12)
+            if (i < 12)
+            {
                 value[i] = guid.guidPrefix.value[i];
+            }
             else
-                value[i] = guid.entityId.value[i-12];
+            {
+                value[i] = guid.entityId.value[i - 12];
+            }
         }
         return *this;
     }
 
     /**
-    * Know if the instance handle is defined
-    * @return True if the values are not zero.
-    */
+     * Know if the instance handle is defined
+     * @return True if the values are not zero.
+     */
     bool isDefined() const
     {
-        for(uint8_t i=0;i<16;++i)
+        for (uint8_t i = 0; i < 16; ++i)
         {
-            if(value[i]!=0)
+            if (value[i] != 0)
+            {
                 return true;
+            }
         }
         return false;
     }
@@ -109,6 +125,7 @@ struct RTPS_DllAPI InstanceHandle_t{
     {
         return *reinterpret_cast<const GUID_t*>(this);
     }
+
 };
 
 const InstanceHandle_t c_InstanceHandle_Unknown;
@@ -116,59 +133,83 @@ const InstanceHandle_t c_InstanceHandle_Unknown;
 #ifndef DOXYGEN_SHOULD_SKIP_THIS_PUBLIC
 
 /**
-* Comparison operator
-* @param ihandle1 First InstanceHandle_t to compare
-* @param ihandle2 Second InstanceHandle_t to compare
-* @return True if equal
-*/
-inline bool operator==(const InstanceHandle_t & ihandle1, const InstanceHandle_t& ihandle2)
+ * Comparison operator
+ * @param ihandle1 First InstanceHandle_t to compare
+ * @param ihandle2 Second InstanceHandle_t to compare
+ * @return True if equal
+ */
+inline bool operator ==(
+        const InstanceHandle_t& ihandle1,
+        const InstanceHandle_t& ihandle2)
 {
-    for(uint8_t i =0;i<16;++i)
+    for (uint8_t i = 0; i < 16; ++i)
     {
-        if(ihandle1.value[i] != ihandle2.value[i])
+        if (ihandle1.value[i] != ihandle2.value[i])
+        {
             return false;
+        }
     }
     return true;
 }
+
+inline bool operator !=(
+        const InstanceHandle_t& ihandle1,
+        const InstanceHandle_t& ihandle2)
+{
+    return !(ihandle1 == ihandle2);
+}
+
 #endif
 
 /**
-* Convert InstanceHandle_t to GUID
-* @param guid GUID to store the results
-* @param ihandle InstanceHandle_t to copy
-*/
-inline void iHandle2GUID(GUID_t& guid,const InstanceHandle_t& ihandle)
+ * Convert InstanceHandle_t to GUID
+ * @param guid GUID to store the results
+ * @param ihandle InstanceHandle_t to copy
+ */
+inline void iHandle2GUID(
+        GUID_t& guid,
+        const InstanceHandle_t& ihandle)
 {
-    for(uint8_t i = 0;i<16;++i)
+    for (uint8_t i = 0; i < 16; ++i)
     {
-        if(i<12)
+        if (i < 12)
+        {
             guid.guidPrefix.value[i] = ihandle.value[i];
+        }
         else
-            guid.entityId.value[i-12] = ihandle.value[i];
+        {
+            guid.entityId.value[i - 12] = ihandle.value[i];
+        }
     }
     return;
 }
 
-
 /**
-* Convert GUID to InstanceHandle_t
-* @param ihandle InstanceHandle_t to store the results
-* @return GUID_t
-*/
-inline GUID_t iHandle2GUID(const InstanceHandle_t& ihandle)
+ * Convert GUID to InstanceHandle_t
+ * @param ihandle InstanceHandle_t to store the results
+ * @return GUID_t
+ */
+inline GUID_t iHandle2GUID(
+        const InstanceHandle_t& ihandle)
 {
     GUID_t guid;
-    for(uint8_t i = 0;i<16;++i)
+    for (uint8_t i = 0; i < 16; ++i)
     {
-        if(i<12)
+        if (i < 12)
+        {
             guid.guidPrefix.value[i] = ihandle.value[i];
+        }
         else
-            guid.entityId.value[i-12] = ihandle.value[i];
+        {
+            guid.entityId.value[i - 12] = ihandle.value[i];
+        }
     }
     return guid;
 }
 
-inline bool operator<(const InstanceHandle_t& h1, const InstanceHandle_t& h2)
+inline bool operator <(
+        const InstanceHandle_t& h1,
+        const InstanceHandle_t& h2)
 {
     return memcmp(h1.value, h2.value, 16) < 0;
 }
@@ -176,15 +217,19 @@ inline bool operator<(const InstanceHandle_t& h1, const InstanceHandle_t& h2)
 #ifndef DOXYGEN_SHOULD_SKIP_THIS_PUBLIC
 
 /**
-*
-* @param output
-* @param iHandle
-*/
-inline std::ostream& operator<<(std::ostream& output,const InstanceHandle_t& iHandle)
+ *
+ * @param output
+ * @param iHandle
+ */
+inline std::ostream& operator <<(
+        std::ostream& output,
+        const InstanceHandle_t& iHandle)
 {
     output << std::hex;
-    for(uint8_t i =0;i<15;++i)
+    for (uint8_t i = 0; i < 15; ++i)
+    {
         output << (int)iHandle.value[i] << ".";
+    }
     output << (int)iHandle.value[15] << std::dec;
     return output;
 }

--- a/include/fastdds/rtps/writer/RTPSWriter.h
+++ b/include/fastdds/rtps/writer/RTPSWriter.h
@@ -211,7 +211,7 @@ public:
      * @return at least one change has been removed
      */
     virtual bool try_remove_change(
-            std::chrono::steady_clock::time_point& max_blocking_time_point,
+            const std::chrono::steady_clock::time_point& max_blocking_time_point,
             std::unique_lock<RecursiveTimedMutex>& lock) = 0;
 
     /*

--- a/include/fastdds/rtps/writer/StatefulWriter.h
+++ b/include/fastdds/rtps/writer/StatefulWriter.h
@@ -173,7 +173,7 @@ public:
      * @return True if removed.
      */
     bool try_remove_change(
-            std::chrono::steady_clock::time_point& max_blocking_time_point,
+            const std::chrono::steady_clock::time_point& max_blocking_time_point,
             std::unique_lock<RecursiveTimedMutex>& lock) override;
 
     /**

--- a/include/fastdds/rtps/writer/StatelessWriter.h
+++ b/include/fastdds/rtps/writer/StatelessWriter.h
@@ -124,7 +124,7 @@ public:
             const CacheChange_t* change) const override;
 
     bool try_remove_change(
-            std::chrono::steady_clock::time_point&,
+            const std::chrono::steady_clock::time_point&,
             std::unique_lock<RecursiveTimedMutex>&) override;
 
     void add_flow_controller(

--- a/include/fastrtps/publisher/Publisher.h
+++ b/include/fastrtps/publisher/Publisher.h
@@ -84,25 +84,35 @@ public:
             rtps::WriteParams& wparams);
 
     /*!
-     * @brief Registers an instance.
-     * Informs the publisher will start writing samples of this instance.
-     * @param sample Pointer to the sample used to retrieve the instance.
+     * @brief Informs that the application will be modifying a particular instance.
+     * It gives and opportunity to the middleware to pre-configure itself to improve performance.
+     * @param[in] instance Sample used to get the instance's key.
+     * @return Handle containing the instance's key.
+     * This handle could be used in successive `write` or `dispose` operations.
+     * In case of error, HANDLE_NIL will be returned.
      */
     fastrtps::rtps::InstanceHandle_t register_instance(
             void* instance);
 
-    /**
-     * Dispose of a previously written data.
-     * @param Data Pointer to the data.
-     * @return True if correct.
+    /*!
+     * @brief Requests the middleware to delete the instance.
+     * Applications are made aware of the deletion through the DataReader objects.
+     * @param[in] data Sample used to deduce instance's key in case of `handle` parameter is HANDLE_NIL.
+     * @param[in] handle Instance's key to be unregistered.
+     * @return Returns the operation's result.
+     * If the operation finishes successfully, `true` is returned.
      */
     bool dispose(
             void* data,
             const rtps::InstanceHandle_t& handle);
-    /**
-     * Unregister a previously written data.
-     * @param Data Pointer to the data.
-     * @return True if correct.
+    /*!
+     * @brief This operation reserves the action of `register_instance`.
+     * Informs the middleware that the DataWriter is not intending to modify any more of that data instance.
+     * Also indicates that the middleware can locally remove all information regarding that instance.
+     * @param[in] instance Sample used to deduce instance's key in case of `handle` parameter is HANDLE_NIL.
+     * @param[in] handle Instance's key to be unregistered.
+     * @return Returns the operation's result.
+     * If the operation finishes successfully, `true` is returned.
      */
     bool unregister_instance(
             void* instance,

--- a/include/fastrtps/publisher/Publisher.h
+++ b/include/fastrtps/publisher/Publisher.h
@@ -30,11 +30,10 @@
 namespace eprosima {
 namespace fastrtps {
 
-namespace rtps
-{
-    struct GUID_t;
-    class WriteParams;
-    class RTPSParticipant;
+namespace rtps {
+struct GUID_t;
+class WriteParams;
+class RTPSParticipant;
 }
 
 class Participant;
@@ -55,7 +54,8 @@ public:
      * Constructor from a PublisherImpl pointer
      * @param pimpl Actual implementation of the publisher
      */
-    Publisher(PublisherImpl* pimpl);
+    Publisher(
+            PublisherImpl* pimpl);
 
     /*!
      * @brief Writes a sample of the topic.
@@ -66,7 +66,8 @@ public:
      * @par Calling example:
      * @snippet fastrtps_example.cpp ex_PublisherWrite
      */
-    bool write(void* sample);
+    bool write(
+            void* sample);
 
     /*!
      * @brief Writes a sample of the topic with additional options.
@@ -82,38 +83,51 @@ public:
             void* sample,
             rtps::WriteParams& wparams);
 
+    /*!
+     * @brief Registers an instance.
+     * Informs the publisher will start writing samples of this instance.
+     * @param sample Pointer to the sample used to retrieve the instance.
+     */
+    fastrtps::rtps::InstanceHandle_t register_instance(
+            void* sample);
+
     /**
      * Dispose of a previously written data.
      * @param Data Pointer to the data.
      * @return True if correct.
      */
-    bool dispose(void* Data);
+    bool dispose(
+            void* Data);
     /**
      * Unregister a previously written data.
      * @param Data Pointer to the data.
      * @return True if correct.
      */
-    bool unregister(void* Data);
+    bool unregister(
+            void* Data);
     /**
      * Dispose and unregister a previously written data.
      * @param Data Pointer to the data.
      * @return True if correct.
      */
-    bool dispose_and_unregister(void* Data);
+    bool dispose_and_unregister(
+            void* Data);
 
     /**
      * Remove all the Changes in the associated RTPSWriter.
      * @param[out] removed Number of elements removed
      * @return True if all elements were removed.
      */
-    bool removeAllChange(size_t* removed = nullptr);
+    bool removeAllChange(
+            size_t* removed = nullptr);
 
     /**
-    * Waits until all changes were acknowledged or max_wait.
-    * @param max_wait Maximum time to wait until all changes are acknowledged.
-    * @return True if all were acknowledged.
-    */
-    bool wait_for_all_acked(const Duration_t& max_wait);
+     * Waits until all changes were acknowledged or max_wait.
+     * @param max_wait Maximum time to wait until all changes are acknowledged.
+     * @return True if all were acknowledged.
+     */
+    bool wait_for_all_acked(
+            const Duration_t& max_wait);
 
     /**
      * Get the GUID_t of the associated RTPSWriter.
@@ -132,13 +146,15 @@ public:
      * @param att Reference to a PublisherAttributes object to update the parameters.
      * @return True if correctly updated, false if ANY of the updated parameters cannot be updated.
      */
-    bool updateAttributes(const PublisherAttributes& att);
+    bool updateAttributes(
+            const PublisherAttributes& att);
 
     /**
      * @brief Returns the offered deadline missed status
      * @param status missed status struct
      */
-    void get_offered_deadline_missed_status(OfferedDeadlineMissedStatus& status);
+    void get_offered_deadline_missed_status(
+            OfferedDeadlineMissedStatus& status);
 
     /**
      * @brief Asserts liveliness
@@ -149,7 +165,8 @@ public:
      * @brief Returns the liveliness lost status
      * @param status Liveliness lost status
      */
-    void get_liveliness_lost_status(LivelinessLostStatus& status);
+    void get_liveliness_lost_status(
+            LivelinessLostStatus& status);
 
 private:
 

--- a/include/fastrtps/publisher/Publisher.h
+++ b/include/fastrtps/publisher/Publisher.h
@@ -89,7 +89,7 @@ public:
      * @param sample Pointer to the sample used to retrieve the instance.
      */
     fastrtps::rtps::InstanceHandle_t register_instance(
-            void* sample);
+            void* instance);
 
     /**
      * Dispose of a previously written data.
@@ -103,15 +103,9 @@ public:
      * @param Data Pointer to the data.
      * @return True if correct.
      */
-    bool unregister(
-            void* Data);
-    /**
-     * Dispose and unregister a previously written data.
-     * @param Data Pointer to the data.
-     * @return True if correct.
-     */
-    bool dispose_and_unregister(
-            void* Data);
+    bool unregister_instance(
+            void* instance,
+            const rtps::InstanceHandle_t& handle);
 
     /**
      * Remove all the Changes in the associated RTPSWriter.

--- a/include/fastrtps/publisher/Publisher.h
+++ b/include/fastrtps/publisher/Publisher.h
@@ -97,7 +97,8 @@ public:
      * @return True if correct.
      */
     bool dispose(
-            void* Data);
+            void* data,
+            const rtps::InstanceHandle_t& handle);
     /**
      * Unregister a previously written data.
      * @param Data Pointer to the data.

--- a/include/fastrtps/publisher/PublisherHistory.h
+++ b/include/fastrtps/publisher/PublisherHistory.h
@@ -129,7 +129,7 @@ public:
 
     /*!
      * @brief Checks if the instance's key is registered.
-     * @param[in] Instance's key.
+     * @param[in] handle Instance's key.
      * return `true` if instance's key is registered in the history.
      */
     bool key_is_registered(

--- a/include/fastrtps/publisher/PublisherHistory.h
+++ b/include/fastrtps/publisher/PublisherHistory.h
@@ -105,7 +105,8 @@ public:
             rtps::CacheChange_t* a_change);
 
     bool remove_instance_changes(
-            const rtps::InstanceHandle_t& handle);
+            const rtps::InstanceHandle_t& handle,
+            const rtps::SequenceNumber_t& seq_up_to);
 
     /**
      * @brief Sets the next deadline for the given instance

--- a/include/fastrtps/publisher/PublisherHistory.h
+++ b/include/fastrtps/publisher/PublisherHistory.h
@@ -132,7 +132,7 @@ public:
      * @param[in] handle Instance's key.
      * return `true` if instance's key is registered in the history.
      */
-    bool key_is_registered(
+    bool is_key_registered(
             const rtps::InstanceHandle_t& handle);
 
 private:
@@ -156,7 +156,7 @@ private:
      * @param map_it A map iterator to the given key
      * @return True if the key was found or could be added to the map
      */
-    bool find_key(
+    bool find_or_add_key(
             const rtps::InstanceHandle_t& instance_handle,
             t_m_Inst_Caches::iterator* map_it);
 };

--- a/include/fastrtps/publisher/PublisherHistory.h
+++ b/include/fastrtps/publisher/PublisherHistory.h
@@ -39,6 +39,7 @@ namespace fastrtps {
 class PublisherHistory : public rtps::WriterHistory
 {
 public:
+
     /**
      * Constructor of the PublisherHistory.
      * @param topic_att TopicAttributed
@@ -52,6 +53,18 @@ public:
 
     virtual ~PublisherHistory();
 
+    /*!
+     * @brief Try to reserve resources for the new instance.
+     * @param instance_handle
+     * @param lock
+     * @param max_blocking_time
+     * @return True if resources was reserved successfully.
+     */
+    bool register_instance(
+            const rtps::InstanceHandle_t& instance_handle,
+            std::unique_lock<RecursiveTimedMutex>& lock,
+            std::chrono::time_point<std::chrono::steady_clock> max_blocking_time);
+
     /**
      * Add a change comming from the Publisher.
      * @param change Pointer to the change
@@ -62,7 +75,7 @@ public:
      */
     bool add_pub_change(
             rtps::CacheChange_t* change,
-            rtps::WriteParams &wparams,
+            rtps::WriteParams& wparams,
             std::unique_lock<RecursiveTimedMutex>& lock,
             std::chrono::time_point<std::chrono::steady_clock> max_blocking_time);
 
@@ -71,7 +84,8 @@ public:
      * @param removed Number of elements removed.
      * @return True if all elements were removed.
      */
-    bool removeAllChange(size_t* removed);
+    bool removeAllChange(
+            size_t* removed);
 
     /**
      * Remove the change with the minimum sequence Number.
@@ -84,9 +98,11 @@ public:
      * @param change Pointer to the CacheChange_t.
      * @return True if removed.
      */
-    bool remove_change_pub(rtps::CacheChange_t* change);
+    bool remove_change_pub(
+            rtps::CacheChange_t* change);
 
-    virtual bool remove_change_g(rtps::CacheChange_t* a_change);
+    virtual bool remove_change_g(
+            rtps::CacheChange_t* a_change);
 
     /**
      * @brief Sets the next deadline for the given instance
@@ -125,12 +141,12 @@ private:
 
     /**
      * @brief Method that finds a key in m_keyedChanges or tries to add it if not found
-     * @param a_change The change to get the key from
+     * @param instance_handle Instance of the key.
      * @param map_it A map iterator to the given key
      * @return True if the key was found or could be added to the map
      */
     bool find_key(
-            rtps::CacheChange_t* a_change,
+            const rtps::InstanceHandle_t& instance_handle,
             t_m_Inst_Caches::iterator* map_it);
 };
 

--- a/include/fastrtps/publisher/PublisherHistory.h
+++ b/include/fastrtps/publisher/PublisherHistory.h
@@ -127,6 +127,9 @@ public:
             rtps::InstanceHandle_t& handle,
             std::chrono::steady_clock::time_point& next_deadline_us);
 
+    bool key_is_registered(
+            const rtps::InstanceHandle_t& handle);
+
 private:
 
     typedef std::map<rtps::InstanceHandle_t, KeyedChanges> t_m_Inst_Caches;

--- a/include/fastrtps/publisher/PublisherHistory.h
+++ b/include/fastrtps/publisher/PublisherHistory.h
@@ -54,10 +54,10 @@ public:
     virtual ~PublisherHistory();
 
     /*!
-     * @brief Try to reserve resources for the new instance.
-     * @param instance_handle
-     * @param lock
-     * @param max_blocking_time
+     * @brief Tries to reserve resources for the new instance.
+     * @param instance_handle Instance's key.
+     * @param lock Lock which should be unlock in case the operation has to wait.
+     * @param max_blocking_time Maximum time the operation should be waiting.
      * @return True if resources was reserved successfully.
      */
     bool register_instance(
@@ -127,6 +127,11 @@ public:
             rtps::InstanceHandle_t& handle,
             std::chrono::steady_clock::time_point& next_deadline_us);
 
+    /*!
+     * @brief Checks if the instance's key is registered.
+     * @param[in] Instance's key.
+     * return `true` if instance's key is registered in the history.
+     */
     bool key_is_registered(
             const rtps::InstanceHandle_t& handle);
 

--- a/include/fastrtps/publisher/PublisherHistory.h
+++ b/include/fastrtps/publisher/PublisherHistory.h
@@ -63,7 +63,7 @@ public:
     bool register_instance(
             const rtps::InstanceHandle_t& instance_handle,
             std::unique_lock<RecursiveTimedMutex>& lock,
-            std::chrono::time_point<std::chrono::steady_clock> max_blocking_time);
+            const std::chrono::time_point<std::chrono::steady_clock>& max_blocking_time);
 
     /**
      * Add a change comming from the Publisher.
@@ -77,7 +77,7 @@ public:
             rtps::CacheChange_t* change,
             rtps::WriteParams& wparams,
             std::unique_lock<RecursiveTimedMutex>& lock,
-            std::chrono::time_point<std::chrono::steady_clock> max_blocking_time);
+            const std::chrono::time_point<std::chrono::steady_clock>& max_blocking_time);
 
     /**
      * Remove all change from the associated history.
@@ -103,6 +103,9 @@ public:
 
     virtual bool remove_change_g(
             rtps::CacheChange_t* a_change);
+
+    bool remove_instance_changes(
+            const rtps::InstanceHandle_t& handle);
 
     /**
      * @brief Sets the next deadline for the given instance

--- a/src/cpp/fastdds/publisher/DataWriter.cpp
+++ b/src/cpp/fastdds/publisher/DataWriter.cpp
@@ -22,9 +22,6 @@
 #include <fastdds/dds/publisher/Publisher.hpp>
 
 namespace eprosima {
-
-using namespace fastrtps;
-
 namespace fastdds {
 namespace dds {
 
@@ -69,6 +66,12 @@ ReturnCode_t DataWriter::write(
         const fastrtps::rtps::InstanceHandle_t& handle)
 {
     return impl_->write(data, handle);
+}
+
+fastrtps::rtps::InstanceHandle_t DataWriter::register_instance(
+        void* key)
+{
+    return impl_->register_instance(key);
 }
 
 ReturnCode_t DataWriter::dispose(
@@ -134,7 +137,7 @@ const Publisher* DataWriter::get_publisher() const
 }
 
 ReturnCode_t DataWriter::wait_for_acknowledgments(
-        const Duration_t& max_wait)
+        const fastrtps::Duration_t& max_wait)
 {
     return impl_->wait_for_acknowledgments(max_wait);
 }

--- a/src/cpp/fastdds/publisher/DataWriter.cpp
+++ b/src/cpp/fastdds/publisher/DataWriter.cpp
@@ -85,13 +85,7 @@ ReturnCode_t DataWriter::dispose(
         void* data,
         const fastrtps::rtps::InstanceHandle_t& handle)
 {
-    return impl_->dispose(data, handle);
-}
-
-bool DataWriter::dispose(
-        void* data)
-{
-    return impl_->dispose(data);
+    return impl_->unregister_instance(data, handle, true);
 }
 
 const fastrtps::rtps::GUID_t& DataWriter::guid()

--- a/src/cpp/fastdds/publisher/DataWriter.cpp
+++ b/src/cpp/fastdds/publisher/DataWriter.cpp
@@ -69,9 +69,16 @@ ReturnCode_t DataWriter::write(
 }
 
 fastrtps::rtps::InstanceHandle_t DataWriter::register_instance(
-        void* key)
+        void* instance)
 {
-    return impl_->register_instance(key);
+    return impl_->register_instance(instance);
+}
+
+ReturnCode_t DataWriter::unregister_instance(
+        void* instance,
+        const fastrtps::rtps::InstanceHandle_t& handle)
+{
+    return impl_->unregister_instance(instance, handle);
 }
 
 ReturnCode_t DataWriter::dispose(

--- a/src/cpp/fastdds/publisher/DataWriterImpl.cpp
+++ b/src/cpp/fastdds/publisher/DataWriterImpl.cpp
@@ -309,10 +309,15 @@ ReturnCode_t DataWriterImpl::unregister_instance(
     }
 #endif
 
-    if (history_.key_is_registered(ih))
+    if (history_.is_key_registered(ih))
     {
         WriteParams wparams;
-        ChangeKind_t change_kind = dispose ? NOT_ALIVE_DISPOSED : NOT_ALIVE_UNREGISTERED;
+        ChangeKind_t change_kind = 
+            dispose ?  NOT_ALIVE_DISPOSED : (
+                qos_.writer_data_lifecycle().autodispose_unregistered_instances ?
+                NOT_ALIVE_DISPOSED_UNREGISTERED :
+                NOT_ALIVE_UNREGISTERED
+                );
         if (create_new_change_with_params(change_kind, instance, wparams, ih))
         {
             returned_value = ReturnCode_t::RETCODE_OK;

--- a/src/cpp/fastdds/publisher/DataWriterImpl.cpp
+++ b/src/cpp/fastdds/publisher/DataWriterImpl.cpp
@@ -652,7 +652,7 @@ void DataWriterImpl::InnerDataWriterListener::onWriterChangeReceivedByAll(
             (NOT_ALIVE_UNREGISTERED == ch->kind ||
             NOT_ALIVE_DISPOSED_UNREGISTERED == ch->kind))
     {
-        data_writer_->history_.remove_instance_changes(ch->instanceHandle);
+        data_writer_->history_.remove_instance_changes(ch->instanceHandle, ch->sequenceNumber);
     }
     else if (data_writer_->qos_.durability().kind == VOLATILE_DURABILITY_QOS)
     {

--- a/src/cpp/fastdds/publisher/DataWriterImpl.cpp
+++ b/src/cpp/fastdds/publisher/DataWriterImpl.cpp
@@ -318,6 +318,10 @@ ReturnCode_t DataWriterImpl::unregister_instance(
             returned_value = ReturnCode_t::RETCODE_OK;
         }
     }
+    else
+    {
+        returned_value = ReturnCode_t::RETCODE_PRECONDITION_NOT_MET;
+    }
 
     return returned_value;
 }

--- a/src/cpp/fastdds/publisher/DataWriterImpl.hpp
+++ b/src/cpp/fastdds/publisher/DataWriterImpl.hpp
@@ -116,15 +116,28 @@ public:
             void* data,
             const fastrtps::rtps::InstanceHandle_t& handle);
 
-    /**!
-     * @brief
-     * @param key
-     * @param[out] instance_handle
-     * @return
+    /*!
+     * @brief Implementation of the DDS `register_instance` operation.
+     * It deduces the instance's key and tries to get resources in the PublisherHistory.
+     * @param[in] instance Sample used to get the instance's key.
+     * @return Handle containing the instance's key.
+     * This handle could be used in successive `write` or `dispose` operations.
+     * In case of error, HANDLE_NIL will be returned.
      */
     fastrtps::rtps::InstanceHandle_t register_instance(
             void* instance);
 
+    /*!
+     * @brief Implementation of the DDS `register_instance` and `dispose` operations.
+     * It sends a CacheChange_t  with the king to NOT_ALIVE_UNREGISTERED or NOT_ALIVE_DISPOSED,
+     * depending on the `dispose` parameter.
+     * @param[in] instance Sample used to deduce instance's key in case of `handle` parameter is HANDLE_NIL.
+     * @param[in] handle Instance's key to be unregistered or disposed.
+     * @param[in] dispose If it is `false`, a CacheChange_t with kind to NOT_ALIVE_UNREGISTERED is sent.
+     * If it is `true`, a CacheChange_t with kind to NOT_ALIVE_DISPOSED is sent.
+     * @return Returns the operation's result.
+     * If the operation finishes successfully, ReturnCode_t::RETCODE_OK is returned.
+     */
     ReturnCode_t unregister_instance(
             void* instance,
             const fastrtps::rtps::InstanceHandle_t& handle,

--- a/src/cpp/fastdds/publisher/DataWriterImpl.hpp
+++ b/src/cpp/fastdds/publisher/DataWriterImpl.hpp
@@ -128,7 +128,7 @@ public:
             void* instance);
 
     /*!
-     * @brief Implementation of the DDS `register_instance` and `dispose` operations.
+     * @brief Implementation of the DDS `unregister_instance` and `dispose` operations.
      * It sends a CacheChange_t  with the king to NOT_ALIVE_UNREGISTERED or NOT_ALIVE_DISPOSED,
      * depending on the `dispose` parameter.
      * @param[in] instance Sample used to deduce instance's key in case of `handle` parameter is HANDLE_NIL.

--- a/src/cpp/fastdds/publisher/DataWriterImpl.hpp
+++ b/src/cpp/fastdds/publisher/DataWriterImpl.hpp
@@ -127,7 +127,8 @@ public:
 
     ReturnCode_t unregister_instance(
             void* instance,
-            const fastrtps::rtps::InstanceHandle_t& handle);
+            const fastrtps::rtps::InstanceHandle_t& handle,
+            bool dispose = false);
 
     /**
      *
@@ -173,13 +174,6 @@ public:
             void* key_holder,
             const fastrtps::rtps::InstanceHandle_t& handle);
      */
-
-    ReturnCode_t dispose(
-            void* data,
-            const fastrtps::rtps::InstanceHandle_t& handle);
-
-    bool dispose(
-            void* data);
 
     ReturnCode_t get_liveliness_lost_status(
             LivelinessLostStatus& status);

--- a/src/cpp/fastdds/publisher/DataWriterImpl.hpp
+++ b/src/cpp/fastdds/publisher/DataWriterImpl.hpp
@@ -116,6 +116,15 @@ public:
             void* data,
             const fastrtps::rtps::InstanceHandle_t& handle);
 
+    /**!
+     * @brief
+     * @param key
+     * @param[out] instance_handle
+     * @return
+     */
+    fastrtps::rtps::InstanceHandle_t register_instance(
+            void* key);
+
     /**
      *
      * @return

--- a/src/cpp/fastdds/publisher/DataWriterImpl.hpp
+++ b/src/cpp/fastdds/publisher/DataWriterImpl.hpp
@@ -133,8 +133,10 @@ public:
      * depending on the `dispose` parameter.
      * @param[in] instance Sample used to deduce instance's key in case of `handle` parameter is HANDLE_NIL.
      * @param[in] handle Instance's key to be unregistered or disposed.
-     * @param[in] dispose If it is `false`, a CacheChange_t with kind to NOT_ALIVE_UNREGISTERED is sent.
-     * If it is `true`, a CacheChange_t with kind to NOT_ALIVE_DISPOSED is sent.
+     * @param[in] dispose If it is `false`, a CacheChange_t with kind to NOT_ALIVE_UNREGISTERED is sent, or if
+     * `writer_data_lifecycle.autodispose_unregistered_instances` is `true` then it is sent with kind to
+     * NOT_ALIVE_DISPOSED_UNREGISTERED.
+     * If `dispose` is `true`, a CacheChange_t with kind to NOT_ALIVE_DISPOSED is sent.
      * @return Returns the operation's result.
      * If the operation finishes successfully, ReturnCode_t::RETCODE_OK is returned.
      */

--- a/src/cpp/fastdds/publisher/DataWriterImpl.hpp
+++ b/src/cpp/fastdds/publisher/DataWriterImpl.hpp
@@ -123,7 +123,11 @@ public:
      * @return
      */
     fastrtps::rtps::InstanceHandle_t register_instance(
-            void* key);
+            void* instance);
+
+    ReturnCode_t unregister_instance(
+            void* instance,
+            const fastrtps::rtps::InstanceHandle_t& handle);
 
     /**
      *

--- a/src/cpp/fastdds/publisher/DataWriterImpl.hpp
+++ b/src/cpp/fastdds/publisher/DataWriterImpl.hpp
@@ -129,14 +129,14 @@ public:
 
     /*!
      * @brief Implementation of the DDS `unregister_instance` and `dispose` operations.
-     * It sends a CacheChange_t  with the king to NOT_ALIVE_UNREGISTERED or NOT_ALIVE_DISPOSED,
-     * depending on the `dispose` parameter.
+     * It sends a CacheChange_t with a kind that depends on the `dispose` parameter and
+     * `writer_data_lifecycle` QoS.
      * @param[in] instance Sample used to deduce instance's key in case of `handle` parameter is HANDLE_NIL.
      * @param[in] handle Instance's key to be unregistered or disposed.
-     * @param[in] dispose If it is `false`, a CacheChange_t with kind to NOT_ALIVE_UNREGISTERED is sent, or if
-     * `writer_data_lifecycle.autodispose_unregistered_instances` is `true` then it is sent with kind to
+     * @param[in] dispose If it is `false`, a CacheChange_t with kind set to NOT_ALIVE_UNREGISTERED is sent, or if
+     * `writer_data_lifecycle.autodispose_unregistered_instances` is `true` then it is sent with kind set to
      * NOT_ALIVE_DISPOSED_UNREGISTERED.
-     * If `dispose` is `true`, a CacheChange_t with kind to NOT_ALIVE_DISPOSED is sent.
+     * If `dispose` is `true`, a CacheChange_t with kind set to NOT_ALIVE_DISPOSED is sent.
      * @return Returns the operation's result.
      * If the operation finishes successfully, ReturnCode_t::RETCODE_OK is returned.
      */

--- a/src/cpp/fastrtps_deprecated/publisher/Publisher.cpp
+++ b/src/cpp/fastrtps_deprecated/publisher/Publisher.cpp
@@ -63,23 +63,15 @@ bool Publisher::dispose(
         void* Data)
 {
     logInfo(PUBLISHER, "Disposing of Data");
-    return mp_impl->create_new_change(NOT_ALIVE_DISPOSED, Data);
+    return false; //mp_impl->unregister_instance(Data, true);
 }
 
-bool Publisher::unregister(
-        void* Data)
+bool Publisher::unregister_instance(
+        void* instance,
+        const rtps::InstanceHandle_t& handle)
 {
     //Convert data to serialized Payload
-    logInfo(PUBLISHER, "Unregistering of Data");
-    return mp_impl->create_new_change(NOT_ALIVE_UNREGISTERED, Data);
-}
-
-bool Publisher::dispose_and_unregister(
-        void* Data)
-{
-    //Convert data to serialized Payload
-    logInfo(PUBLISHER, "Disposing and Unregistering Data");
-    return mp_impl->create_new_change(NOT_ALIVE_DISPOSED_UNREGISTERED, Data);
+    return mp_impl->unregister_instance(instance, handle);
 }
 
 bool Publisher::removeAllChange(

--- a/src/cpp/fastrtps_deprecated/publisher/Publisher.cpp
+++ b/src/cpp/fastrtps_deprecated/publisher/Publisher.cpp
@@ -26,53 +26,73 @@
 using namespace eprosima::fastrtps;
 using namespace eprosima::fastrtps::rtps;
 
-Publisher::Publisher(PublisherImpl* pimpl) : mp_impl(pimpl)
+Publisher::Publisher(
+        PublisherImpl* pimpl)
+    : mp_impl(pimpl)
 {
     // TODO Auto-generated constructor stub
 }
 
-Publisher::~Publisher() {
+Publisher::~Publisher()
+{
     // TODO Auto-generated destructor stub
 }
 
-bool Publisher::write(void* Data) {
-    logInfo(PUBLISHER,"Writing new data");
-    return mp_impl->create_new_change(ALIVE,Data);
+bool Publisher::write(
+        void* Data)
+{
+    logInfo(PUBLISHER, "Writing new data");
+    return mp_impl->create_new_change(ALIVE, Data);
 }
 
-bool Publisher::write(void* Data, WriteParams &wparams) {
-    logInfo(PUBLISHER,"Writing new data with WriteParams");
+bool Publisher::write(
+        void* Data,
+        WriteParams& wparams)
+{
+    logInfo(PUBLISHER, "Writing new data with WriteParams");
     return mp_impl->create_new_change_with_params(ALIVE, Data, wparams);
 }
 
-bool Publisher::dispose(void* Data)
+rtps::InstanceHandle_t Publisher::register_instance(
+        void* sample)
 {
-    logInfo(PUBLISHER,"Disposing of Data");
-    return mp_impl->create_new_change(NOT_ALIVE_DISPOSED,Data);
+    return mp_impl->register_instance(sample);
 }
 
-
-bool Publisher::unregister(void* Data) {
-    //Convert data to serialized Payload
-    logInfo(PUBLISHER,"Unregistering of Data");
-    return mp_impl->create_new_change(NOT_ALIVE_UNREGISTERED,Data);
-}
-
-bool Publisher::dispose_and_unregister(void* Data) {
-    //Convert data to serialized Payload
-    logInfo(PUBLISHER,"Disposing and Unregistering Data");
-    return mp_impl->create_new_change(NOT_ALIVE_DISPOSED_UNREGISTERED,Data);
-}
-
-bool Publisher::removeAllChange(size_t* removed )
+bool Publisher::dispose(
+        void* Data)
 {
-    logInfo(PUBLISHER,"Removing all data from history");
+    logInfo(PUBLISHER, "Disposing of Data");
+    return mp_impl->create_new_change(NOT_ALIVE_DISPOSED, Data);
+}
+
+bool Publisher::unregister(
+        void* Data)
+{
+    //Convert data to serialized Payload
+    logInfo(PUBLISHER, "Unregistering of Data");
+    return mp_impl->create_new_change(NOT_ALIVE_UNREGISTERED, Data);
+}
+
+bool Publisher::dispose_and_unregister(
+        void* Data)
+{
+    //Convert data to serialized Payload
+    logInfo(PUBLISHER, "Disposing and Unregistering Data");
+    return mp_impl->create_new_change(NOT_ALIVE_DISPOSED_UNREGISTERED, Data);
+}
+
+bool Publisher::removeAllChange(
+        size_t* removed )
+{
+    logInfo(PUBLISHER, "Removing all data from history");
     return mp_impl->removeAllChange(removed);
 }
 
-bool Publisher::wait_for_all_acked(const eprosima::fastrtps::Duration_t& max_wait)
+bool Publisher::wait_for_all_acked(
+        const eprosima::fastrtps::Duration_t& max_wait)
 {
-    logInfo(PUBLISHER,"Waiting for all samples acknowledged");
+    logInfo(PUBLISHER, "Waiting for all samples acknowledged");
     return mp_impl->wait_for_all_acked(max_wait);
 }
 
@@ -86,17 +106,20 @@ const PublisherAttributes& Publisher::getAttributes() const
     return mp_impl->getAttributes();
 }
 
-bool Publisher::updateAttributes(const PublisherAttributes& att)
+bool Publisher::updateAttributes(
+        const PublisherAttributes& att)
 {
     return mp_impl->updateAttributes(att);
 }
 
-void Publisher::get_offered_deadline_missed_status(OfferedDeadlineMissedStatus &status)
+void Publisher::get_offered_deadline_missed_status(
+        OfferedDeadlineMissedStatus& status)
 {
     mp_impl->get_offered_deadline_missed_status(status);
 }
 
-void Publisher::get_liveliness_lost_status(LivelinessLostStatus &status)
+void Publisher::get_liveliness_lost_status(
+        LivelinessLostStatus& status)
 {
     mp_impl->get_liveliness_lost_status(status);
 }

--- a/src/cpp/fastrtps_deprecated/publisher/Publisher.cpp
+++ b/src/cpp/fastrtps_deprecated/publisher/Publisher.cpp
@@ -60,10 +60,11 @@ rtps::InstanceHandle_t Publisher::register_instance(
 }
 
 bool Publisher::dispose(
-        void* Data)
+        void* data,
+        const rtps::InstanceHandle_t& handle)
 {
     logInfo(PUBLISHER, "Disposing of Data");
-    return false; //mp_impl->unregister_instance(Data, true);
+    return mp_impl->unregister_instance(data, handle, true);
 }
 
 bool Publisher::unregister_instance(

--- a/src/cpp/fastrtps_deprecated/publisher/PublisherHistory.cpp
+++ b/src/cpp/fastrtps_deprecated/publisher/PublisherHistory.cpp
@@ -311,7 +311,8 @@ bool PublisherHistory::remove_instance_changes(
 
     std::lock_guard<RecursiveTimedMutex> guard(*this->mp_mutex);
     t_m_Inst_Caches::iterator vit;
-    if (!this->find_or_add_key(handle, &vit))
+    vit = keyed_changes_.find(handle);
+    if (vit == keyed_changes_.end())
     {
         return false;
     }

--- a/src/cpp/fastrtps_deprecated/publisher/PublisherHistory.cpp
+++ b/src/cpp/fastrtps_deprecated/publisher/PublisherHistory.cpp
@@ -401,3 +401,17 @@ bool PublisherHistory::get_next_deadline(
 
     return false;
 }
+
+bool PublisherHistory::key_is_registered(
+        const InstanceHandle_t& handle)
+{
+    if (mp_writer == nullptr || mp_mutex == nullptr)
+    {
+        logError(RTPS_HISTORY, "You need to create a Writer with this History before using it");
+        return false;
+    }
+    std::lock_guard<RecursiveTimedMutex> guard(*this->mp_mutex);
+    t_m_Inst_Caches::iterator vit;
+    vit = keyed_changes_.find(handle);
+    return (vit != keyed_changes_.end());
+}

--- a/src/cpp/fastrtps_deprecated/publisher/PublisherHistory.cpp
+++ b/src/cpp/fastrtps_deprecated/publisher/PublisherHistory.cpp
@@ -39,17 +39,17 @@ PublisherHistory::PublisherHistory(
         uint32_t payloadMaxSize,
         MemoryManagementPolicy_t mempolicy)
     : WriterHistory(HistoryAttributes(mempolicy, payloadMaxSize,
-            topic_att.historyQos.kind == KEEP_ALL_HISTORY_QOS ?
-            topic_att.resourceLimitsQos.allocated_samples :
-            topic_att.getTopicKind() == NO_KEY ?
-            std::min(topic_att.resourceLimitsQos.allocated_samples, topic_att.historyQos.depth) :
-            std::min(topic_att.resourceLimitsQos.allocated_samples, topic_att.historyQos.depth
-            * topic_att.resourceLimitsQos.max_instances),
-            topic_att.historyQos.kind == KEEP_ALL_HISTORY_QOS ?
-            topic_att.resourceLimitsQos.max_samples :
-            topic_att.getTopicKind() == NO_KEY ?
-            topic_att.historyQos.depth :
-            topic_att.historyQos.depth * topic_att.resourceLimitsQos.max_instances))
+                topic_att.historyQos.kind == KEEP_ALL_HISTORY_QOS ?
+                        topic_att.resourceLimitsQos.allocated_samples :
+                        topic_att.getTopicKind() == NO_KEY ?
+                            std::min(topic_att.resourceLimitsQos.allocated_samples, topic_att.historyQos.depth) :
+                            std::min(topic_att.resourceLimitsQos.allocated_samples, topic_att.historyQos.depth
+                                     * topic_att.resourceLimitsQos.max_instances),
+                topic_att.historyQos.kind == KEEP_ALL_HISTORY_QOS ?
+                        topic_att.resourceLimitsQos.max_samples :
+                        topic_att.getTopicKind() == NO_KEY ?
+                            topic_att.historyQos.depth :
+                            topic_att.historyQos.depth * topic_att.resourceLimitsQos.max_instances))
     , history_qos_(topic_att.historyQos)
     , resource_limited_qos_(topic_att.resourceLimitsQos)
     , topic_att_(topic_att)
@@ -74,7 +74,7 @@ bool PublisherHistory::register_instance(
     }
 
     t_m_Inst_Caches::iterator vit;
-    return find_key(instance_handle, &vit);
+    return find_or_add_key(instance_handle, &vit);
 }
 
 bool PublisherHistory::add_pub_change(
@@ -123,7 +123,7 @@ bool PublisherHistory::add_pub_change(
     else if (topic_att_.getTopicKind() == WITH_KEY)
     {
         t_m_Inst_Caches::iterator vit;
-        if (find_key(change->instanceHandle, &vit))
+        if (find_or_add_key(change->instanceHandle, &vit))
         {
             logInfo(RTPS_HISTORY, "Found key: " << vit->first);
             bool add = false;
@@ -177,7 +177,7 @@ bool PublisherHistory::add_pub_change(
     return returnedValue;
 }
 
-bool PublisherHistory::find_key(
+bool PublisherHistory::find_or_add_key(
         const InstanceHandle_t& instance_handle,
         t_m_Inst_Caches::iterator* vit_out)
 {
@@ -267,7 +267,7 @@ bool PublisherHistory::remove_change_pub(
     else
     {
         t_m_Inst_Caches::iterator vit;
-        if (!this->find_key(change->instanceHandle, &vit))
+        if (!this->find_or_add_key(change->instanceHandle, &vit))
         {
             return false;
         }
@@ -312,7 +312,7 @@ bool PublisherHistory::remove_instance_changes(
 
     std::lock_guard<RecursiveTimedMutex> guard(*this->mp_mutex);
     t_m_Inst_Caches::iterator vit;
-    if (!this->find_key(handle, &vit))
+    if (!this->find_or_add_key(handle, &vit))
     {
         return false;
     }
@@ -397,7 +397,7 @@ bool PublisherHistory::get_next_deadline(
     return false;
 }
 
-bool PublisherHistory::key_is_registered(
+bool PublisherHistory::is_key_registered(
         const InstanceHandle_t& handle)
 {
     if (mp_writer == nullptr || mp_mutex == nullptr)

--- a/src/cpp/fastrtps_deprecated/publisher/PublisherHistory.cpp
+++ b/src/cpp/fastrtps_deprecated/publisher/PublisherHistory.cpp
@@ -39,17 +39,17 @@ PublisherHistory::PublisherHistory(
         uint32_t payloadMaxSize,
         MemoryManagementPolicy_t mempolicy)
     : WriterHistory(HistoryAttributes(mempolicy, payloadMaxSize,
-                topic_att.historyQos.kind == KEEP_ALL_HISTORY_QOS ?
-                        topic_att.resourceLimitsQos.allocated_samples :
-                        topic_att.getTopicKind() == NO_KEY ?
-                            std::min(topic_att.resourceLimitsQos.allocated_samples, topic_att.historyQos.depth) :
-                            std::min(topic_att.resourceLimitsQos.allocated_samples, topic_att.historyQos.depth
-                                     * topic_att.resourceLimitsQos.max_instances),
-                topic_att.historyQos.kind == KEEP_ALL_HISTORY_QOS ?
-                        topic_att.resourceLimitsQos.max_samples :
-                        topic_att.getTopicKind() == NO_KEY ?
-                            topic_att.historyQos.depth :
-                            topic_att.historyQos.depth * topic_att.resourceLimitsQos.max_instances))
+            topic_att.historyQos.kind == KEEP_ALL_HISTORY_QOS ?
+            topic_att.resourceLimitsQos.allocated_samples :
+            topic_att.getTopicKind() == NO_KEY ?
+            std::min(topic_att.resourceLimitsQos.allocated_samples, topic_att.historyQos.depth) :
+            std::min(topic_att.resourceLimitsQos.allocated_samples, topic_att.historyQos.depth
+            * topic_att.resourceLimitsQos.max_instances),
+            topic_att.historyQos.kind == KEEP_ALL_HISTORY_QOS ?
+            topic_att.resourceLimitsQos.max_samples :
+            topic_att.getTopicKind() == NO_KEY ?
+            topic_att.historyQos.depth :
+            topic_att.historyQos.depth * topic_att.resourceLimitsQos.max_instances))
     , history_qos_(topic_att.historyQos)
     , resource_limited_qos_(topic_att.resourceLimitsQos)
     , topic_att_(topic_att)
@@ -58,6 +58,28 @@ PublisherHistory::PublisherHistory(
 
 PublisherHistory::~PublisherHistory()
 {
+}
+
+bool PublisherHistory::register_instance(
+        const InstanceHandle_t& instance_handle,
+        std::unique_lock<RecursiveTimedMutex>& lock,
+        std::chrono::time_point<std::chrono::steady_clock> max_blocking_time)
+{
+    bool returned_value = false;
+
+    /// Preconditions
+    if (topic_att_.getTopicKind() == NO_KEY)
+    {
+        return false;
+    }
+
+    t_m_Inst_Caches::iterator vit;
+    if (find_key(instance_handle, &vit))
+    {
+        returned_value = true;
+    }
+
+    return returned_value;
 }
 
 bool PublisherHistory::add_pub_change(
@@ -106,7 +128,7 @@ bool PublisherHistory::add_pub_change(
     else if (topic_att_.getTopicKind() == WITH_KEY)
     {
         t_m_Inst_Caches::iterator vit;
-        if (find_key(change, &vit))
+        if (find_key(change->instanceHandle, &vit))
         {
             logInfo(RTPS_HISTORY, "Found key: " << vit->first);
             bool add = false;
@@ -147,7 +169,7 @@ bool PublisherHistory::add_pub_change(
 #endif
                 {
                     logInfo(RTPS_HISTORY,
-                            topic_att_.getTopicDataType() 
+                            topic_att_.getTopicDataType()
                             << " Change " << change->sequenceNumber << " added with key: " << change->instanceHandle
                             << " and " << change->serializedPayload.length << " bytes");
                     returnedValue =  true;
@@ -161,11 +183,11 @@ bool PublisherHistory::add_pub_change(
 }
 
 bool PublisherHistory::find_key(
-        CacheChange_t* a_change,
+        const InstanceHandle_t& instance_handle,
         t_m_Inst_Caches::iterator* vit_out)
 {
     t_m_Inst_Caches::iterator vit;
-    vit = keyed_changes_.find(a_change->instanceHandle);
+    vit = keyed_changes_.find(instance_handle);
     if (vit != keyed_changes_.end())
     {
         *vit_out = vit;
@@ -174,22 +196,10 @@ bool PublisherHistory::find_key(
 
     if (static_cast<int>(keyed_changes_.size()) < resource_limited_qos_.max_instances)
     {
-        *vit_out = keyed_changes_.insert(std::make_pair(a_change->instanceHandle, KeyedChanges())).first;
+        *vit_out = keyed_changes_.insert(std::make_pair(instance_handle, KeyedChanges())).first;
         return true;
     }
-    else
-    {
-        for (vit = keyed_changes_.begin(); vit != keyed_changes_.end(); ++vit)
-        {
-            if (vit->second.cache_changes.size() == 0)
-            {
-                keyed_changes_.erase(vit);
-                *vit_out = keyed_changes_.insert(std::make_pair(a_change->instanceHandle, KeyedChanges())).first;
-                return true;
-            }
-        }
-        logWarning(PUBLISHER, "History has reached the maximum number of instances");
-    }
+
     return false;
 }
 
@@ -262,7 +272,7 @@ bool PublisherHistory::remove_change_pub(
     else
     {
         t_m_Inst_Caches::iterator vit;
-        if (!this->find_key(change, &vit))
+        if (!this->find_key(change->instanceHandle, &vit))
         {
             return false;
         }
@@ -337,11 +347,11 @@ bool PublisherHistory::get_next_deadline(
             keyed_changes_.begin(),
             keyed_changes_.end(),
             [](
-                    const std::pair<InstanceHandle_t, KeyedChanges>& lhs,
-                    const std::pair<InstanceHandle_t, KeyedChanges>& rhs)
-            {
-                return lhs.second.next_deadline_us < rhs.second.next_deadline_us;
-            });
+                const std::pair<InstanceHandle_t, KeyedChanges>& lhs,
+                const std::pair<InstanceHandle_t, KeyedChanges>& rhs)
+        {
+            return lhs.second.next_deadline_us < rhs.second.next_deadline_us;
+        });
 
         handle = min->first;
         next_deadline_us = min->second.next_deadline_us;

--- a/src/cpp/fastrtps_deprecated/publisher/PublisherHistory.cpp
+++ b/src/cpp/fastrtps_deprecated/publisher/PublisherHistory.cpp
@@ -74,12 +74,7 @@ bool PublisherHistory::register_instance(
     }
 
     t_m_Inst_Caches::iterator vit;
-    if (find_key(instance_handle, &vit))
-    {
-        returned_value = true;
-    }
-
-    return returned_value;
+    return find_key(instance_handle, &vit);
 }
 
 bool PublisherHistory::add_pub_change(

--- a/src/cpp/fastrtps_deprecated/publisher/PublisherImpl.cpp
+++ b/src/cpp/fastrtps_deprecated/publisher/PublisherImpl.cpp
@@ -494,7 +494,7 @@ void PublisherImpl::PublisherWriterListener::onWriterChangeReceivedByAll(
             (NOT_ALIVE_UNREGISTERED == ch->kind ||
             NOT_ALIVE_DISPOSED_UNREGISTERED == ch->kind))
     {
-        mp_publisherImpl->m_history.remove_instance_changes(ch->instanceHandle);
+        mp_publisherImpl->m_history.remove_instance_changes(ch->instanceHandle, ch->sequenceNumber);
     }
     else if (mp_publisherImpl->m_att.qos.m_durability.kind == VOLATILE_DURABILITY_QOS)
     {

--- a/src/cpp/fastrtps_deprecated/publisher/PublisherImpl.cpp
+++ b/src/cpp/fastrtps_deprecated/publisher/PublisherImpl.cpp
@@ -337,7 +337,7 @@ bool PublisherImpl::unregister_instance(
     }
 #endif
 
-    if (m_history.key_is_registered(ih))
+    if (m_history.is_key_registered(ih))
     {
         WriteParams wparams;
         ChangeKind_t change_kind = dispose ? NOT_ALIVE_DISPOSED : NOT_ALIVE_UNREGISTERED;

--- a/src/cpp/fastrtps_deprecated/publisher/PublisherImpl.cpp
+++ b/src/cpp/fastrtps_deprecated/publisher/PublisherImpl.cpp
@@ -73,18 +73,18 @@ PublisherImpl::PublisherImpl(
     , lifespan_duration_us_(m_att.qos.m_lifespan.duration.to_ns() * 1e-3)
 {
     deadline_timer_ = new TimedEvent(mp_participant->get_resource_event(),
-            [&]() -> bool
-            {
-                return deadline_missed();
-            },
-            att.qos.m_deadline.period.to_ns() * 1e-6);
+                    [&]() -> bool
+    {
+        return deadline_missed();
+    },
+                    att.qos.m_deadline.period.to_ns() * 1e-6);
 
     lifespan_timer_ = new TimedEvent(mp_participant->get_resource_event(),
-            [&]() -> bool
-            {
-                return lifespan_expired();
-            },
-            m_att.qos.m_lifespan.duration.to_ns() * 1e-6);
+                    [&]() -> bool
+    {
+        return lifespan_expired();
+    },
+                    m_att.qos.m_lifespan.duration.to_ns() * 1e-6);
 }
 
 PublisherImpl::~PublisherImpl()
@@ -114,7 +114,6 @@ bool PublisherImpl::create_new_change_with_params(
         void* data,
         WriteParams& wparams)
 {
-
     /// Preconditions
     if (data == nullptr)
     {
@@ -200,7 +199,7 @@ bool PublisherImpl::create_new_change_with_params(
                 // Fragment the data.
                 // Set the fragment size to the cachechange.
                 ch->setFragmentSize(static_cast<uint16_t>(
-                    (std::min)(final_high_mark_for_frag, RTPSMessageGroup::get_max_fragment_payload_size())));
+                            (std::min)(final_high_mark_for_frag, RTPSMessageGroup::get_max_fragment_payload_size())));
             }
 
             InstanceHandle_t change_handle = ch->instanceHandle;
@@ -244,6 +243,49 @@ bool PublisherImpl::create_new_change_with_params(
     }
 
     return false;
+}
+
+InstanceHandle_t PublisherImpl::register_instance(
+        void* sample)
+{
+    /// Preconditions
+    if (sample == nullptr)
+    {
+        logError(PUBLISHER, "Data pointer not valid");
+        return c_InstanceHandle_Unknown;
+    }
+
+    if (m_att.topic.topicKind == NO_KEY)
+    {
+        logError(PUBLISHER, "Topic is NO_KEY, operation not permitted");
+        return c_InstanceHandle_Unknown;
+    }
+
+    InstanceHandle_t instance_handle = c_InstanceHandle_Unknown;
+    bool is_key_protected = false;
+#if HAVE_SECURITY
+    is_key_protected = mp_writer->getAttributes().security_attributes().is_key_protected;
+#endif
+    mp_type->getKey(sample, &instance_handle, is_key_protected);
+
+    // Block lowlevel writer
+    auto max_blocking_time = std::chrono::steady_clock::now() +
+            std::chrono::microseconds(::TimeConv::Time_t2MicroSecondsInt64(m_att.qos.m_reliability.max_blocking_time));
+
+#if HAVE_STRICT_REALTIME
+    std::unique_lock<RecursiveTimedMutex> lock(mp_writer->getMutex(), std::defer_lock);
+    if (lock.try_lock_until(max_blocking_time))
+#else
+    std::unique_lock<RecursiveTimedMutex> lock(mp_writer->getMutex());
+#endif
+    {
+        if (m_history.register_instance(instance_handle, lock, max_blocking_time))
+        {
+            return instance_handle;
+        }
+    }
+
+    return c_InstanceHandle_Unknown;
 }
 
 bool PublisherImpl::removeMinSeqChange()

--- a/src/cpp/fastrtps_deprecated/publisher/PublisherImpl.cpp
+++ b/src/cpp/fastrtps_deprecated/publisher/PublisherImpl.cpp
@@ -318,7 +318,9 @@ bool PublisherImpl::unregister_instance(
     bool returned_value = false;
     InstanceHandle_t ih = handle;
 
+#if !defined(NDEBUG)
     if (c_InstanceHandle_Unknown == ih)
+#endif
     {
         bool is_key_protected = false;
 #if HAVE_SECURITY
@@ -326,6 +328,14 @@ bool PublisherImpl::unregister_instance(
 #endif
         mp_type->getKey(instance, &ih, is_key_protected);
     }
+
+#if !defined(NDEBUG)
+    if (c_InstanceHandle_Unknown != handle && ih != handle)
+    {
+        logError(PUBLISHER, "handle differs from data's key.");
+        return false;
+    }
+#endif
 
     if (m_history.key_is_registered(ih))
     {
@@ -481,7 +491,8 @@ void PublisherImpl::PublisherWriterListener::onWriterChangeReceivedByAll(
         CacheChange_t* ch)
 {
     if (mp_publisherImpl->m_att.topic.topicKind == WITH_KEY &&
-            ch->kind != ALIVE)
+            (NOT_ALIVE_UNREGISTERED == ch->kind ||
+            NOT_ALIVE_DISPOSED_UNREGISTERED == ch->kind))
     {
         mp_publisherImpl->m_history.remove_instance_changes(ch->instanceHandle);
     }

--- a/src/cpp/fastrtps_deprecated/publisher/PublisherImpl.h
+++ b/src/cpp/fastrtps_deprecated/publisher/PublisherImpl.h
@@ -92,6 +92,12 @@ public:
             void* Data,
             rtps::WriteParams& wparams);
 
+    bool create_new_change_with_params(
+            rtps::ChangeKind_t kind,
+            void* Data,
+            rtps::WriteParams& wparams,
+            const rtps::InstanceHandle_t& handle);
+
     /*!
      * @param key
      * @return
@@ -107,7 +113,8 @@ public:
      */
     bool unregister_instance(
             void* instance,
-            const rtps::InstanceHandle_t& handle);
+            const rtps::InstanceHandle_t& handle,
+            bool dispose = false);
 
     /**
      * Removes the cache change with the minimum sequence number

--- a/src/cpp/fastrtps_deprecated/publisher/PublisherImpl.h
+++ b/src/cpp/fastrtps_deprecated/publisher/PublisherImpl.h
@@ -93,11 +93,21 @@ public:
             rtps::WriteParams& wparams);
 
     /*!
-     * @param sample
+     * @param key
      * @return
      */
     rtps::InstanceHandle_t register_instance(
-            void* sample);
+            void* instance);
+
+    /*!
+     * @param key
+     * @param instance_handle
+     * @param dispose
+     * @return
+     */
+    bool unregister_instance(
+            void* instance,
+            const rtps::InstanceHandle_t& handle);
 
     /**
      * Removes the cache change with the minimum sequence number

--- a/src/cpp/fastrtps_deprecated/publisher/PublisherImpl.h
+++ b/src/cpp/fastrtps_deprecated/publisher/PublisherImpl.h
@@ -35,9 +35,8 @@
 #include <fastdds/dds/topic/TopicDataType.hpp>
 
 namespace eprosima {
-namespace fastrtps{
-namespace rtps
-{
+namespace fastrtps {
+namespace rtps {
 class RTPSWriter;
 class RTPSParticipant;
 class TimedEvent;
@@ -56,17 +55,18 @@ class Publisher;
 class PublisherImpl
 {
     friend class ParticipantImpl;
-    public:
+
+public:
 
     /**
      * Create a publisher, assigning its pointer to the associated writer.
      * Don't use directly, create Publisher using DomainRTPSParticipant static function.
      */
     PublisherImpl(
-        ParticipantImpl* p,
-        fastdds::dds::TopicDataType* ptype,
-        const PublisherAttributes& att,
-        PublisherListener* p_listen = nullptr);
+            ParticipantImpl* p,
+            fastdds::dds::TopicDataType* ptype,
+            const PublisherAttributes& att,
+            PublisherListener* p_listen = nullptr);
 
     virtual ~PublisherImpl();
 
@@ -77,8 +77,8 @@ class PublisherImpl
      * @return
      */
     bool create_new_change(
-        rtps::ChangeKind_t kind,
-        void* Data);
+            rtps::ChangeKind_t kind,
+            void* Data);
 
     /**
      *
@@ -88,9 +88,16 @@ class PublisherImpl
      * @return
      */
     bool create_new_change_with_params(
-        rtps::ChangeKind_t kind,
-        void* Data,
-        rtps::WriteParams& wparams);
+            rtps::ChangeKind_t kind,
+            void* Data,
+            rtps::WriteParams& wparams);
+
+    /*!
+     * @param sample
+     * @return
+     */
+    rtps::InstanceHandle_t register_instance(
+            void* sample);
 
     /**
      * Removes the cache change with the minimum sequence number
@@ -102,7 +109,8 @@ class PublisherImpl
      * @param[out] removed Number of removed elements
      * @return True if correct.
      */
-    bool removeAllChange(size_t* removed);
+    bool removeAllChange(
+            size_t* removed);
 
     /**
      *
@@ -115,40 +123,51 @@ class PublisherImpl
      * @param att Reference to a PublisherAttributes object to update the parameters;
      * @return True if correctly updated, false if ANY of the updated parameters cannot be updated
      */
-    bool updateAttributes(const PublisherAttributes& att);
+    bool updateAttributes(
+            const PublisherAttributes& att);
 
     /**
      * Get the Attributes of the Subscriber.
      * @return Attributes of the Subscriber.
      */
-    inline const PublisherAttributes& getAttributes(){ return m_att; };
+    inline const PublisherAttributes& getAttributes()
+    {
+        return m_att;
+    }
 
     /**
      * Get topic data type
      * @return Topic data type
      */
-    fastdds::dds::TopicDataType* getType() {return mp_type;};
+    fastdds::dds::TopicDataType* getType()
+    {
+        return mp_type;
+    }
 
-    bool wait_for_all_acked(const Duration_t& max_wait);
+    bool wait_for_all_acked(
+            const Duration_t& max_wait);
 
     /**
      * @brief Returns the offered deadline missed status
      * @param Deadline missed status struct
      */
-    void get_offered_deadline_missed_status(OfferedDeadlineMissedStatus& status);
+    void get_offered_deadline_missed_status(
+            OfferedDeadlineMissedStatus& status);
 
     /**
      * @brief Returns the liveliness lost status
      * @param status Liveliness lost status
      */
-    void get_liveliness_lost_status(LivelinessLostStatus& status);
+    void get_liveliness_lost_status(
+            LivelinessLostStatus& status);
 
     /**
      * @brief Asserts liveliness
      */
     void assert_liveliness();
 
-    private:
+private:
+
     ParticipantImpl* mp_participant;
     //! Pointer to the associated Data Writer.
     rtps::RTPSWriter* mp_writer;
@@ -161,23 +180,32 @@ class PublisherImpl
     //!PublisherListener
     PublisherListener* mp_listener;
     //!Listener to capture the events of the Writer
-    class PublisherWriterListener: public rtps::WriterListener
+    class PublisherWriterListener : public rtps::WriterListener
     {
-        public:
-            PublisherWriterListener(PublisherImpl* p):mp_publisherImpl(p){};
-            virtual ~PublisherWriterListener(){};
-            void onWriterMatched(
-                    rtps::RTPSWriter* writer,
-                    rtps::MatchingInfo& info) override;
-            void onWriterChangeReceivedByAll(
-                    rtps::RTPSWriter* writer,
-                    rtps::CacheChange_t* change) override;
-            void on_liveliness_lost(
-                    rtps::RTPSWriter* writer,
-                    const LivelinessLostStatus& status) override;
+public:
 
-            PublisherImpl* mp_publisherImpl;
-    }m_writerListener;
+        PublisherWriterListener(
+                PublisherImpl* p)
+            : mp_publisherImpl(p)
+        {
+        }
+
+        virtual ~PublisherWriterListener()
+        {
+        }
+
+        void onWriterMatched(
+                rtps::RTPSWriter* writer,
+                rtps::MatchingInfo& info) override;
+        void onWriterChangeReceivedByAll(
+                rtps::RTPSWriter* writer,
+                rtps::CacheChange_t* change) override;
+        void on_liveliness_lost(
+                rtps::RTPSWriter* writer,
+                const LivelinessLostStatus& status) override;
+
+        PublisherImpl* mp_publisherImpl;
+    } m_writerListener;
 
     Publisher* mp_userPublisher;
 
@@ -188,7 +216,7 @@ class PublisherImpl
     //! A timer used to check for deadlines
     rtps::TimedEvent* deadline_timer_;
     //! Deadline duration in microseconds
-    std::chrono::duration<double, std::ratio<1,1000000>> deadline_duration_us_;
+    std::chrono::duration<double, std::ratio<1, 1000000> > deadline_duration_us_;
     //! The current timer owner, i.e. the instance which started the deadline timer
     rtps::InstanceHandle_t timer_owner_;
     //! The offered deadline missed status
@@ -197,7 +225,7 @@ class PublisherImpl
     //! A timed callback to remove expired samples for lifespan QoS
     rtps::TimedEvent* lifespan_timer_;
     //! The lifespan duration, in microseconds
-    std::chrono::duration<double, std::ratio<1, 1000000>> lifespan_duration_us_;
+    std::chrono::duration<double, std::ratio<1, 1000000> > lifespan_duration_us_;
 
     /**
      * @brief A method called when an instance misses the deadline

--- a/src/cpp/fastrtps_deprecated/publisher/PublisherImpl.h
+++ b/src/cpp/fastrtps_deprecated/publisher/PublisherImpl.h
@@ -99,17 +99,26 @@ public:
             const rtps::InstanceHandle_t& handle);
 
     /*!
-     * @param key
-     * @return
+     * @brief Implementation of the DDS `register_instance` operation.
+     * It deduces the instance's key and tries to get resources in the PublisherHistory.
+     * @param[in] instance Sample used to get the instance's key.
+     * @return Handle containing the instance's key.
+     * This handle could be used in successive `write` or `dispose` operations.
+     * In case of error, HANDLE_NIL will be returned.
      */
     rtps::InstanceHandle_t register_instance(
             void* instance);
 
     /*!
-     * @param key
-     * @param instance_handle
-     * @param dispose
-     * @return
+     * @brief Implementation of the DDS `register_instance` and `dispose` operations.
+     * It sends a CacheChange_t  with the king to NOT_ALIVE_UNREGISTERED or NOT_ALIVE_DISPOSED,
+     * depending on the `dispose` parameter.
+     * @param[in] instance Sample used to deduce instance's key in case of `handle` parameter is HANDLE_NIL.
+     * @param[in] handle Instance's key to be unregistered or disposed.
+     * @param[in] dispose If it is `false`, a CacheChange_t with kind to NOT_ALIVE_UNREGISTERED is sent.
+     * If it is `true`, a CacheChange_t with kind to NOT_ALIVE_DISPOSED is sent.
+     * @return Returns the operation's result.
+     * If the operation finishes successfully, `true` is returned.
      */
     bool unregister_instance(
             void* instance,

--- a/src/cpp/fastrtps_deprecated/subscriber/SubscriberHistory.cpp
+++ b/src/cpp/fastrtps_deprecated/subscriber/SubscriberHistory.cpp
@@ -57,17 +57,17 @@ SubscriberHistory::SubscriberHistory(
         uint32_t payloadMaxSize,
         MemoryManagementPolicy_t mempolicy)
     : ReaderHistory(HistoryAttributes(mempolicy, payloadMaxSize,
-            topic_att.historyQos.kind == KEEP_ALL_HISTORY_QOS ?
-            topic_att.resourceLimitsQos.allocated_samples :
-            topic_att.getTopicKind() == NO_KEY ?
-            std::min(topic_att.resourceLimitsQos.allocated_samples, topic_att.historyQos.depth) :
-            std::min(topic_att.resourceLimitsQos.allocated_samples, topic_att.historyQos.depth
-            * topic_att.resourceLimitsQos.max_instances),
-            topic_att.historyQos.kind == KEEP_ALL_HISTORY_QOS ?
-            topic_att.resourceLimitsQos.max_samples :
-            topic_att.getTopicKind() == NO_KEY ?
-            topic_att.historyQos.depth :
-            topic_att.historyQos.depth * topic_att.resourceLimitsQos.max_instances))
+                topic_att.historyQos.kind == KEEP_ALL_HISTORY_QOS ?
+                        topic_att.resourceLimitsQos.allocated_samples :
+                        topic_att.getTopicKind() == NO_KEY ?
+                            std::min(topic_att.resourceLimitsQos.allocated_samples, topic_att.historyQos.depth) :
+                            std::min(topic_att.resourceLimitsQos.allocated_samples, topic_att.historyQos.depth
+                                     * topic_att.resourceLimitsQos.max_instances),
+                topic_att.historyQos.kind == KEEP_ALL_HISTORY_QOS ?
+                        topic_att.resourceLimitsQos.max_samples :
+                        topic_att.getTopicKind() == NO_KEY ?
+                            topic_att.historyQos.depth :
+                            topic_att.historyQos.depth * topic_att.resourceLimitsQos.max_instances))
     , history_qos_(topic_att.historyQos)
     , resource_limited_qos_(topic_att.resourceLimitsQos)
     , topic_att_(topic_att)
@@ -314,8 +314,8 @@ bool SubscriberHistory::deserialize_change(
     if (info != nullptr)
     {
         if (topic_att_.topicKind == WITH_KEY &&
-                change->instanceHandle == c_InstanceHandle_Unknown &&
-                change->kind == ALIVE)
+            change->instanceHandle == c_InstanceHandle_Unknown &&
+            change->kind == ALIVE)
         {
             bool is_key_protected = false;
 #if HAVE_SECURITY

--- a/src/cpp/fastrtps_deprecated/subscriber/SubscriberHistory.cpp
+++ b/src/cpp/fastrtps_deprecated/subscriber/SubscriberHistory.cpp
@@ -57,17 +57,17 @@ SubscriberHistory::SubscriberHistory(
         uint32_t payloadMaxSize,
         MemoryManagementPolicy_t mempolicy)
     : ReaderHistory(HistoryAttributes(mempolicy, payloadMaxSize,
-                topic_att.historyQos.kind == KEEP_ALL_HISTORY_QOS ?
-                        topic_att.resourceLimitsQos.allocated_samples :
-                        topic_att.getTopicKind() == NO_KEY ?
-                            std::min(topic_att.resourceLimitsQos.allocated_samples, topic_att.historyQos.depth) :
-                            std::min(topic_att.resourceLimitsQos.allocated_samples, topic_att.historyQos.depth
-                                     * topic_att.resourceLimitsQos.max_instances),
-                topic_att.historyQos.kind == KEEP_ALL_HISTORY_QOS ?
-                        topic_att.resourceLimitsQos.max_samples :
-                        topic_att.getTopicKind() == NO_KEY ?
-                            topic_att.historyQos.depth :
-                            topic_att.historyQos.depth * topic_att.resourceLimitsQos.max_instances))
+            topic_att.historyQos.kind == KEEP_ALL_HISTORY_QOS ?
+            topic_att.resourceLimitsQos.allocated_samples :
+            topic_att.getTopicKind() == NO_KEY ?
+            std::min(topic_att.resourceLimitsQos.allocated_samples, topic_att.historyQos.depth) :
+            std::min(topic_att.resourceLimitsQos.allocated_samples, topic_att.historyQos.depth
+            * topic_att.resourceLimitsQos.max_instances),
+            topic_att.historyQos.kind == KEEP_ALL_HISTORY_QOS ?
+            topic_att.resourceLimitsQos.max_samples :
+            topic_att.getTopicKind() == NO_KEY ?
+            topic_att.historyQos.depth :
+            topic_att.historyQos.depth * topic_att.resourceLimitsQos.max_instances))
     , history_qos_(topic_att.historyQos)
     , resource_limited_qos_(topic_att.resourceLimitsQos)
     , topic_att_(topic_att)
@@ -314,8 +314,8 @@ bool SubscriberHistory::deserialize_change(
     if (info != nullptr)
     {
         if (topic_att_.topicKind == WITH_KEY &&
-            change->instanceHandle == c_InstanceHandle_Unknown &&
-            change->kind == ALIVE)
+                change->instanceHandle == c_InstanceHandle_Unknown &&
+                change->kind == ALIVE)
         {
             bool is_key_protected = false;
 #if HAVE_SECURITY

--- a/src/cpp/rtps/writer/StatefulWriter.cpp
+++ b/src/cpp/rtps/writer/StatefulWriter.cpp
@@ -73,7 +73,7 @@ bool send_data_or_fragments(
             else
             {
                 logError(RTPS_WRITER, "Error sending fragment ("
-                    << change->sequenceNumber << ", " << frag << ")");
+                        << change->sequenceNumber << ", " << frag << ")");
                 break;
             }
         }
@@ -93,7 +93,7 @@ bool send_data_or_fragments(
 
     return sent_ok;
 }
-    
+
 static void null_sent_fun(
         FragmentNumber_t /*frag*/)
 {
@@ -133,25 +133,25 @@ StatefulWriter::StatefulWriter(
     const RTPSParticipantAttributes& part_att = pimpl->getRTPSParticipantAttributes();
 
     periodic_hb_event_ = new TimedEvent(pimpl->getEventResource(), [&]() -> bool
-            {
-                return send_periodic_heartbeat();
-            },
-            TimeConv::Time_t2MilliSecondsDouble(m_times.heartbeatPeriod));
+                {
+                    return send_periodic_heartbeat();
+                },
+                    TimeConv::Time_t2MilliSecondsDouble(m_times.heartbeatPeriod));
 
     nack_response_event_ = new TimedEvent(pimpl->getEventResource(), [&]() -> bool
-            {
-                perform_nack_response();
-                return false;
-            },
-            TimeConv::Time_t2MilliSecondsDouble(m_times.nackResponseDelay));
+                {
+                    perform_nack_response();
+                    return false;
+                },
+                    TimeConv::Time_t2MilliSecondsDouble(m_times.nackResponseDelay));
 
     if (disable_positive_acks_)
     {
         ack_event_ = new TimedEvent(pimpl->getEventResource(), [&]() -> bool
-                {
+                    {
                         return ack_timer_expired();
-                },
-                att.keep_duration.to_ns() * 1e-6); // in milliseconds
+                    },
+                        att.keep_duration.to_ns() * 1e-6); // in milliseconds
     }
 
     for (size_t n = 0; n < att.matched_readers_allocation.initial; ++n)
@@ -281,23 +281,23 @@ void StatefulWriter::unsent_change_added_to_history(
                         RTPSMessageGroup group(mp_RTPSParticipant, this, *this, max_blocking_time);
 
                         auto sent_fun = [this, change](
-                                FragmentNumber_t frag)
-                        {
-                            if (frag > 0)
-                            {
-                                for (ReaderProxy* it : matched_readers_)
+                            FragmentNumber_t frag)
                                 {
-                                    if (!it->is_local_reader())
+                                    if (frag > 0)
                                     {
-                                        bool allFragmentsSent = false;
-                                        it->mark_fragment_as_sent_for_change(
-                                            change->sequenceNumber,
-                                            frag,
-                                            allFragmentsSent);
+                                        for (ReaderProxy* it : matched_readers_)
+                                        {
+                                            if (!it->is_local_reader())
+                                            {
+                                                bool allFragmentsSent = false;
+                                                it->mark_fragment_as_sent_for_change(
+                                                    change->sequenceNumber,
+                                                    frag,
+                                                    allFragmentsSent);
+                                            }
+                                        }
                                     }
-                                }
-                            }
-                        };
+                                };
 
                         send_data_or_fragments(group, change, expectsInlineQos, sent_fun);
                         send_heartbeat_nts_(all_remote_readers_.size(), group, disable_positive_acks_);
@@ -610,31 +610,31 @@ void StatefulWriter::send_changes_separatedly(
         {
             SequenceNumber_t max_ack_seq = SequenceNumber_t::unknown();
             auto unsent_change_process =
-                [&](const SequenceNumber_t& seqNum, const ChangeForReader_t* unsentChange)
-            {
-                if (unsentChange != nullptr && unsentChange->isRelevant() && unsentChange->isValid())
-                {
-                    if (intraprocess_delivery(unsentChange->getChange(), remoteReader))
+                    [&](const SequenceNumber_t& seqNum, const ChangeForReader_t* unsentChange)
                     {
-                        max_ack_seq = seqNum;
-                    }
-                    else
-                    {
-                        remoteReader->set_change_to_status(seqNum, UNDERWAY, false);
-                    }
-                }
-                else
-                {
-                    if (intraprocess_gap(remoteReader, seqNum))
-                    {
-                        max_ack_seq = seqNum;
-                    }
-                    else
-                    {
-                        remoteReader->set_change_to_status(seqNum, UNDERWAY, true);
-                    }
-                }
-            };
+                        if (unsentChange != nullptr && unsentChange->isRelevant() && unsentChange->isValid())
+                        {
+                            if (intraprocess_delivery(unsentChange->getChange(), remoteReader))
+                            {
+                                max_ack_seq = seqNum;
+                            }
+                            else
+                            {
+                                remoteReader->set_change_to_status(seqNum, UNDERWAY, false);
+                            }
+                        }
+                        else
+                        {
+                            if (intraprocess_gap(remoteReader, seqNum))
+                            {
+                                max_ack_seq = seqNum;
+                            }
+                            else
+                            {
+                                remoteReader->set_change_to_status(seqNum, UNDERWAY, true);
+                            }
+                        }
+                    };
             remoteReader->for_each_unsent_change(max_sequence, unsent_change_process);
             if (max_ack_seq != SequenceNumber_t::unknown())
             {
@@ -657,62 +657,62 @@ void StatefulWriter::send_changes_separatedly(
 
                 uint32_t lastBytesProcessed = 0;
                 auto sent_fun = [this, remoteReader, &lastBytesProcessed, &group](
-                        FragmentNumber_t /*frag*/)
-                {
-                    // Heartbeat piggyback.
-                    send_heartbeat_piggyback_nts_(remoteReader, group, lastBytesProcessed);
-                };
+                    FragmentNumber_t /*frag*/)
+                        {
+                            // Heartbeat piggyback.
+                            send_heartbeat_piggyback_nts_(remoteReader, group, lastBytesProcessed);
+                        };
 
                 auto unsent_change_process =
-                    [&](const SequenceNumber_t& seqNum, const ChangeForReader_t* unsentChange)
-                {
-                    if (unsentChange != nullptr && unsentChange->isRelevant() && unsentChange->isValid())
-                    {
-                        bool sent_ok = send_data_or_fragments(
-                            group,
-                            unsentChange->getChange(),
-                            remoteReader->expects_inline_qos(),
-                            sent_fun);
-                        if (sent_ok)
+                        [&](const SequenceNumber_t& seqNum, const ChangeForReader_t* unsentChange)
                         {
-                            remoteReader->set_change_to_status(seqNum, UNDERWAY, true);
-                            activateHeartbeatPeriod = true;
-                        }
-                    }
-                    else
-                    {
-                        if (seqNum >= min_history_seq)
-                        {
-                            gaps.add(seqNum);
-                        }
-                        remoteReader->set_change_to_status(seqNum, UNDERWAY, true);
-                    }
-                };
+                            if (unsentChange != nullptr && unsentChange->isRelevant() && unsentChange->isValid())
+                            {
+                                bool sent_ok = send_data_or_fragments(
+                                    group,
+                                    unsentChange->getChange(),
+                                    remoteReader->expects_inline_qos(),
+                                    sent_fun);
+                                if (sent_ok)
+                                {
+                                    remoteReader->set_change_to_status(seqNum, UNDERWAY, true);
+                                    activateHeartbeatPeriod = true;
+                                }
+                            }
+                            else
+                            {
+                                if (seqNum >= min_history_seq)
+                                {
+                                    gaps.add(seqNum);
+                                }
+                                remoteReader->set_change_to_status(seqNum, UNDERWAY, true);
+                            }
+                        };
                 remoteReader->for_each_unsent_change(max_sequence, unsent_change_process);
             }
             else
             {
                 SequenceNumber_t max_ack_seq = SequenceNumber_t::unknown();
                 auto unsent_change_process =
-                    [&](const SequenceNumber_t& seqNum, const ChangeForReader_t* unsentChange)
-                {
-                    if (unsentChange != nullptr && unsentChange->isRelevant() && unsentChange->isValid())
-                    {
-                        bool sent_ok = send_data_or_fragments(
-                            group,
-                            unsentChange->getChange(),
-                            remoteReader->expects_inline_qos(),
-                            null_sent_fun);
-                        if (sent_ok)
+                        [&](const SequenceNumber_t& seqNum, const ChangeForReader_t* unsentChange)
                         {
-                            max_ack_seq = seqNum;
-                        }
-                    }
-                    else
-                    {
-                        max_ack_seq = seqNum;
-                    }
-                };
+                            if (unsentChange != nullptr && unsentChange->isRelevant() && unsentChange->isValid())
+                            {
+                                bool sent_ok = send_data_or_fragments(
+                                    group,
+                                    unsentChange->getChange(),
+                                    remoteReader->expects_inline_qos(),
+                                    null_sent_fun);
+                                if (sent_ok)
+                                {
+                                    max_ack_seq = seqNum;
+                                }
+                            }
+                            else
+                            {
+                                max_ack_seq = seqNum;
+                            }
+                        };
                 remoteReader->for_each_unsent_change(max_sequence, unsent_change_process);
                 if (max_ack_seq != SequenceNumber_t::unknown())
                 {
@@ -733,30 +733,30 @@ void StatefulWriter::send_all_intraprocess_changes(
             intraprocess_heartbeat(remoteReader, false);
             SequenceNumber_t max_ack_seq = SequenceNumber_t::unknown();
             auto unsent_change_process = [&](const SequenceNumber_t& seq_num, const ChangeForReader_t* unsentChange)
-            {
-                if (unsentChange != nullptr && unsentChange->isRelevant() && unsentChange->isValid())
-                {
-                    if (intraprocess_delivery(unsentChange->getChange(), remoteReader))
                     {
-                        max_ack_seq = seq_num;
-                    }
-                    else
-                    {
-                        remoteReader->set_change_to_status(seq_num, UNDERWAY, false);
-                    }
-                }
-                else
-                {
-                    if (intraprocess_gap(remoteReader, seq_num))
-                    {
-                        max_ack_seq = seq_num;
-                    }
-                    else
-                    {
-                        remoteReader->set_change_to_status(seq_num, UNDERWAY, true);
-                    }
-                }
-            };
+                        if (unsentChange != nullptr && unsentChange->isRelevant() && unsentChange->isValid())
+                        {
+                            if (intraprocess_delivery(unsentChange->getChange(), remoteReader))
+                            {
+                                max_ack_seq = seq_num;
+                            }
+                            else
+                            {
+                                remoteReader->set_change_to_status(seq_num, UNDERWAY, false);
+                            }
+                        }
+                        else
+                        {
+                            if (intraprocess_gap(remoteReader, seq_num))
+                            {
+                                max_ack_seq = seq_num;
+                            }
+                            else
+                            {
+                                remoteReader->set_change_to_status(seq_num, UNDERWAY, true);
+                            }
+                        }
+                    };
 
             remoteReader->for_each_unsent_change(max_sequence, unsent_change_process);
             if (max_ack_seq != SequenceNumber_t::unknown())
@@ -793,7 +793,7 @@ void StatefulWriter::send_all_unsent_changes(
         network.select_locators(locator_selector_);
         compute_selected_guids();
 
-        bool acknack_required = next_all_acked_notify_sequence_ < get_seq_num_min();;
+        bool acknack_required = next_all_acked_notify_sequence_ < get_seq_num_min();
         bool heartbeat_has_been_sent = false;
 
         RTPSMessageGroup group(mp_RTPSParticipant, this, *this);
@@ -803,25 +803,25 @@ void StatefulWriter::send_all_unsent_changes(
         uint32_t lastBytesProcessed = 0;
         auto sent_fun = [this, &lastBytesProcessed, &group](
             FragmentNumber_t /*frag*/)
-        {
-            // Heartbeat piggyback.
-            send_heartbeat_piggyback_nts_(nullptr, group, lastBytesProcessed);
-        };
+                {
+                    // Heartbeat piggyback.
+                    send_heartbeat_piggyback_nts_(nullptr, group, lastBytesProcessed);
+                };
 
         RTPSGapBuilder gap_builder(group);
         uint32_t total_sent_size = 0;
 
         History::iterator cit;
         for (cit = mp_history->changesBegin();
-             cit != mp_history->changesEnd() && (total_sent_size < implicit_flow_controller_size);
-             cit++)
+                cit != mp_history->changesEnd() && (total_sent_size < implicit_flow_controller_size);
+                cit++)
         {
             SequenceNumber_t seq = (*cit)->sequenceNumber;
 
             // Deselect all entries on the locator selector (we will only activate the
             // readers for which this sequence number is pending)
             locator_selector_.reset(false);
-            
+
             bool is_irrelevant = true;   // Will turn to false if change is relevant for at least one reader
             bool should_be_sent = false;
             bool inline_qos = false;
@@ -829,7 +829,7 @@ void StatefulWriter::send_all_unsent_changes(
             {
                 if (!remoteReader->is_local_reader())
                 {
-                    if(remoteReader->change_is_unsent(seq, is_irrelevant))
+                    if (remoteReader->change_is_unsent(seq, is_irrelevant))
                     {
                         should_be_sent = true;
                         locator_selector_.enable(remoteReader->guid());
@@ -866,7 +866,7 @@ void StatefulWriter::send_all_unsent_changes(
                         {
                             if (!remoteReader->is_local_reader())
                             {
-                                if(remoteReader->change_is_unsent(seq, tmp_bool))
+                                if (remoteReader->change_is_unsent(seq, tmp_bool))
                                 {
                                     remoteReader->set_change_to_status(seq, UNDERWAY, true);
                                     if (remoteReader->is_reliable())
@@ -947,23 +947,23 @@ void StatefulWriter::send_unsent_changes_with_flow_control(
 
         RTPSGapBuilder gaps(group, remoteReader->guid());
         auto unsent_change_process = [&](const SequenceNumber_t& seq_num, const ChangeForReader_t* unsentChange)
-            {
-                if (unsentChange != nullptr && unsentChange->isRelevant() && unsentChange->isValid())
                 {
-                    relevantChanges.add_change(
-                        unsentChange->getChange(), remoteReader, unsentChange->getUnsentFragments());
-                }
-                else
-                {
-                    // Skip holes in history, as they were added before
-                    if (unsentChange != nullptr && remoteReader->is_reliable())
+                    if (unsentChange != nullptr && unsentChange->isRelevant() && unsentChange->isValid())
                     {
-                        gaps.add(seq_num);
+                        relevantChanges.add_change(
+                            unsentChange->getChange(), remoteReader, unsentChange->getUnsentFragments());
                     }
+                    else
+                    {
+                        // Skip holes in history, as they were added before
+                        if (unsentChange != nullptr && remoteReader->is_reliable())
+                        {
+                            gaps.add(seq_num);
+                        }
 
-                    remoteReader->set_change_to_status(seq_num, UNDERWAY, true);
-                }
-            };
+                        remoteReader->set_change_to_status(seq_num, UNDERWAY, true);
+                    }
+                };
 
         remoteReader->for_each_unsent_change(max_sequence, unsent_change_process);
     }
@@ -1101,7 +1101,7 @@ bool StatefulWriter::send_hole_gaps_to_group(
     SequenceNumber_t min_history_seq = get_seq_num_min();
     uint32_t history_size = static_cast<uint32_t>(mp_history->getHistorySize());
     if ((next_all_acked_notify_sequence_ < max_removed) &&    // some holes pending acknowledgement
-        (min_history_seq + history_size != last_sequence))    // There is a hole in the history
+            (min_history_seq + history_size != last_sequence)) // There is a hole in the history
     {
         try
         {
@@ -1157,9 +1157,9 @@ void StatefulWriter::update_reader_info(
     {
         RTPSParticipantImpl* part = getRTPSParticipant();
         locator_selector_.for_each([part](const Locator_t& loc)
-        {
-            part->createSenderResources(loc);
-        });
+                    {
+                        part->createSenderResources(loc);
+                    });
     }
 
     // Check if we have local or remote readers
@@ -1284,10 +1284,10 @@ bool StatefulWriter::matched_reader_add(
             }
 
             ChangeForReader_t changeForReader(*cit);
-            bool relevance = 
-                rp->durability_kind() >= TRANSIENT_LOCAL &&
-                m_att.durabilityKind >= TRANSIENT_LOCAL &&
-                rp->rtps_is_relevant(*cit);
+            bool relevance =
+                    rp->durability_kind() >= TRANSIENT_LOCAL &&
+                    m_att.durabilityKind >= TRANSIENT_LOCAL &&
+                    rp->rtps_is_relevant(*cit);
             changeForReader.setRelevance(relevance);
             if (!relevance && is_reliable)
             {
@@ -1469,9 +1469,9 @@ bool StatefulWriter::is_acked_by_all(
     assert(mp_history->next_sequence_number() > change->sequenceNumber);
     return std::all_of(matched_readers_.begin(), matched_readers_.end(),
                    [change](const ReaderProxy* reader)
-    {
-        return reader->change_is_acked(change->sequenceNumber);
-    });
+                {
+                    return reader->change_is_acked(change->sequenceNumber);
+                });
 }
 
 bool StatefulWriter::all_readers_updated()
@@ -1497,17 +1497,17 @@ bool StatefulWriter::wait_for_all_acked(
 
     all_acked_ = std::none_of(matched_readers_.begin(), matched_readers_.end(),
                     [](const ReaderProxy* reader)
-    {
-        return reader->has_changes();
-    });
+                {
+                    return reader->has_changes();
+                });
     lock.unlock();
 
     if (!all_acked_)
     {
         std::chrono::microseconds max_w(TimeConv::Duration_t2MicroSecondsInt64(max_wait));
         all_acked_cond_.wait_for(all_acked_lock, max_w, [&]() {
-            return all_acked_;
-        });
+                        return all_acked_;
+                    });
     }
 
     return all_acked_;
@@ -1551,13 +1551,13 @@ void StatefulWriter::check_acked_status()
                 // inside the callback
                 History::iterator history_end = mp_history->changesEnd();
                 History::iterator cit =
-                    std::lower_bound(mp_history->changesBegin(), history_end, min_low_mark,
-                        [](
-                            const CacheChange_t* change,
-                            const SequenceNumber_t& seq)
-                        {
-                            return change->sequenceNumber < seq;
-                        });
+                        std::lower_bound(mp_history->changesBegin(), history_end, min_low_mark,
+                                [](
+                                    const CacheChange_t* change,
+                                    const SequenceNumber_t& seq)
+                            {
+                                return change->sequenceNumber < seq;
+                            });
                 if (cit != history_end && (*cit)->sequenceNumber == min_low_mark)
                 {
                     ++cit;
@@ -1565,7 +1565,7 @@ void StatefulWriter::check_acked_status()
 
                 SequenceNumber_t seq{};
                 SequenceNumber_t end_seq = min_seq > next_all_acked_notify_sequence_ ?
-                    min_seq : next_all_acked_notify_sequence_;
+                        min_seq : next_all_acked_notify_sequence_;
 
                 // The iterator starts pointing to the change inmediately after min_low_mark
                 --cit;
@@ -1612,7 +1612,7 @@ void StatefulWriter::check_acked_status()
 }
 
 bool StatefulWriter::try_remove_change(
-        std::chrono::steady_clock::time_point& max_blocking_time_point,
+        const std::chrono::steady_clock::time_point& max_blocking_time_point,
         std::unique_lock<RecursiveTimedMutex>& lock)
 {
     logInfo(RTPS_WRITER, "Starting process try remove change for writer " << getGuid());
@@ -1640,8 +1640,8 @@ bool StatefulWriter::try_remove_change(
         may_remove_change_ = 0;
         may_remove_change_cond_.wait_until(lock, max_blocking_time_point,
                 [&]() {
-            return may_remove_change_ > 0;
-        });
+                        return may_remove_change_ > 0;
+                    });
         may_remove_change = may_remove_change_;
     }
 
@@ -1743,9 +1743,9 @@ bool StatefulWriter::send_periodic_heartbeat(
 
             unacked_changes = std::any_of(matched_readers_.begin(), matched_readers_.end(),
                             [](const ReaderProxy* reader)
-            {
-                return reader->has_unacknowledged();
-            });
+                        {
+                            return reader->has_unacknowledged();
+                        });
 
             if (unacked_changes)
             {
@@ -1798,7 +1798,7 @@ void StatefulWriter::send_heartbeat_to_nts(
         if (first_seq != c_SequenceNumber_Unknown)
         {
             if (remoteReaderProxy.durability_kind() < TRANSIENT_LOCAL ||
-                getAttributes().durabilityKind < TRANSIENT_LOCAL)
+                    getAttributes().durabilityKind < TRANSIENT_LOCAL)
             {
                 SequenceNumber_t last_irrelevance = remoteReaderProxy.changes_low_mark();
                 if (first_seq <= last_irrelevance)

--- a/src/cpp/rtps/writer/StatelessWriter.cpp
+++ b/src/cpp/rtps/writer/StatelessWriter.cpp
@@ -363,7 +363,7 @@ bool StatelessWriter::is_acked_by_all(
 }
 
 bool StatelessWriter::try_remove_change(
-        std::chrono::steady_clock::time_point&,
+        const std::chrono::steady_clock::time_point&,
         std::unique_lock<RecursiveTimedMutex>&)
 {
     return mp_history->remove_min_change();

--- a/test/blackbox/BlackboxTestsDeadlineQos.cpp
+++ b/test/blackbox/BlackboxTestsDeadlineQos.cpp
@@ -178,7 +178,7 @@ TEST_P(DeadlineQos, KeyedTopicLongDeadline)
     for (auto data_sample : data)
     {
         // Send data
-        data_sample.key(count % 2);
+        data_sample.key(count % 2 + 1);
         writer.send_sample(data_sample);
         ++count;
         reader.block_for_at_least(count);
@@ -223,7 +223,7 @@ TEST_P(DeadlineQos, KeyedTopicShortDeadline)
     for (auto data_sample : data)
     {
         // Send data
-        data_sample.key(count % 2);
+        data_sample.key(count % 2 + 1);
         writer.send_sample(data_sample);
         ++count;
         reader.block_for_at_least(count);

--- a/test/blackbox/BlackboxTestsKeys.cpp
+++ b/test/blackbox/BlackboxTestsKeys.cpp
@@ -56,8 +56,8 @@ TEST(KeyedTopic, RegistrationFail)
     PubSubWriter<KeyedHelloWorldType> writer(TEST_TOPIC_NAME);
 
     writer.
-    resource_limits_max_instances(1).
-    init();
+        resource_limits_max_instances(1).
+        init();
 
     ASSERT_TRUE(writer.isInitialized());
 
@@ -73,8 +73,8 @@ TEST(KeyedTopic, UnregistrationFail)
     PubSubWriter<KeyedHelloWorldType> writer(TEST_TOPIC_NAME);
 
     writer.
-    resource_limits_max_instances(1).
-    init();
+        resource_limits_max_instances(1).
+        init();
 
     ASSERT_TRUE(writer.isInitialized());
 
@@ -91,8 +91,8 @@ TEST(KeyedTopic, DisposeFail)
     PubSubWriter<KeyedHelloWorldType> writer(TEST_TOPIC_NAME);
 
     writer.
-    resource_limits_max_instances(1).
-    init();
+        resource_limits_max_instances(1).
+        init();
 
     ASSERT_TRUE(writer.isInitialized());
 
@@ -109,8 +109,8 @@ TEST(KeyedTopic, RegistrationAfterUnregistration)
     PubSubWriter<KeyedHelloWorldType> writer(TEST_TOPIC_NAME);
 
     writer.
-    resource_limits_max_instances(1).
-    init();
+        resource_limits_max_instances(1).
+        init();
 
     ASSERT_TRUE(writer.isInitialized());
 
@@ -122,10 +122,12 @@ TEST(KeyedTopic, RegistrationAfterUnregistration)
     EXPECT_EQ(writer.register_instance(data.back()), eprosima::fastrtps::rtps::c_InstanceHandle_Unknown);
 
     ASSERT_TRUE(writer.unregister_instance(data.front(), instance_handle_1));
+    ASSERT_FALSE(writer.unregister_instance(data.front(), instance_handle_1));
     EXPECT_NE(writer.register_instance(data.back()), eprosima::fastrtps::rtps::c_InstanceHandle_Unknown);
     EXPECT_EQ(writer.register_instance(data.front()), eprosima::fastrtps::rtps::c_InstanceHandle_Unknown);
 
     ASSERT_TRUE(writer.unregister_instance(data.back(), eprosima::fastrtps::rtps::c_InstanceHandle_Unknown));
+    ASSERT_FALSE(writer.unregister_instance(data.back(), eprosima::fastrtps::rtps::c_InstanceHandle_Unknown));
     EXPECT_NE(writer.register_instance(data.front()), eprosima::fastrtps::rtps::c_InstanceHandle_Unknown);
 }
 
@@ -134,8 +136,8 @@ TEST(KeyedTopic, RegistrationAfterDispose)
     PubSubWriter<KeyedHelloWorldType> writer(TEST_TOPIC_NAME);
 
     writer.
-    resource_limits_max_instances(1).
-    init();
+        resource_limits_max_instances(1).
+        init();
 
     ASSERT_TRUE(writer.isInitialized());
 
@@ -151,6 +153,32 @@ TEST(KeyedTopic, RegistrationAfterDispose)
 
     ASSERT_TRUE(writer.unregister_instance(data.front(), instance_handle_1));
     EXPECT_NE(writer.register_instance(data.back()), eprosima::fastrtps::rtps::c_InstanceHandle_Unknown);
+}
+
+TEST(KeyedTopic, UnregisterWhenHistoryKeepAll)
+{
+    PubSubWriter<KeyedHelloWorldType> writer(TEST_TOPIC_NAME);
+
+    writer.
+        history_kind(eprosima::fastrtps::KEEP_ALL_HISTORY_QOS).
+        init();
+
+    ASSERT_TRUE(writer.isInitialized());
+
+    auto data = default_keyedhelloworld_data_generator();
+
+    // Register instances.
+    auto instance_handle_1 = writer.register_instance(data.front());
+    auto instance_handle_2 = writer.register_instance(*(++data.begin()));
+
+    writer.send(data);
+    // In this test all data should be sent.
+    EXPECT_EQ(data.size(), static_cast<size_t>(0));
+
+    data = default_keyedhelloworld_data_generator(2);
+
+    ASSERT_TRUE(writer.unregister_instance(data.front(), instance_handle_1));
+    ASSERT_TRUE(writer.unregister_instance(data.back(), instance_handle_2));
 }
 
 /* Uncomment when DDS API supports NO_WRITERS_ALIVE

--- a/test/blackbox/BlackboxTestsKeys.cpp
+++ b/test/blackbox/BlackboxTestsKeys.cpp
@@ -68,6 +68,42 @@ TEST(KeyedTopic, RegistrationFail)
     EXPECT_EQ(writer.register_instance(data.back()), eprosima::fastrtps::rtps::c_InstanceHandle_Unknown);
 }
 
+TEST(KeyedTopic, UnregistrationFail)
+{
+    PubSubWriter<KeyedHelloWorldType> writer(TEST_TOPIC_NAME);
+
+    writer.
+    resource_limits_max_instances(1).
+    init();
+
+    ASSERT_TRUE(writer.isInitialized());
+
+    eprosima::fastrtps::rtps::InstanceHandle_t handle;
+    handle.value[0] = 1;
+
+    auto data = default_keyedhelloworld_data_generator(1);
+
+    ASSERT_FALSE(writer.unregister_instance(data.front(), handle));
+}
+
+TEST(KeyedTopic, DisposeFail)
+{
+    PubSubWriter<KeyedHelloWorldType> writer(TEST_TOPIC_NAME);
+
+    writer.
+    resource_limits_max_instances(1).
+    init();
+
+    ASSERT_TRUE(writer.isInitialized());
+
+    eprosima::fastrtps::rtps::InstanceHandle_t handle;
+    handle.value[0] = 1;
+
+    auto data = default_keyedhelloworld_data_generator(1);
+
+    ASSERT_FALSE(writer.dispose(data.front(), handle));
+}
+
 TEST(KeyedTopic, RegistrationAfterUnregistration)
 {
     PubSubWriter<KeyedHelloWorldType> writer(TEST_TOPIC_NAME);
@@ -87,4 +123,140 @@ TEST(KeyedTopic, RegistrationAfterUnregistration)
 
     ASSERT_TRUE(writer.unregister_instance(data.front(), instance_handle_1));
     EXPECT_NE(writer.register_instance(data.back()), eprosima::fastrtps::rtps::c_InstanceHandle_Unknown);
+    EXPECT_EQ(writer.register_instance(data.front()), eprosima::fastrtps::rtps::c_InstanceHandle_Unknown);
+
+    ASSERT_TRUE(writer.unregister_instance(data.back(), eprosima::fastrtps::rtps::c_InstanceHandle_Unknown));
+    EXPECT_NE(writer.register_instance(data.front()), eprosima::fastrtps::rtps::c_InstanceHandle_Unknown);
+}
+
+TEST(KeyedTopic, RegistrationAfterDispose)
+{
+    PubSubWriter<KeyedHelloWorldType> writer(TEST_TOPIC_NAME);
+
+    writer.
+    resource_limits_max_instances(1).
+    init();
+
+    ASSERT_TRUE(writer.isInitialized());
+
+    auto data = default_keyedhelloworld_data_generator(2);
+
+    // Register instances.
+    auto instance_handle_1 = writer.register_instance(data.front());
+    EXPECT_NE(instance_handle_1, eprosima::fastrtps::rtps::c_InstanceHandle_Unknown);
+    EXPECT_EQ(writer.register_instance(data.back()), eprosima::fastrtps::rtps::c_InstanceHandle_Unknown);
+
+    ASSERT_TRUE(writer.dispose(data.front(), instance_handle_1));
+    EXPECT_NE(writer.register_instance(data.back()), eprosima::fastrtps::rtps::c_InstanceHandle_Unknown);
+    EXPECT_EQ(writer.register_instance(data.front()), eprosima::fastrtps::rtps::c_InstanceHandle_Unknown);
+
+    ASSERT_TRUE(writer.dispose(data.back(), eprosima::fastrtps::rtps::c_InstanceHandle_Unknown));
+    EXPECT_NE(writer.register_instance(data.front()), eprosima::fastrtps::rtps::c_InstanceHandle_Unknown);
+}
+
+TEST(KeyedTopic, WriteSamplesBestEffort)
+{
+    PubSubWriter<KeyedHelloWorldType> writer(TEST_TOPIC_NAME);
+    PubSubReader<KeyedHelloWorldType> reader(TEST_TOPIC_NAME);
+
+    writer.
+    resource_limits_max_instances(1).
+    reliability(eprosima::fastrtps::BEST_EFFORT_RELIABILITY_QOS).
+    init();
+
+    ASSERT_TRUE(writer.isInitialized());
+
+    reader.
+    resource_limits_max_instances(1).
+    reliability(eprosima::fastrtps::BEST_EFFORT_RELIABILITY_QOS).
+    init();
+
+    ASSERT_TRUE(reader.isInitialized());
+
+    // Wait for discovery.
+    writer.wait_discovery();
+    reader.wait_discovery();
+
+    auto data = default_keyedhelloworld_data_generator(2);
+
+    // Register instances.
+    auto instance_handle_1 = writer.register_instance(data.front());
+    EXPECT_NE(instance_handle_1, eprosima::fastrtps::rtps::c_InstanceHandle_Unknown);
+
+    reader.startReception(data);
+    // Send data
+    writer.send(data);
+    // In this test all data should be sent.
+    EXPECT_EQ(data.size(), static_cast<size_t>(1));
+    // Block reader until reception finished or timeout.
+    reader.block_for_at_least(1);
+
+    auto data2 = default_keyedhelloworld_data_generator(2);
+
+    ASSERT_TRUE(writer.unregister_instance(data2.front(), instance_handle_1));
+
+    auto instance_handle_2 = writer.register_instance(data.back());
+    EXPECT_NE(instance_handle_2, eprosima::fastrtps::rtps::c_InstanceHandle_Unknown);
+
+    writer.send(data);
+    // In this test all data should be sent.
+    ASSERT_TRUE(data.empty());
+    // Block reader until reception finished or timeout.
+    reader.block_for_at_least(1);
+}
+
+TEST(KeyedTopic, WriteSamplesReliable)
+{
+    PubSubWriter<KeyedHelloWorldType> writer(TEST_TOPIC_NAME);
+    PubSubReader<KeyedHelloWorldType> reader(TEST_TOPIC_NAME);
+
+    writer.
+    resource_limits_max_instances(1).
+    reliability(eprosima::fastrtps::RELIABLE_RELIABILITY_QOS).
+    init();
+
+    ASSERT_TRUE(writer.isInitialized());
+
+    reader.
+    resource_limits_max_instances(1).
+    reliability(eprosima::fastrtps::RELIABLE_RELIABILITY_QOS).
+    init();
+
+    ASSERT_TRUE(reader.isInitialized());
+
+    // Wait for discovery.
+    writer.wait_discovery();
+    reader.wait_discovery();
+
+    auto data = default_keyedhelloworld_data_generator(2);
+
+    // Register instances.
+    auto instance_handle_1 = writer.register_instance(data.front());
+    EXPECT_NE(instance_handle_1, eprosima::fastrtps::rtps::c_InstanceHandle_Unknown);
+
+    reader.startReception(data);
+    // Send data
+    writer.send(data);
+    // In this test all data should be sent.
+    EXPECT_EQ(data.size(), static_cast<size_t>(1));
+    // Block reader until reception finished or timeout.
+    reader.block_for_at_least(1);
+
+    auto data2 = default_keyedhelloworld_data_generator(2);
+    ASSERT_TRUE(writer.unregister_instance(data2.front(), instance_handle_1));
+
+    auto instance_handle_2 = writer.register_instance(data.back());
+    // Is it deterministic?
+    EXPECT_EQ(instance_handle_2, eprosima::fastrtps::rtps::c_InstanceHandle_Unknown);
+
+    writer.waitForAllAcked(std::chrono::milliseconds(100));
+
+    instance_handle_2 = writer.register_instance(data.back());
+    EXPECT_NE(instance_handle_2, eprosima::fastrtps::rtps::c_InstanceHandle_Unknown);
+
+    writer.send(data);
+    // In this test all data should be sent.
+    ASSERT_TRUE(data.empty());
+    // Block reader until reception finished or timeout.
+    reader.block_for_at_least(1);
 }

--- a/test/blackbox/BlackboxTestsKeys.cpp
+++ b/test/blackbox/BlackboxTestsKeys.cpp
@@ -17,6 +17,23 @@
 #include "PubSubReader.hpp"
 #include "PubSubWriter.hpp"
 
+TEST(KeyedTopic, RegistrationNonKeyedFail)
+{
+    PubSubWriter<HelloWorldType> writer(TEST_TOPIC_NAME);
+
+    writer.init();
+
+    ASSERT_TRUE(writer.isInitialized());
+
+    auto data = default_helloworld_data_generator(2);
+
+    for (auto data_sample : data)
+    {
+        // Register instances
+        EXPECT_EQ(writer.register_instance(data_sample), eprosima::fastrtps::rtps::c_InstanceHandle_Unknown);
+    }
+}
+
 TEST(KeyedTopic, RegistrationSuccess)
 {
     PubSubWriter<KeyedHelloWorldType> writer(TEST_TOPIC_NAME);
@@ -49,4 +66,25 @@ TEST(KeyedTopic, RegistrationFail)
     // Register instances.
     EXPECT_NE(writer.register_instance(data.front()), eprosima::fastrtps::rtps::c_InstanceHandle_Unknown);
     EXPECT_EQ(writer.register_instance(data.back()), eprosima::fastrtps::rtps::c_InstanceHandle_Unknown);
+}
+
+TEST(KeyedTopic, RegistrationAfterUnregistration)
+{
+    PubSubWriter<KeyedHelloWorldType> writer(TEST_TOPIC_NAME);
+
+    writer.
+    resource_limits_max_instances(1).
+    init();
+
+    ASSERT_TRUE(writer.isInitialized());
+
+    auto data = default_keyedhelloworld_data_generator(2);
+
+    // Register instances.
+    auto instance_handle_1 = writer.register_instance(data.front());
+    EXPECT_NE(instance_handle_1, eprosima::fastrtps::rtps::c_InstanceHandle_Unknown);
+    EXPECT_EQ(writer.register_instance(data.back()), eprosima::fastrtps::rtps::c_InstanceHandle_Unknown);
+
+    ASSERT_TRUE(writer.unregister_instance(data.front(), instance_handle_1));
+    EXPECT_NE(writer.register_instance(data.back()), eprosima::fastrtps::rtps::c_InstanceHandle_Unknown);
 }

--- a/test/blackbox/BlackboxTestsKeys.cpp
+++ b/test/blackbox/BlackboxTestsKeys.cpp
@@ -153,8 +153,9 @@ TEST(KeyedTopic, RegistrationAfterDispose)
     EXPECT_NE(writer.register_instance(data.back()), eprosima::fastrtps::rtps::c_InstanceHandle_Unknown);
 }
 
-TEST(KeyedTopic, WriteSamplesBestEffort)
-{
+/* Uncomment when DDS API supports NO_WRITERS_ALIVE
+   TEST(KeyedTopic, WriteSamplesBestEffort)
+   {
     PubSubWriter<KeyedHelloWorldType> writer(TEST_TOPIC_NAME);
     PubSubReader<KeyedHelloWorldType> reader(TEST_TOPIC_NAME);
 
@@ -202,10 +203,10 @@ TEST(KeyedTopic, WriteSamplesBestEffort)
     ASSERT_TRUE(data.empty());
     // Block reader until reception finished or timeout.
     reader.block_for_at_least(1);
-}
+   }
 
-TEST(KeyedTopic, WriteSamplesReliable)
-{
+   TEST(KeyedTopic, WriteSamplesReliable)
+   {
     PubSubWriter<KeyedHelloWorldType> writer(TEST_TOPIC_NAME);
     PubSubReader<KeyedHelloWorldType> reader(TEST_TOPIC_NAME);
 
@@ -258,4 +259,5 @@ TEST(KeyedTopic, WriteSamplesReliable)
     ASSERT_TRUE(data.empty());
     // Block reader until reception finished or timeout.
     reader.block_for_at_least(1);
-}
+   }
+ */

--- a/test/blackbox/BlackboxTestsKeys.cpp
+++ b/test/blackbox/BlackboxTestsKeys.cpp
@@ -147,11 +147,10 @@ TEST(KeyedTopic, RegistrationAfterDispose)
     EXPECT_EQ(writer.register_instance(data.back()), eprosima::fastrtps::rtps::c_InstanceHandle_Unknown);
 
     ASSERT_TRUE(writer.dispose(data.front(), instance_handle_1));
-    EXPECT_NE(writer.register_instance(data.back()), eprosima::fastrtps::rtps::c_InstanceHandle_Unknown);
-    EXPECT_EQ(writer.register_instance(data.front()), eprosima::fastrtps::rtps::c_InstanceHandle_Unknown);
+    EXPECT_EQ(writer.register_instance(data.back()), eprosima::fastrtps::rtps::c_InstanceHandle_Unknown);
 
-    ASSERT_TRUE(writer.dispose(data.back(), eprosima::fastrtps::rtps::c_InstanceHandle_Unknown));
-    EXPECT_NE(writer.register_instance(data.front()), eprosima::fastrtps::rtps::c_InstanceHandle_Unknown);
+    ASSERT_TRUE(writer.unregister_instance(data.front(), instance_handle_1));
+    EXPECT_NE(writer.register_instance(data.back()), eprosima::fastrtps::rtps::c_InstanceHandle_Unknown);
 }
 
 TEST(KeyedTopic, WriteSamplesBestEffort)

--- a/test/blackbox/BlackboxTestsKeys.cpp
+++ b/test/blackbox/BlackboxTestsKeys.cpp
@@ -1,0 +1,52 @@
+// Copyright 2019 Proyectos y Sistemas de Mantenimiento SL (eProsima).
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "BlackboxTests.hpp"
+
+#include "PubSubReader.hpp"
+#include "PubSubWriter.hpp"
+
+TEST(KeyedTopic, RegistrationSuccess)
+{
+    PubSubWriter<KeyedHelloWorldType> writer(TEST_TOPIC_NAME);
+
+    writer.init();
+
+    ASSERT_TRUE(writer.isInitialized());
+
+    auto data = default_keyedhelloworld_data_generator(2);
+
+    for (auto data_sample : data)
+    {
+        // Register instances
+        EXPECT_NE(writer.register_instance(data_sample), eprosima::fastrtps::rtps::c_InstanceHandle_Unknown);
+    }
+}
+
+TEST(KeyedTopic, RegistrationFail)
+{
+    PubSubWriter<KeyedHelloWorldType> writer(TEST_TOPIC_NAME);
+
+    writer.
+    resource_limits_max_instances(1).
+    init();
+
+    ASSERT_TRUE(writer.isInitialized());
+
+    auto data = default_keyedhelloworld_data_generator(2);
+
+    // Register instances.
+    EXPECT_NE(writer.register_instance(data.front()), eprosima::fastrtps::rtps::c_InstanceHandle_Unknown);
+    EXPECT_EQ(writer.register_instance(data.back()), eprosima::fastrtps::rtps::c_InstanceHandle_Unknown);
+}

--- a/test/blackbox/api/dds-pim/PubSubWriter.hpp
+++ b/test/blackbox/api/dds-pim/PubSubWriter.hpp
@@ -380,6 +380,13 @@ public:
         return datawriter_->register_instance((void*)&msg);
     }
 
+    bool unregister_instance(
+            type& msg,
+            eprosima::fastrtps::rtps::InstanceHandle_t& instance_handle)
+    {
+        return ReturnCode_t::RETCODE_OK == datawriter_->unregister_instance((void*)&msg, instance_handle);
+    }
+
     bool send_sample(
             type& msg)
     {

--- a/test/blackbox/api/dds-pim/PubSubWriter.hpp
+++ b/test/blackbox/api/dds-pim/PubSubWriter.hpp
@@ -382,9 +382,16 @@ public:
 
     bool unregister_instance(
             type& msg,
-            eprosima::fastrtps::rtps::InstanceHandle_t& instance_handle)
+            const eprosima::fastrtps::rtps::InstanceHandle_t& instance_handle)
     {
         return ReturnCode_t::RETCODE_OK == datawriter_->unregister_instance((void*)&msg, instance_handle);
+    }
+
+    bool dispose(
+            type& msg,
+            const eprosima::fastrtps::rtps::InstanceHandle_t& instance_handle)
+    {
+        return ReturnCode_t::RETCODE_OK == datawriter_->dispose((void*)&msg, instance_handle);
     }
 
     bool send_sample(

--- a/test/blackbox/api/dds-pim/PubSubWriter.hpp
+++ b/test/blackbox/api/dds-pim/PubSubWriter.hpp
@@ -374,6 +374,12 @@ public:
         }
     }
 
+    eprosima::fastrtps::rtps::InstanceHandle_t register_instance(
+            type& msg)
+    {
+        return datawriter_->register_instance((void*)&msg);
+    }
+
     bool send_sample(
             type& msg)
     {

--- a/test/blackbox/api/fastrtps_deprecated/PubSubWriter.hpp
+++ b/test/blackbox/api/fastrtps_deprecated/PubSubWriter.hpp
@@ -359,9 +359,16 @@ public:
 
     bool unregister_instance(
             type& msg,
-            eprosima::fastrtps::rtps::InstanceHandle_t& instance_handle)
+            const eprosima::fastrtps::rtps::InstanceHandle_t& instance_handle)
     {
         return publisher_->unregister_instance((void*)&msg, instance_handle);
+    }
+
+    bool dispose(
+            type& msg,
+            const eprosima::fastrtps::rtps::InstanceHandle_t& instance_handle)
+    {
+        return publisher_->dispose((void*)&msg, instance_handle);
     }
 
     bool send_sample(

--- a/test/blackbox/api/fastrtps_deprecated/PubSubWriter.hpp
+++ b/test/blackbox/api/fastrtps_deprecated/PubSubWriter.hpp
@@ -357,6 +357,13 @@ public:
         return publisher_->register_instance((void*)&msg);
     }
 
+    bool unregister_instance(
+            type& msg,
+            eprosima::fastrtps::rtps::InstanceHandle_t& instance_handle)
+    {
+        return publisher_->unregister_instance((void*)&msg, instance_handle);
+    }
+
     bool send_sample(
             type& msg)
     {

--- a/test/blackbox/api/fastrtps_deprecated/PubSubWriter.hpp
+++ b/test/blackbox/api/fastrtps_deprecated/PubSubWriter.hpp
@@ -351,6 +351,12 @@ public:
         }
     }
 
+    eprosima::fastrtps::rtps::InstanceHandle_t register_instance(
+            type& msg)
+    {
+        return publisher_->register_instance((void*)&msg);
+    }
+
     bool send_sample(
             type& msg)
     {

--- a/test/blackbox/utils/data_generators.cpp
+++ b/test/blackbox/utils/data_generators.cpp
@@ -20,7 +20,8 @@
 #include <list>
 #include <sstream>
 
-std::list<HelloWorld> default_helloworld_data_generator(size_t max)
+std::list<HelloWorld> default_helloworld_data_generator(
+        size_t max)
 {
     uint16_t index = 1;
     size_t maximum = max ? max : 10;
@@ -40,7 +41,8 @@ std::list<HelloWorld> default_helloworld_data_generator(size_t max)
     return returnedValue;
 }
 
-std::list<FixedSized> default_fixed_sized_data_generator(size_t max)
+std::list<FixedSized> default_fixed_sized_data_generator(
+        size_t max)
 {
     uint16_t index = 1;
     size_t maximum = max ? max : 10;
@@ -57,7 +59,8 @@ std::list<FixedSized> default_fixed_sized_data_generator(size_t max)
     return returnedValue;
 }
 
-std::list<KeyedHelloWorld> default_keyedhelloworld_data_generator(size_t max)
+std::list<KeyedHelloWorld> default_keyedhelloworld_data_generator(
+        size_t max)
 {
     uint16_t index = 0;
     size_t maximum = max ? max : 10;
@@ -67,7 +70,7 @@ std::list<KeyedHelloWorld> default_keyedhelloworld_data_generator(size_t max)
     {
         KeyedHelloWorld hello;
         hello.index(index);
-        hello.key(index % 2);
+        hello.key(index % 2 + 1);
         std::stringstream ss;
         ss << "HelloWorld " << index;
         hello.message(ss.str());
@@ -78,7 +81,8 @@ std::list<KeyedHelloWorld> default_keyedhelloworld_data_generator(size_t max)
     return returnedValue;
 }
 
-std::list<String> default_large_string_data_generator(size_t max)
+std::list<String> default_large_string_data_generator(
+        size_t max)
 {
     uint16_t index = 1;
     size_t maximum = max ? max : 10;
@@ -98,7 +102,8 @@ std::list<String> default_large_string_data_generator(size_t max)
 }
 
 const size_t data64kb_length = 63996;
-std::list<Data64kb> default_data64kb_data_generator(size_t max)
+std::list<Data64kb> default_data64kb_data_generator(
+        size_t max)
 {
     unsigned char index = 1;
     size_t maximum = max ? max : 10;
@@ -121,7 +126,8 @@ std::list<Data64kb> default_data64kb_data_generator(size_t max)
 }
 
 const size_t data300kb_length = 307201;
-std::list<Data1mb> default_data300kb_data_generator(size_t max)
+std::list<Data1mb> default_data300kb_data_generator(
+        size_t max)
 {
     unsigned char index = 1;
     size_t maximum = max ? max : 10;
@@ -143,7 +149,8 @@ std::list<Data1mb> default_data300kb_data_generator(size_t max)
     return returnedValue;
 }
 
-std::list<Data1mb> default_data300kb_mix_data_generator(size_t max)
+std::list<Data1mb> default_data300kb_mix_data_generator(
+        size_t max)
 {
     unsigned char index = 1;
     size_t maximum = max ? max : 10;
@@ -166,26 +173,27 @@ std::list<Data1mb> default_data300kb_mix_data_generator(size_t max)
     return returnedValue;
 }
 
-const size_t data96kb_length = 96*1024;
-std::list<Data1mb> default_data96kb_data300kb_data_generator(size_t max)
+const size_t data96kb_length = 96 * 1024;
+std::list<Data1mb> default_data96kb_data300kb_data_generator(
+        size_t max)
 {
     unsigned char index = 1;
     size_t maximum = max ? max : 10;
     std::list<Data1mb> returnedValue(maximum);
 
     std::generate(returnedValue.begin(), returnedValue.end(), [&index]
+    {
+        Data1mb data;
+        size_t length = index % 2 != 0 ? data96kb_length : data300kb_length;
+        data.data().resize(length);
+        data.data()[0] = index;
+        for (size_t i = 1; i < length; ++i)
         {
-            Data1mb data;
-            size_t length = index % 2 != 0 ? data96kb_length : data300kb_length;
-            data.data().resize(length);
-            data.data()[0] = index;
-            for (size_t i = 1; i < length; ++i)
-            {
-                data.data()[i] = static_cast<unsigned char>(i + data.data()[0]);
-            }
-            ++index;
-            return data;
-        });
+            data.data()[i] = static_cast<unsigned char>(i + data.data()[0]);
+        }
+        ++index;
+        return data;
+    });
 
     return returnedValue;
 }


### PR DESCRIPTION
Implementation of `unregister_instance()` and `dispose()` on Writer side.

* `unregister_instance()`: sends a `CacheChange_t` with `NOT_ALIVE_UNREGISTER`. When this `CacheChange_t` is acked by all, removes all samples of this instance from `PublisherHistory`.

* `dispose()`: sends a `CacheChange_t` with `NOT_ALIVE_DISPOSE`.

Also now `PublisherHistory::find_key()` cannot remove a instance slot.