### PR TITLE
Fix examples files installation <2.0.x> [8566]

### DIFF
--- a/examples/C++/DDS/DynamicHelloWorldExample/CMakeLists.txt
+++ b/examples/C++/DDS/DynamicHelloWorldExample/CMakeLists.txt
@@ -50,5 +50,7 @@ add_executable(DDSDynamicHelloWorldExample
 target_link_libraries(DDSDynamicHelloWorldExample fastrtps fastcdr)
 install(TARGETS DDSDynamicHelloWorldExample
     RUNTIME DESTINATION examples/C++/DDS/DynamicHelloWorldExample/${BIN_INSTALL_DIR})
+install(FILES ${CMAKE_CURRENT_SOURCE_DIR}/example_type.xml
+    DESTINATION examples/C++/DDS/DynamicHelloWorldExample/${BIN_INSTALL_DIR})
 
 file(COPY example_type.xml DESTINATION ${PROJECT_BINARY_DIR})

--- a/examples/C++/DDS/SecureHelloWorldExample/CMakeLists.txt
+++ b/examples/C++/DDS/SecureHelloWorldExample/CMakeLists.txt
@@ -54,6 +54,8 @@ target_include_directories(DDSSecureHelloWorldExample PRIVATE)
 target_link_libraries(DDSSecureHelloWorldExample fastrtps fastcdr foonathan_memory)
 install(TARGETS DDSSecureHelloWorldExample
     RUNTIME DESTINATION examples/C++/DDS/SecureHelloWorldExample/${BIN_INSTALL_DIR})
+install(DIRECTORY ${PROJECT_SOURCE_DIR}/certs
+    DESTINATION examples/C++/DDS/SecureHelloWorldExample/${BIN_INSTALL_DIR})
 
 add_custom_command(TARGET DDSSecureHelloWorldExample POST_BUILD
     COMMAND ${CMAKE_COMMAND} -E copy_directory

--- a/examples/C++/DDS/StaticHelloWorldExample/CMakeLists.txt
+++ b/examples/C++/DDS/StaticHelloWorldExample/CMakeLists.txt
@@ -58,3 +58,5 @@ add_executable(DDSStaticHelloWorldExample ${DDS_STATIC_HELLOWORLD_EXAMPLE_SOURCE
 target_link_libraries(DDSStaticHelloWorldExample fastrtps fastcdr foonathan_memory)
 install(TARGETS DDSStaticHelloWorldExample
     RUNTIME DESTINATION examples/C++/DDS/StaticHelloWorldExample/${BIN_INSTALL_DIR})
+install(FILES ${CMAKE_CURRENT_SOURCE_DIR}/HelloWorldPublisher.xml
+    DESTINATION examples/C++/DDS/StaticHelloWorldExample/${BIN_INSTALL_DIR})

--- a/examples/C++/DDS/TypeLookupService/CMakeLists.txt
+++ b/examples/C++/DDS/TypeLookupService/CMakeLists.txt
@@ -50,5 +50,7 @@ add_executable(TypeLookupExample
 target_link_libraries(TypeLookupExample fastrtps fastcdr)
 install(TARGETS TypeLookupExample
     RUNTIME DESTINATION examples/C++/DDS/TypeLookupService/${BIN_INSTALL_DIR})
+install(FILES ${CMAKE_CURRENT_SOURCE_DIR}/example_type.xml
+    DESTINATION examples/C++/DDS/TypeLookupService/${BIN_INSTALL_DIR})
 
 file(COPY example_type.xml DESTINATION ${PROJECT_BINARY_DIR})

--- a/examples/C++/DDS/TypeLookupService/TypeLookupPublisher.cpp
+++ b/examples/C++/DDS/TypeLookupService/TypeLookupPublisher.cpp
@@ -44,7 +44,13 @@ TypeLookupPublisher::TypeLookupPublisher()
 
 bool TypeLookupPublisher::init()
 {
-    xmlparser::XMLProfileManager::loadXMLFile("example_type.xml");
+    if (xmlparser::XMLP_ret::XML_OK !=
+        xmlparser::XMLProfileManager::loadXMLFile("example_type.xml"))
+    {
+        std::cout << "Cannot open XML file \"example_type.xml\". Please, run the publisher from the folder "
+                  << "that contatins this XML file." << std::endl;
+        return false;
+    }
 
     types::DynamicType_ptr dyn_type = xmlparser::XMLProfileManager::getDynamicTypeByName("TypeLookup")->build();
     TypeSupport m_type(new types::DynamicPubSubType(dyn_type));

--- a/examples/C++/SecureHelloWorldExample/CMakeLists.txt
+++ b/examples/C++/SecureHelloWorldExample/CMakeLists.txt
@@ -54,6 +54,8 @@ target_include_directories(SecureHelloWorldExample PRIVATE)
 target_link_libraries(SecureHelloWorldExample fastrtps fastcdr foonathan_memory)
 install(TARGETS SecureHelloWorldExample
     RUNTIME DESTINATION examples/C++/SecureHelloWorldExample/${BIN_INSTALL_DIR})
+install(DIRECTORY ${PROJECT_SOURCE_DIR}/certs
+    DESTINATION examples/C++/SecureHelloWorldExample/${BIN_INSTALL_DIR}/certs)
 
 add_custom_command(TARGET SecureHelloWorldExample POST_BUILD
     COMMAND ${CMAKE_COMMAND} -E copy_directory

--- a/examples/C++/StaticHelloWorldExample/CMakeLists.txt
+++ b/examples/C++/StaticHelloWorldExample/CMakeLists.txt
@@ -58,3 +58,5 @@ add_executable(StaticHelloWorldExample ${HELLOWORLD_EXAMPLE_SOURCES_CXX} ${HELLO
 target_link_libraries(StaticHelloWorldExample fastrtps fastcdr foonathan_memory)
 install(TARGETS StaticHelloWorldExample
     RUNTIME DESTINATION examples/C++/HelloWorldExample/${BIN_INSTALL_DIR})
+install(FILES ${CMAKE_CURRENT_SOURCE_DIR}/HelloWorldPublisher.xml
+    DESTINATION examples/C++/HelloWorldExample/${BIN_INSTALL_DIR})

--- a/examples/C++/XMLProfiles/CMakeLists.txt
+++ b/examples/C++/XMLProfiles/CMakeLists.txt
@@ -56,3 +56,5 @@ add_executable(XMLProfiles ${XMLPROFILESEXAMPLE_SOURCES_CXX} ${XMLPROFILESEXAMPL
 target_link_libraries(XMLProfiles fastrtps fastcdr foonathan_memory)
 install(TARGETS XMLProfiles
     RUNTIME DESTINATION examples/C++/XMLProfilesExample/${BIN_INSTALL_DIR})
+install(FILES ${CMAKE_CURRENT_SOURCE_DIR}/XMLProfilesExample.xml
+    DESTINATION examples/C++/XMLProfilesExample/${BIN_INSTALL_DIR})


### PR DESCRIPTION
- Fix segfault in DDSTypeLookupService when no XML file is found.
- Install examples XML and certs files.