### PR TITLE
Different return codes when extracting profile

### DIFF
--- a/include/fastrtps/xmlparser/XMLProfileManager.h
+++ b/include/fastrtps/xmlparser/XMLProfileManager.h
@@ -64,7 +64,7 @@ public:
     /**
      * Load a profiles XML file.
      * @param filename Name for the file to be loaded.
-     * @return XMLP_ret::XML_OK if all profiles are correct, XMLP_ret::XML_NOK some are a some are not,
+     * @return XMLP_ret::XML_OK if all profiles are correct, XMLP_ret::XML_NOK if some are and some are not,
      *         XMLP_ret::XML_ERROR in other case.
      */
     RTPS_DllAPI static XMLP_ret loadXMLFile(
@@ -73,7 +73,7 @@ public:
     /**
      * Load a profiles XML node.
      * @param doc Node to be loaded.
-     * @return XMLP_ret::XML_OK if all profiles are correct, XMLP_ret::XML_NOK some are a some are not,
+     * @return XMLP_ret::XML_OK if all profiles are correct, XMLP_ret::XML_NOK if some are and some are not,
      *         XMLP_ret::XML_ERROR in other case.
      */
     RTPS_DllAPI static XMLP_ret loadXMLNode(
@@ -82,7 +82,7 @@ public:
     /**
      * Load a profiles XML node.
      * @param profiles Node to be loaded.
-     * @return XMLP_ret::XML_OK if all profiles are correct, XMLP_ret::XML_NOK some are a some are not,
+     * @return XMLP_ret::XML_OK if all profiles are correct, XMLP_ret::XML_NOK if some are and some are not,
      *         XMLP_ret::XML_ERROR in other case.
      */
     RTPS_DllAPI static XMLP_ret loadXMLProfiles(

--- a/include/fastrtps/xmlparser/XMLProfileManager.h
+++ b/include/fastrtps/xmlparser/XMLProfileManager.h
@@ -58,14 +58,14 @@ public:
 
     /**
      * Load the default profiles XML file.
-     * @return XMLP_ret::XML_OK on success, XMLP_ret::XML_ERROR in other case.
      */
     RTPS_DllAPI static void loadDefaultXMLFile();
 
     /**
      * Load a profiles XML file.
      * @param filename Name for the file to be loaded.
-     * @return XMLP_ret::XML_OK on success, XMLP_ret::XML_ERROR in other case.
+     * @return XMLP_ret::XML_OK if all profiles are correct, XMLP_ret::XML_NOK some are a some are not,
+     *         XMLP_ret::XML_ERROR in other case.
      */
     RTPS_DllAPI static XMLP_ret loadXMLFile(
             const std::string& filename);
@@ -73,7 +73,8 @@ public:
     /**
      * Load a profiles XML node.
      * @param doc Node to be loaded.
-     * @return XMLP_ret::XML_OK on success, XMLP_ret::XML_ERROR in other case.
+     * @return XMLP_ret::XML_OK if all profiles are correct, XMLP_ret::XML_NOK some are a some are not,
+     *         XMLP_ret::XML_ERROR in other case.
      */
     RTPS_DllAPI static XMLP_ret loadXMLNode(
             tinyxml2::XMLDocument& doc);
@@ -81,7 +82,8 @@ public:
     /**
      * Load a profiles XML node.
      * @param profiles Node to be loaded.
-     * @return XMLP_ret::XML_OK on success, XMLP_ret::XML_ERROR in other case.
+     * @return XMLP_ret::XML_OK if all profiles are correct, XMLP_ret::XML_NOK some are a some are not,
+     *         XMLP_ret::XML_ERROR in other case.
      */
     RTPS_DllAPI static XMLP_ret loadXMLProfiles(
             tinyxml2::XMLElement& profiles);

--- a/src/cpp/rtps/xmlparser/XMLParser.cpp
+++ b/src/cpp/rtps/xmlparser/XMLParser.cpp
@@ -712,7 +712,7 @@ XMLP_ret XMLParser::parseXMLCommonSharedMemTransportData(
                 <xs:element name="maxMessageSize" type="uint32Type" minOccurs="0" maxOccurs="1"/>
                 <xs:element name="maxInitialPeersRange" type="uint32Type" minOccurs="0" maxOccurs="1"/>
                 <xs:element name="segment_size" type="uint32Type" minOccurs="0" maxOccurs="1"/>
-                <xs:element name="port_queue_capacity" type="uint32Type" minOccurs="0" maxOccurs="1"/>                
+                <xs:element name="port_queue_capacity" type="uint32Type" minOccurs="0" maxOccurs="1"/>
                 <xs:element name="healthy_check_timeout_ms" type="uint32Type" minOccurs="0" maxOccurs="1"/>
                 <xs:element name="rtps_dump_file" type="stringType" minOccurs="0" maxOccurs="1"/>
                 </xs:all>
@@ -2614,6 +2614,7 @@ XMLP_ret XMLParser::parseProfiles(
     tinyxml2::XMLElement* p_profile = p_root->FirstChildElement();
     const char* tag = nullptr;
     bool parseOk = true;
+    XMLP_ret ret = XMLP_ret::XML_OK;
     while (nullptr != p_profile)
     {
         if (nullptr != (tag = p_profile->Value()))
@@ -2677,11 +2678,11 @@ XMLP_ret XMLParser::parseProfiles(
         if (!parseOk)
         {
             logError(XMLPARSER, "Error parsing profile's tag " << tag);
-            return XMLP_ret::XML_ERROR;
+            ret = XMLP_ret::XML_ERROR;
         }
         p_profile = p_profile->NextSiblingElement();
     }
-    return XMLP_ret::XML_OK;
+    return ret;
 }
 
 XMLP_ret XMLParser::parseDynamicTypes(

--- a/src/cpp/rtps/xmlparser/XMLProfileManager.cpp
+++ b/src/cpp/rtps/xmlparser/XMLProfileManager.cpp
@@ -360,6 +360,7 @@ XMLP_ret XMLProfileManager::extractProfiles(
 
     unsigned int profile_count = 0u;
 
+    XMLP_ret ret = XMLP_ret::XML_OK;
     for (auto&& profile: profiles->getChildren())
     {
         if (NodeType::PARTICIPANT == profile->getType())
@@ -368,12 +369,20 @@ XMLP_ret XMLProfileManager::extractProfiles(
             {
                 ++profile_count;
             }
+            else
+            {
+                ret = XMLP_ret::XML_NOK;
+            }
         }
         else if (NodeType::PUBLISHER == profile.get()->getType())
         {
             if (XMLP_ret::XML_OK == extractPublisherProfile(profile, filename))
             {
                 ++profile_count;
+            }
+            else
+            {
+                ret = XMLP_ret::XML_NOK;
             }
         }
         else if (NodeType::SUBSCRIBER == profile.get()->getType())
@@ -382,12 +391,20 @@ XMLP_ret XMLProfileManager::extractProfiles(
             {
                 ++profile_count;
             }
+            else
+            {
+                ret = XMLP_ret::XML_NOK;
+            }
         }
         else if (NodeType::TOPIC == profile.get()->getType())
         {
             if (XMLP_ret::XML_OK == extractTopicProfile(profile, filename))
             {
                 ++profile_count;
+            }
+            else
+            {
+                ret = XMLP_ret::XML_NOK;
             }
         }
         else if (NodeType::REQUESTER == profile.get()->getType())
@@ -396,12 +413,20 @@ XMLP_ret XMLProfileManager::extractProfiles(
             {
                 ++profile_count;
             }
+            else
+            {
+                ret = XMLP_ret::XML_NOK;
+            }
         }
         else if (NodeType::REPLIER == profile.get()->getType())
         {
             if (XMLP_ret::XML_OK == extractReplierProfile(profile, filename))
             {
                 ++profile_count;
+            }
+            else
+            {
+                ret = XMLP_ret::XML_NOK;
             }
         }
         else
@@ -412,9 +437,15 @@ XMLP_ret XMLProfileManager::extractProfiles(
 
     profile_count += static_cast<unsigned int>(transport_profiles_.size()); // Count transport profiles
 
-    xml_files_.emplace(filename, XMLP_ret::XML_OK);
+    if (ret != XMLP_ret::XML_OK && profile_count == 0)
+    {
+        // Could not extract any profile
+        ret = XMLP_ret::XML_ERROR;
+    }
 
-    return XMLP_ret::XML_OK;
+    xml_files_.emplace(filename, ret);
+
+    return ret;
 }
 
 XMLP_ret XMLProfileManager::extractParticipantProfile(


### PR DESCRIPTION
This PR adds different error codes when extracting profiles from an XML file
* All profiles were successfully extracted --> `XMLP_ret::XML_OK`
* Only some profiles were successfully extracted --> `XMLP_ret::XML_NOK`
* No profile was successfully extracted --> `XMLP_ret::XML_ERROR`

This is of special importance since this error propagates up to the user when calling `XMLProfileManager::loadXMLFile`

Signed-off-by: EduPonz <eduardoponz@eprosima.com>