### PR TITLE
ThreadSanitizer: data race on socket close/receive_from.

### DIFF
--- a/include/fastdds/rtps/transport/UDPChannelResource.h
+++ b/include/fastdds/rtps/transport/UDPChannelResource.h
@@ -169,6 +169,7 @@ protected:
 private:
 
     TransportReceiverInterface* message_receiver_; //Associated Readers/Writers inside of MessageReceiver
+    std::mutex socket_mutex_;
     eProsimaUDPSocket socket_;
     bool only_multicast_purpose_;
     std::string interface_;


### PR DESCRIPTION
fix https://github.com/ros2/rmw_fastrtps/issues/391,

Signed-off-by: Tomoya.Fujita <Tomoya.Fujita@sony.com>